### PR TITLE
Avoid "v" prefix to adhere to Helm semantic versioning requirements

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,7 +54,7 @@ helm-lint:
     - apk add --update curl curl-dev openssl bash git openssh make
     - curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
   script:
-    - helm lint helm/k8s-nim-operator/
+    - helm lint deployments/helm/k8s-nim-operator/
 
 # Define the image build targets
 .image-build:

--- a/.nvidia-ci.yml
+++ b/.nvidia-ci.yml
@@ -190,7 +190,8 @@ helm:ngc:
     - 'echo "Pushing the helm chart to NGC"'
     - helm lint deployments/helm/*
     - make helm-chart
-    - export VERSION=$(awk -F= '/^VERSION/ { print $2 }' versions.mk | tr -d '[:space:]')
+    # Ensure that VERSION is not prefixed by "v" to follow strict semantic versioning for Helm
+    - export VERSION=$(awk -F= '/^VERSION/ { print $2 }' versions.mk | tr -d '[:space:]' | sed 's/^v//')
     - ngc-cli/ngc registry chart push --source k8s-nim-operator-${VERSION}.tgz --org nvidia --team no-team nvidia/k8s-nim-operator:${VERSION}
 
 sign:ngc-short-tag:

--- a/Makefile
+++ b/Makefile
@@ -145,10 +145,12 @@ build-installer: manifests generate kustomize ## Generate a consolidated YAML wi
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/default > dist/install.yaml
 
-# Short version of hack/package-helm-charts.sh
+# Generate helm chart with the specified chart version
+# CHART_VERSION is stripped from "v" prefix to adhere to strict semantic versioning required by Helm.
+CHART_VERSION := $(shell echo ${VERSION} | sed 's/^v//')
 .PHONY: helm-charts
 helm-charts:
-	helm package deployments/helm/k8s-nim-operator/ --version ${VERSION} --app-version ${VERSION}
+	helm package deployments/helm/k8s-nim-operator/ --version $(CHART_VERSION) --app-version $(CHART_VERSION)
 
 # Generate bundle manifests and metadata, then validate generated files.
 .PHONY: bundle bundle-validate

--- a/deployments/helm/k8s-nim-operator/templates/_helpers.tpl
+++ b/deployments/helm/k8s-nim-operator/templates/_helpers.tpl
@@ -54,5 +54,5 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Full image name with tag
 */}}
 {{- define "k8s-nim-operator.fullimage" -}}
-{{- .Values.operator.image.repository -}}:{{- .Values.operator.image.tag | default .Chart.AppVersion -}}
+{{- .Values.operator.image.repository -}}:{{- .Values.operator.image.tag | default (printf "v%s" .Chart.AppVersion) -}}
 {{- end }}


### PR DESCRIPTION
As a general practice, we should avoid adding "v" prefix to the chart version.  It can lead to issues with version comparison, dependency resolution, and consistency across tools.