### PR TITLE
Direct customers to docs.nvidia.com

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -5,6 +5,8 @@
 
 # Installing NIM Operator for Kubernetes using Helm
 
+> TIP: For customer-facing documentation, go to <https://docs.nvidia.com/nim-operator/latest>.
+
 ### Pre-requisites
 
 * A Kubernetes cluster with supported GPUs (H100, A100, L40S)


### PR DESCRIPTION
I don't have permission to config `About` on the repo front page, but someone with perms could add the URL there too.