### PR TITLE
Updating Kubectl version in container image to fix CVE

### DIFF
--- a/deployments/container/Dockerfile
+++ b/deployments/container/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
 
 # Install kubectl for must-gather and helm upgrades hooks
 RUN if [ "$TARGETARCH" = "x86_64" ]; then OS_ARCH="amd64"; elif [ "$TARGETARCH" = "aarch64" ]; then OS_ARCH="arm64"; else OS_ARCH="$TARGETARCH"; fi \
-    && curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/${OS_ARCH}/kubectl \
+    && curl -LO https://dl.k8s.io/release/$(curl -Ls https://dl.k8s.io/release/stable.txt)/bin/linux/${OS_ARCH}/kubectl \
     && chmod +x ./kubectl
 
 # Use distroless as minimal base image to package the manager binary


### PR DESCRIPTION
fixing following CVE
```
 +------------+-----------------+-----------+----------------------------------+----------------------------------------------------------+---------------------+
    | GateAction | Gate            | Trigger   | Additional Info                  | Check Output                                             | Inherited from Base |
    +------------+-----------------+-----------+----------------------------------+----------------------------------------------------------+---------------------+
    | go         | vulnerabilities | package   | Cloud Native Allowlist           | HIGH Vulnerability found in non-os package type (go) -   | false               |
    |            |                 |           |                                  | /usr/local/bin/kubectl (fixed in: 1.22.7,                |                     |
    |            |                 |           |                                  | 1.23.1)(CVE-2024-34156 -                                 |                     |
    |            |                 |           |                                  | https://nvd.nist.gov/vuln/detail/CVE-2024-34156)         |                     |
    | go         | vulnerabilities | package   | Cloud Native Allowlist           | HIGH Vulnerability found in non-os package type (go) -   | false               |
    |            |                 |           |                                  | /usr/local/bin/kubectl (fixed in: 1.22.7,                |                     |
    |            |                 |           |                                  | 1.23.1)(CVE-2024-34158 -                                 |                     |
    |            |                 |           |                                  | https://nvd.nist.gov/vuln/detail/CVE-2024-34158)         |                     |
    | warn       | metadata        | attribute | 4cfbaae813afd1f28aa34cc889c06e5b | Attribute check for attribute: 'size' check: '>'         | false               |
    |            |                 |           |                                  | check_value: '3741824' matched image value: '155301888'  |                     |
    | warn       | vulnerabilities | package   | CVE-2024-34155+stdlib-go1.22.5   | MEDIUM Vulnerability found in non-os package type (go) - | false               |
    |            |                 |           |                                  | /usr/local/bin/kubectl (fixed in: 1.22.7,                |                     |
    |            |                 |           |                                  | 1.23.1)(CVE-2024-34155 -                                 |                     |
    |            |                 |           |                                  | https://nvd.nist.gov/vuln/detail/CVE-2024-34155)         |                     |
    ```