### PR TITLE
Add orchestrator type specific spec for pods created by the operator

### DIFF
--- a/internal/controller/nemo_guardrail_controller.go
+++ b/internal/controller/nemo_guardrail_controller.go
@@ -151,14 +151,12 @@ func (r *NemoGuardrailReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}
 	}
 
-	// Set container orchestrator type
-	if r.GetOrchestratorType() != "" {
-		orchestratorType, err := k8sutil.GetOrchestratorType(r.GetClient())
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("Unable to get container orchestrator type, %v", err)
-		}
-		r.orchestratorType = orchestratorType
+	// Fetch container orchestrator type
+	orchestratorType, err := r.GetOrchestratorType()
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("Unable to get container orchestrator type, %v", err)
 	}
+	logger.Info("Container orchestrator is successfully set", "type", orchestratorType)
 
 	// Handle platform-specific reconciliation
 	if result, err := r.reconcileNemoGuardrail(ctx, NemoGuardrail); err != nil {
@@ -211,8 +209,15 @@ func (r *NemoGuardrailReconciler) GetEventRecorder() record.EventRecorder {
 }
 
 // GetOrchestratorType returns the container platform type
-func (r *NemoGuardrailReconciler) GetOrchestratorType() k8sutil.OrchestratorType {
-	return r.orchestratorType
+func (r *NemoGuardrailReconciler) GetOrchestratorType() (k8sutil.OrchestratorType, error) {
+	if r.orchestratorType == "" {
+		orchestratorType, err := k8sutil.GetOrchestratorType(r.GetClient())
+		if err != nil {
+			return k8sutil.Unknown, fmt.Errorf("Unable to get container orchestrator type, %v", err)
+		}
+		r.orchestratorType = orchestratorType
+	}
+	return r.orchestratorType, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/nemo_guardrail_controller.go
+++ b/internal/controller/nemo_guardrail_controller.go
@@ -155,7 +155,7 @@ func (r *NemoGuardrailReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	if r.GetOrchestratorType() != "" {
 		orchestratorType, err := k8sutil.GetOrchestratorType(r.GetClient())
 		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("Unable to get container orhestrator type, %v", err)
+			return ctrl.Result{}, fmt.Errorf("Unable to get container orchestrator type, %v", err)
 		}
 		r.orchestratorType = orchestratorType
 	}

--- a/internal/controller/nemo_guardrail_controller.go
+++ b/internal/controller/nemo_guardrail_controller.go
@@ -152,11 +152,10 @@ func (r *NemoGuardrailReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	// Fetch container orchestrator type
-	orchestratorType, err := r.GetOrchestratorType()
+	_, err := r.GetOrchestratorType()
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("Unable to get container orchestrator type, %v", err)
 	}
-	logger.Info("Container orchestrator is successfully set", "type", orchestratorType)
 
 	// Handle platform-specific reconciliation
 	if result, err := r.reconcileNemoGuardrail(ctx, NemoGuardrail); err != nil {
@@ -216,6 +215,7 @@ func (r *NemoGuardrailReconciler) GetOrchestratorType() (k8sutil.OrchestratorTyp
 			return k8sutil.Unknown, fmt.Errorf("Unable to get container orchestrator type, %v", err)
 		}
 		r.orchestratorType = orchestratorType
+		r.GetLogger().Info("Container orchestrator is successfully set", "type", orchestratorType)
 	}
 	return r.orchestratorType, nil
 }

--- a/internal/controller/nemo_guardrail_controller.go
+++ b/internal/controller/nemo_guardrail_controller.go
@@ -23,6 +23,7 @@ import (
 
 	appsv1alpha1 "github.com/NVIDIA/k8s-nim-operator/api/apps/v1alpha1"
 	"github.com/NVIDIA/k8s-nim-operator/internal/conditions"
+	"github.com/NVIDIA/k8s-nim-operator/internal/k8sutil"
 	"github.com/NVIDIA/k8s-nim-operator/internal/render"
 	"github.com/NVIDIA/k8s-nim-operator/internal/shared"
 	"github.com/NVIDIA/k8s-nim-operator/internal/utils"
@@ -60,6 +61,7 @@ type NemoGuardrailReconciler struct {
 	renderer render.Renderer
 	Config   *rest.Config
 	recorder record.EventRecorder
+	k8sType  k8sutil.OrchestratorType
 }
 
 // Ensure NemoGuardrailReconciler implements the Reconciler interface
@@ -67,12 +69,19 @@ var _ shared.Reconciler = &NemoGuardrailReconciler{}
 
 // NewNemoGuardrailReconciler creates a new reconciler for NemoGuardrail with the given platform
 func NewNemoGuardrailReconciler(client client.Client, scheme *runtime.Scheme, updater conditions.Updater, renderer render.Renderer, log logr.Logger) *NemoGuardrailReconciler {
+	// Set container platform type
+	k8sType, err := k8sutil.GetOrchestratorType(client)
+	if err != nil {
+		return nil
+	}
+
 	return &NemoGuardrailReconciler{
 		Client:   client,
 		scheme:   scheme,
 		updater:  updater,
 		renderer: renderer,
 		log:      log,
+		k8sType:  k8sType,
 	}
 }
 
@@ -197,6 +206,11 @@ func (r *NemoGuardrailReconciler) GetRenderer() render.Renderer {
 // GetEventRecorder returns the event recorder
 func (r *NemoGuardrailReconciler) GetEventRecorder() record.EventRecorder {
 	return r.recorder
+}
+
+// GetK8sType returns the container platform type
+func (r *NemoGuardrailReconciler) GetK8sType() k8sutil.OrchestratorType {
+	return r.k8sType
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/nimcache_controller.go
+++ b/internal/controller/nimcache_controller.go
@@ -178,11 +178,10 @@ func (r *NIMCacheReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	}
 
 	// Fetch container orchestrator type
-	orchestratorType, err := r.GetOrchestratorType()
+	_, err = r.GetOrchestratorType()
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("Unable to get container orchestrator type, %v", err)
 	}
-	logger.Info("Container orchestrator is successfully set", "type", orchestratorType)
 
 	// Handle nim-cache reconciliation
 	result, err = r.reconcileNIMCache(ctx, nimCache)
@@ -239,6 +238,7 @@ func (r *NIMCacheReconciler) GetOrchestratorType() (k8sutil.OrchestratorType, er
 			return k8sutil.Unknown, fmt.Errorf("Unable to get container orchestrator type, %v", err)
 		}
 		r.orchestratorType = orchestratorType
+		r.GetLogger().Info("Container orchestrator is successfully set", "type", orchestratorType)
 	}
 	return r.orchestratorType, nil
 }

--- a/internal/controller/nimcache_controller.go
+++ b/internal/controller/nimcache_controller.go
@@ -181,7 +181,7 @@ func (r *NIMCacheReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	if r.GetOrchestratorType() != "" {
 		orchestratorType, err := k8sutil.GetOrchestratorType(r.GetClient())
 		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("Unable to get container orhestrator type, %v", err)
+			return ctrl.Result{}, fmt.Errorf("Unable to get container orchestrator type, %v", err)
 		}
 		r.orchestratorType = orchestratorType
 	}

--- a/internal/controller/nimcache_controller_test.go
+++ b/internal/controller/nimcache_controller_test.go
@@ -39,6 +39,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	appsv1alpha1 "github.com/NVIDIA/k8s-nim-operator/api/apps/v1alpha1"
+	"github.com/NVIDIA/k8s-nim-operator/internal/k8sutil"
 	"github.com/NVIDIA/k8s-nim-operator/internal/nimparser"
 )
 
@@ -338,7 +339,7 @@ var _ = Describe("NIMCache Controller", func() {
 					Source: appsv1alpha1.NIMSource{NGC: &appsv1alpha1.NGCSource{ModelPuller: "nvcr.io/nim:test", PullSecret: "my-secret"}},
 				},
 			}
-			pod := constructPodSpec(nimCache)
+			pod := constructPodSpec(nimCache, k8sutil.K8s)
 			Expect(pod.Name).To(Equal(getPodName(nimCache)))
 			Expect(pod.Spec.Containers[0].Image).To(Equal("nvcr.io/nim:test"))
 			Expect(pod.Spec.ImagePullSecrets[0].Name).To(Equal("my-secret"))
@@ -359,7 +360,7 @@ var _ = Describe("NIMCache Controller", func() {
 				},
 			}
 
-			pod := constructPodSpec(nimCache)
+			pod := constructPodSpec(nimCache, k8sutil.K8s)
 
 			err := cli.Create(context.TODO(), pod)
 			Expect(err).ToNot(HaveOccurred())
@@ -387,7 +388,7 @@ var _ = Describe("NIMCache Controller", func() {
 				},
 			}
 
-			job, err := reconciler.constructJob(context.TODO(), nimCache)
+			job, err := reconciler.constructJob(context.TODO(), nimCache, k8sutil.K8s)
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(job.Name).To(Equal(getJobName(nimCache)))
@@ -418,7 +419,7 @@ var _ = Describe("NIMCache Controller", func() {
 				},
 			}
 
-			job, err := reconciler.constructJob(context.TODO(), nimCache)
+			job, err := reconciler.constructJob(context.TODO(), nimCache, k8sutil.K8s)
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(job.Name).To(Equal(getJobName(nimCache)))
@@ -445,7 +446,7 @@ var _ = Describe("NIMCache Controller", func() {
 				},
 			}
 
-			job, err := reconciler.constructJob(context.TODO(), nimCache)
+			job, err := reconciler.constructJob(context.TODO(), nimCache, k8sutil.K8s)
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(job.Name).To(Equal(getJobName(nimCache)))
@@ -481,7 +482,7 @@ var _ = Describe("NIMCache Controller", func() {
 				},
 			}
 
-			job, err := reconciler.constructJob(context.TODO(), nimCache)
+			job, err := reconciler.constructJob(context.TODO(), nimCache, k8sutil.K8s)
 			Expect(err).ToNot(HaveOccurred())
 
 			err = cli.Create(context.TODO(), job)
@@ -544,7 +545,7 @@ var _ = Describe("NIMCache Controller", func() {
 			err := reconciler.Create(context.TODO(), configMap)
 			Expect(err).ToNot(HaveOccurred())
 
-			job, err := reconciler.constructJob(context.TODO(), nimCache)
+			job, err := reconciler.constructJob(context.TODO(), nimCache, k8sutil.K8s)
 			Expect(err).ToNot(HaveOccurred())
 
 			err = cli.Create(context.TODO(), job)

--- a/internal/controller/nimservice_controller.go
+++ b/internal/controller/nimservice_controller.go
@@ -152,7 +152,7 @@ func (r *NIMServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	if r.GetOrchestratorType() != "" {
 		orchestratorType, err := k8sutil.GetOrchestratorType(r.GetClient())
 		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("Unable to get container orhestrator type, %v", err)
+			return ctrl.Result{}, fmt.Errorf("Unable to get container orchestrator type, %v", err)
 		}
 		r.orchestratorType = orchestratorType
 	}

--- a/internal/controller/nimservice_controller.go
+++ b/internal/controller/nimservice_controller.go
@@ -149,11 +149,10 @@ func (r *NIMServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 
 	// Fetch container orchestrator type
-	orchestratorType, err := r.GetOrchestratorType()
+	_, err := r.GetOrchestratorType()
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("Unable to get container orchestrator type, %v", err)
 	}
-	logger.Info("Container orchestrator is successfully set", "type", orchestratorType)
 
 	// Handle platform-specific reconciliation
 	if result, err := r.Platform.Sync(ctx, r, nimService); err != nil {
@@ -207,6 +206,7 @@ func (r *NIMServiceReconciler) GetOrchestratorType() (k8sutil.OrchestratorType, 
 			return k8sutil.Unknown, fmt.Errorf("Unable to get container orchestrator type, %v", err)
 		}
 		r.orchestratorType = orchestratorType
+		r.GetLogger().Info("Container orchestrator is successfully set", "type", orchestratorType)
 	}
 	return r.orchestratorType, nil
 }

--- a/internal/controller/platform/standalone/nimservice.go
+++ b/internal/controller/platform/standalone/nimservice.go
@@ -22,6 +22,7 @@ import (
 
 	appsv1alpha1 "github.com/NVIDIA/k8s-nim-operator/api/apps/v1alpha1"
 	"github.com/NVIDIA/k8s-nim-operator/internal/conditions"
+	"github.com/NVIDIA/k8s-nim-operator/internal/k8sutil"
 	"github.com/NVIDIA/k8s-nim-operator/internal/render"
 	rendertypes "github.com/NVIDIA/k8s-nim-operator/internal/render/types"
 	"github.com/NVIDIA/k8s-nim-operator/internal/shared"
@@ -73,6 +74,11 @@ func (r *NIMServiceReconciler) GetRenderer() render.Renderer {
 // GetEventRecorder returns the event recorder
 func (r *NIMServiceReconciler) GetEventRecorder() record.EventRecorder {
 	return r.recorder
+}
+
+// GetK8sType returns the container platform type
+func (r *NIMServiceReconciler) GetK8sType() k8sutil.OrchestratorType {
+	return r.k8sType
 }
 
 func (r *NIMServiceReconciler) cleanupNIMService(ctx context.Context, nimService *appsv1alpha1.NIMService) error {
@@ -172,6 +178,8 @@ func (r *NIMServiceReconciler) reconcileNIMService(ctx context.Context, nimServi
 	deploymentParams := nimService.GetDeploymentParams()
 	var modelPVC *appsv1alpha1.PersistentVolumeClaim
 	modelProfile := ""
+
+	deploymentParams.OrchestratorType = string(r.GetK8sType())
 
 	// Select PVC for model store
 	if nimService.GetNIMCacheName() != "" {

--- a/internal/controller/platform/standalone/nimservice.go
+++ b/internal/controller/platform/standalone/nimservice.go
@@ -76,9 +76,9 @@ func (r *NIMServiceReconciler) GetEventRecorder() record.EventRecorder {
 	return r.recorder
 }
 
-// GetK8sType returns the container platform type
-func (r *NIMServiceReconciler) GetK8sType() k8sutil.OrchestratorType {
-	return r.k8sType
+// GetOrchestratorType returns the container platform type
+func (r *NIMServiceReconciler) GetOrchestratorType() k8sutil.OrchestratorType {
+	return r.orchestratorType
 }
 
 func (r *NIMServiceReconciler) cleanupNIMService(ctx context.Context, nimService *appsv1alpha1.NIMService) error {
@@ -179,7 +179,7 @@ func (r *NIMServiceReconciler) reconcileNIMService(ctx context.Context, nimServi
 	var modelPVC *appsv1alpha1.PersistentVolumeClaim
 	modelProfile := ""
 
-	deploymentParams.OrchestratorType = string(r.GetK8sType())
+	deploymentParams.OrchestratorType = string(r.GetOrchestratorType())
 
 	// Select PVC for model store
 	if nimService.GetNIMCacheName() != "" {

--- a/internal/controller/platform/standalone/standalone.go
+++ b/internal/controller/platform/standalone/standalone.go
@@ -21,6 +21,7 @@ import (
 
 	appsv1alpha1 "github.com/NVIDIA/k8s-nim-operator/api/apps/v1alpha1"
 	"github.com/NVIDIA/k8s-nim-operator/internal/conditions"
+	"github.com/NVIDIA/k8s-nim-operator/internal/k8sutil"
 	"github.com/NVIDIA/k8s-nim-operator/internal/render"
 	"github.com/NVIDIA/k8s-nim-operator/internal/shared"
 	"github.com/go-logr/logr"
@@ -59,6 +60,7 @@ type NIMServiceReconciler struct {
 	updater  conditions.Updater
 	renderer render.Renderer
 	recorder record.EventRecorder
+	k8sType  k8sutil.OrchestratorType
 }
 
 // NewNIMCacheReconciler returns NIMCacheReconciler for standalone mode
@@ -80,6 +82,7 @@ func NewNIMServiceReconciler(r shared.Reconciler) *NIMServiceReconciler {
 		log:      r.GetLogger(),
 		updater:  r.GetUpdater(),
 		recorder: r.GetEventRecorder(),
+		k8sType:  r.GetK8sType(),
 	}
 }
 

--- a/internal/controller/platform/standalone/standalone.go
+++ b/internal/controller/platform/standalone/standalone.go
@@ -76,13 +76,15 @@ func NewNIMCacheReconciler(r shared.Reconciler) *NIMCacheReconciler {
 
 // NewNIMServiceReconciler returns NIMServiceReconciler for standalone mode
 func NewNIMServiceReconciler(r shared.Reconciler) *NIMServiceReconciler {
+	orchestratorType, _ := r.GetOrchestratorType()
+
 	return &NIMServiceReconciler{
 		Client:           r.GetClient(),
 		scheme:           r.GetScheme(),
 		log:              r.GetLogger(),
 		updater:          r.GetUpdater(),
 		recorder:         r.GetEventRecorder(),
-		orchestratorType: r.GetOrchestratorType(),
+		orchestratorType: orchestratorType,
 	}
 }
 

--- a/internal/controller/platform/standalone/standalone.go
+++ b/internal/controller/platform/standalone/standalone.go
@@ -55,12 +55,12 @@ type NIMCacheReconciler struct {
 // NIMServiceReconciler represents the NIMService reconciler instance for standalone mode
 type NIMServiceReconciler struct {
 	client.Client
-	scheme   *runtime.Scheme
-	log      logr.Logger
-	updater  conditions.Updater
-	renderer render.Renderer
-	recorder record.EventRecorder
-	k8sType  k8sutil.OrchestratorType
+	scheme           *runtime.Scheme
+	log              logr.Logger
+	updater          conditions.Updater
+	renderer         render.Renderer
+	recorder         record.EventRecorder
+	orchestratorType k8sutil.OrchestratorType
 }
 
 // NewNIMCacheReconciler returns NIMCacheReconciler for standalone mode
@@ -77,12 +77,12 @@ func NewNIMCacheReconciler(r shared.Reconciler) *NIMCacheReconciler {
 // NewNIMServiceReconciler returns NIMServiceReconciler for standalone mode
 func NewNIMServiceReconciler(r shared.Reconciler) *NIMServiceReconciler {
 	return &NIMServiceReconciler{
-		Client:   r.GetClient(),
-		scheme:   r.GetScheme(),
-		log:      r.GetLogger(),
-		updater:  r.GetUpdater(),
-		recorder: r.GetEventRecorder(),
-		k8sType:  r.GetK8sType(),
+		Client:           r.GetClient(),
+		scheme:           r.GetScheme(),
+		log:              r.GetLogger(),
+		updater:          r.GetUpdater(),
+		recorder:         r.GetEventRecorder(),
+		orchestratorType: r.GetOrchestratorType(),
 	}
 }
 

--- a/internal/k8sutil/k8sutil.go
+++ b/internal/k8sutil/k8sutil.go
@@ -24,35 +24,35 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// PlatformType is the underlying container orchestrator type
-type PlatformType string
+// OrchestratorType is the underlying container orchestrator type
+type OrchestratorType string
 
 const (
 	// TKGS is the VMware Tanzu Kubernetes Grid Service
-	TKGS PlatformType = "TKGS"
+	TKGS OrchestratorType = "TKGS"
 	// OpenShift is the RedHat Openshift Container Platform
-	OpenShift PlatformType = "OpenShift"
+	OpenShift OrchestratorType = "OpenShift"
 	// GKE is the Google Kubernetes Engine Service
-	GKE PlatformType = "GKE"
+	GKE OrchestratorType = "GKE"
 	// EKS is the Amazon Elastic Kubernetes Service
-	EKS PlatformType = "EKS"
+	EKS OrchestratorType = "EKS"
 	// AKS is the Azure Kubernetes Service
-	AKS PlatformType = "AKS"
+	AKS OrchestratorType = "AKS"
 	// OKE is the Oracle Kubernetes Service
-	OKE PlatformType = "OKE"
+	OKE OrchestratorType = "OKE"
 	// Ezmeral is the HPE Ezmeral Data Fabric
-	Ezmeral PlatformType = "Ezmeral"
+	Ezmeral OrchestratorType = "Ezmeral"
 	// RKE is the Rancker Kubernetes Engine
-	RKE PlatformType = "RKE"
+	RKE OrchestratorType = "RKE"
 	// K8s is the upstream Kubernetes Distribution
-	K8s PlatformType = "Kubernetes"
+	K8s OrchestratorType = "Kubernetes"
 	// Unknown distribution type
-	Unknown PlatformType = "Unknown"
+	Unknown OrchestratorType = "Unknown"
 )
 
-// GetContainerPlatform checks the platform by looking for specific node labels that identify
+// GetOrchestratorType checks the container orchestrator by looking for specific node labels that identify
 // TKGS, OpenShift, or CSP-specific Kubernetes distributions.
-func GetContainerPlatform(k8sClient client.Client) (PlatformType, error) {
+func GetOrchestratorType(k8sClient client.Client) (OrchestratorType, error) {
 	nodes := &corev1.NodeList{}
 	err := k8sClient.List(context.TODO(), nodes)
 	if err != nil {

--- a/internal/k8sutil/k8sutil_test.go
+++ b/internal/k8sutil/k8sutil_test.go
@@ -28,7 +28,7 @@ func TestDetectPlatform(t *testing.T) {
 	tests := []struct {
 		name     string
 		labels   map[string]string
-		expected PlatformType
+		expected OrchestratorType
 	}{
 		{"TKGS platform detected", map[string]string{"node.vmware.com/tkg": "true"}, TKGS},
 		{"OpenShift platform detected", map[string]string{"node.openshift.io/os_id": "rhcos"}, OpenShift},
@@ -53,7 +53,7 @@ func TestDetectPlatform(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithObjects(node).Build()
 
 			// Detect container platform
-			platform, err := GetContainerPlatform(fakeClient)
+			platform, err := GetOrchestratorType(fakeClient)
 			if err != nil {
 				t.Fatalf("GetContainerPlatform failed: %v", err)
 			}

--- a/internal/render/types/types.go
+++ b/internal/render/types/types.go
@@ -80,6 +80,7 @@ type DeploymentParams struct {
 	UserID             *int64
 	GroupID            *int64
 	RuntimeClassName   string
+	OrchestratorType   string
 }
 
 // StatefulSetParams holds the parameters for rendering a StatefulSet template
@@ -110,6 +111,7 @@ type StatefulSetParams struct {
 	StartupProbe       *corev1.Probe
 	NIMCachePVC        string
 	RuntimeClassName   string
+	OrchestratorType   string
 }
 
 // ServiceParams holds the parameters for rendering a Service template

--- a/internal/shared/reconciler.go
+++ b/internal/shared/reconciler.go
@@ -18,6 +18,7 @@ package shared
 
 import (
 	"github.com/NVIDIA/k8s-nim-operator/internal/conditions"
+	"github.com/NVIDIA/k8s-nim-operator/internal/k8sutil"
 	"github.com/NVIDIA/k8s-nim-operator/internal/render"
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -34,4 +35,5 @@ type Reconciler interface {
 	GetUpdater() conditions.Updater
 	GetRenderer() render.Renderer
 	GetEventRecorder() record.EventRecorder
+	GetK8sType() k8sutil.OrchestratorType
 }

--- a/internal/shared/reconciler.go
+++ b/internal/shared/reconciler.go
@@ -35,5 +35,5 @@ type Reconciler interface {
 	GetUpdater() conditions.Updater
 	GetRenderer() render.Renderer
 	GetEventRecorder() record.EventRecorder
-	GetK8sType() k8sutil.OrchestratorType
+	GetOrchestratorType() k8sutil.OrchestratorType
 }

--- a/internal/shared/reconciler.go
+++ b/internal/shared/reconciler.go
@@ -35,5 +35,5 @@ type Reconciler interface {
 	GetUpdater() conditions.Updater
 	GetRenderer() render.Renderer
 	GetEventRecorder() record.EventRecorder
-	GetOrchestratorType() k8sutil.OrchestratorType
+	GetOrchestratorType() (k8sutil.OrchestratorType, error)
 }

--- a/manifests/deployment.yaml
+++ b/manifests/deployment.yaml
@@ -118,8 +118,10 @@ spec:
       {{- end }}
       {{- end }}
       securityContext:
+        {{- if eq .OrchestratorType "TKGS" }}
         seccompProfile:
           type: RuntimeDefault
+        {{- end }}
         {{- if .UserID }}
         runAsUser: {{ .UserID }}
         {{- end }}


### PR DESCRIPTION
For e.g. seccompprofile is a must for TKGS while not supported on OCP with the nonroot SCC