### PR TITLE
Bump nvidia/distroless/go in /deployments/container (#234)

### DIFF
--- a/deployments/container/Dockerfile
+++ b/deployments/container/Dockerfile
@@ -30,7 +30,7 @@ RUN if [ "$TARGETARCH" = "x86_64" ]; then OS_ARCH="amd64"; elif [ "$TARGETARCH" 
     && chmod +x ./kubectl
 
 # Use distroless as minimal base image to package the manager binary
-FROM nvcr.io/nvidia/distroless/go:v3.1.2
+FROM nvcr.io/nvidia/distroless/go:v3.1.3
 
 ARG VERSION="unknown"
 


### PR DESCRIPTION
Bumps nvidia/distroless/go from v3.1.2 to v3.1.3.

---
updated-dependencies:
- dependency-name: nvidia/distroless/go dependency-type: direct:production ...