### PR TITLE
Error for bad PVC specification

### DIFF
--- a/internal/controller/nimcache_controller.go
+++ b/internal/controller/nimcache_controller.go
@@ -237,7 +237,7 @@ func (r *NIMCacheReconciler) reconcilePVC(ctx context.Context, nimCache *appsv1a
 		if nimCache.Spec.Storage.PVC.Create != nil && *nimCache.Spec.Storage.PVC.Create {
 			pvc, err = shared.ConstructPVC(nimCache.Spec.Storage.PVC, metav1.ObjectMeta{Name: pvcName, Namespace: nimCache.GetNamespace()})
 			if err != nil {
-				logger.Error(err, "Failed to construct pvc", "name", pvc.Name)
+				logger.Error(err, "Failed to construct pvc", "name", pvcName)
 				return err
 			}
 			if err := controllerutil.SetControllerReference(nimCache, pvc, r.GetScheme()); err != nil {
@@ -245,12 +245,12 @@ func (r *NIMCacheReconciler) reconcilePVC(ctx context.Context, nimCache *appsv1a
 			}
 			err = r.Create(ctx, pvc)
 			if err != nil {
-				logger.Error(err, "Failed to create pvc", "name", pvc.Name)
+				logger.Error(err, "Failed to create pvc", "name", pvcName)
 				return err
 			}
-			logger.Info("Created PVC for NIM Cache", "pvc", pvcName)
+			logger.Info("Created PVC for NIM Cache", "pvc", pvc.Name)
 
-			conditions.UpdateCondition(&nimCache.Status.Conditions, appsv1alpha1.NimCacheConditionPVCCreated, metav1.ConditionTrue, "PVCCreated", "The PVC has been created for caching NIM")
+			conditions.UpdateCondition(&nimCache.Status.Conditions, appsv1alpha1.NimCacheConditionPVCCreated, metav1.ConditionTrue, "PVCCreated", "The PVC has been created for caching NIM model")
 			nimCache.Status.State = appsv1alpha1.NimCacheStatusPVCCreated
 			if err := r.Status().Update(ctx, nimCache); err != nil {
 				logger.Error(err, "Failed to update status", "NIMCache", nimCache.Name)


### PR DESCRIPTION
If the PVC isn't created, return predicted name rather than `pvc.Name`.  IIUC, `pvc` is nil.

I had a bad PVC spec:

```
  storage:
    pvc:
      create: true
      storageClass: "nfs-client"
      volumeAccessMode: ReadWriteMany
```

The controller panicked:

```
2024-08-12T13:16:17Z    INFO    Observed a panic in reconciler: runtime error: invalid memory address or nil pointer dereference        {"controller": "nimcache", "controllerGroup": "apps.nvidia.com", "controllerKind": "NIMCache", "NIMCache": {"name":"meta-llama3-8b-instruct","namespace":"nim-service"}, "namespace": "nim-service", "name": "meta-llama3-8b-instruct", "reconcileID": "be258a8b-b3d7-405d-9d37-46c7f466635e"}
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x16766ea]
                                                                                                                        goroutine 259 [running]:
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()
        /workspace/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:111 +0x1e5
panic({0x17f9da0?, 0x29863a0?})
        /usr/local/go/src/runtime/panic.go:770 +0x132
github.com/NVIDIA/k8s-nim-operator/internal/controller.(*NIMCacheReconciler).reconcilePVC(0xc0004bdd60, {0x1cbc780, 0xc0007067b0}, 0xc000774008)
        /workspace/internal/controller/nimcache_controller.go:240 +0x32a
```
