### PR TITLE
Requeue requests to fetch pod logs for extracting NIM manifest

### DIFF
--- a/internal/nimparser/nimparser_test.go
+++ b/internal/nimparser/nimparser_test.go
@@ -71,6 +71,34 @@ var _ = Describe("NIMParser", func() {
 			Expect(profile.Tags["precision"]).To(Equal("fp16"))
 			Expect(profile.ContainerURL).To(Equal("nvcr.io/nim/meta/llama3-70b-instruct:1.0.0"))
 		})
+		It("should parse a model profiles of reranking NIM correctly", func() {
+
+			filePath := filepath.Join("testdata", "manifest_reranking.yaml")
+			config, err := ParseModelManifest(filePath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(*config).To(HaveLen(2))
+
+			profile, exists := (*config)["f5cfb1a2c2f00bff7f504e78bcce237903a4d257cbb0086ea7856c2df3458a5f"]
+			Expect(exists).To(BeTrue())
+			Expect(profile.Tags["backend"]).To(Equal("tensorrt"))
+			Expect(profile.Tags["key"]).To(Equal("NVIDIA-H100_10.0.1_12"))
+			Expect(profile.Tags["precision"]).To(Equal("fp16"))
+			Expect(profile.Tags["product_name_regex"]).To(Equal("^NVIDIA-H100.*"))
+		})
+		It("should parse a model profiles of embedding NIM correctly", func() {
+
+			filePath := filepath.Join("testdata", "manifest_embedding.yaml")
+			config, err := ParseModelManifest(filePath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(*config).To(HaveLen(2))
+
+			profile, exists := (*config)["2ad8fe56fc5c2cd108b4d177286fbd6c6ea5dcd3de3995cb9aeb83f80ddd5c9e"]
+			Expect(exists).To(BeTrue())
+			Expect(profile.Tags["backend"]).To(Equal("tensorrt"))
+			Expect(profile.Tags["key"]).To(Equal("NVIDIA-L4_10.0.1_12"))
+			Expect(profile.Tags["precision"]).To(Equal("fp16"))
+			Expect(profile.Tags["product_name_regex"]).To(Equal("^NVIDIA-L4(?!0S).*"))
+		})
 		It("should match model profiles with given parameters", func() {
 
 			filePath := filepath.Join("testdata", "manifest_trtllm.yaml")

--- a/internal/nimparser/testdata/manifest_embedding.yaml
+++ b/internal/nimparser/testdata/manifest_embedding.yaml
@@ -1,0 +1,13 @@
+2ad8fe56fc5c2cd108b4d177286fbd6c6ea5dcd3de3995cb9aeb83f80ddd5c9e:
+  tags:
+    backend: tensorrt
+    key: NVIDIA-L4_10.0.1_12
+    precision: fp16
+    product_name_regex: ^NVIDIA-L4(?!0S).*
+72972bc1f4dc3f79aff74aa6a9a26d24d27d6f9c74c455dc904b2a2a20f156d2:
+  tags:
+    backend: tensorrt
+    key: NVIDIA-A10G_10.0.1_12
+    precision: fp16
+    product_name_regex: ^NVIDIA-A10(?!0).*
+

--- a/internal/nimparser/testdata/manifest_reranking.yaml
+++ b/internal/nimparser/testdata/manifest_reranking.yaml
@@ -1,0 +1,13 @@
+f5cfb1a2c2f00bff7f504e78bcce237903a4d257cbb0086ea7856c2df3458a5f:
+  tags:
+    backend: tensorrt
+    key: NVIDIA-H100_10.0.1_12
+    precision: fp16
+    product_name_regex: ^NVIDIA-H100.*
+f8db33f235f324d6e5d3c4f06a98b16af31aa6797f9c5437ce83ec49a2912660:
+  tags:
+    backend: tensorrt
+    key: NVIDIA-H100_10.0.1_12_FP8
+    precision: fp8
+    product_name_regex: ^NVIDIA-H100.*
+


### PR DESCRIPTION
* A delay is required to extract NIM pod logs for the manifest, otherwise lead to empty manifest
* Fix requeue logic to queue with delay
* Tests for parsing embedding/reranking manifests