### PR TITLE
Retrieve NIM_ENDPOINT_API_KEY for Guardrail from k8s secret

### DIFF
--- a/api/apps/v1alpha1/nemo_guardrails_types.go
+++ b/api/apps/v1alpha1/nemo_guardrails_types.go
@@ -59,8 +59,8 @@ type NemoGuardrailSpec struct {
 	Command []string        `json:"command,omitempty"`
 	Args    []string        `json:"args,omitempty"`
 	Env     []corev1.EnvVar `json:"env,omitempty"`
-	// The name of an secret that contains authn for the NGC NIM service API
-	AuthSecret string `json:"authSecret"`
+	// The name of an secret that contains authn for the NGC NIM service API, required when the NIM is hosted by NGC
+	AuthSecret string `json:"authSecret,omitempty"`
 	// ConfigStore stores the config of the guardrail service
 	ConfigStore    GuardrailConfig              `json:"configStore,omitempty"`
 	Labels         map[string]string            `json:"labels,omitempty"`
@@ -197,19 +197,21 @@ func (n *NemoGuardrail) GetStandardEnv() []corev1.EnvVar {
 			Name:  "DEMO",
 			Value: "False",
 		},
-		{
+	}
+
+	if len(n.Spec.AuthSecret) > 0 {
+		envVars = append(envVars, corev1.EnvVar{
 			Name: "NIM_ENDPOINT_API_KEY",
 			ValueFrom: &corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{
-					Key: "nim-endpoint-api-key",
+					Key: "NIM_ENDPOINT_API_KEY",
 					LocalObjectReference: corev1.LocalObjectReference{
 						Name: n.Spec.AuthSecret,
 					},
 				},
 			},
-		},
+		})
 	}
-
 	return envVars
 }
 

--- a/api/apps/v1alpha1/nemo_guardrails_types.go
+++ b/api/apps/v1alpha1/nemo_guardrails_types.go
@@ -197,6 +197,17 @@ func (n *NemoGuardrail) GetStandardEnv() []corev1.EnvVar {
 			Name:  "DEMO",
 			Value: "False",
 		},
+		{
+			Name: "NIM_ENDPOINT_API_KEY",
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					Key: "nim-endpoint-api-key",
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: n.Spec.AuthSecret,
+					},
+				},
+			},
+		},
 	}
 
 	return envVars

--- a/bundle/manifests/apps.nvidia.com_nemoguardrails.yaml
+++ b/bundle/manifests/apps.nvidia.com_nemoguardrails.yaml
@@ -57,7 +57,7 @@ spec:
                 type: array
               authSecret:
                 description: The name of an secret that contains authn for the NGC
-                  NIM service API
+                  NIM service API, required when the NIM is hosted by NGC
                 type: string
               command:
                 items:
@@ -2143,7 +2143,6 @@ spec:
                 format: int64
                 type: integer
             required:
-            - authSecret
             - image
             type: object
           status:

--- a/config/crd/bases/apps.nvidia.com_nemoguardrails.yaml
+++ b/config/crd/bases/apps.nvidia.com_nemoguardrails.yaml
@@ -57,7 +57,7 @@ spec:
                 type: array
               authSecret:
                 description: The name of an secret that contains authn for the NGC
-                  NIM service API
+                  NIM service API, required when the NIM is hosted by NGC
                 type: string
               command:
                 items:
@@ -2143,7 +2143,6 @@ spec:
                 format: int64
                 type: integer
             required:
-            - authSecret
             - image
             type: object
           status:

--- a/config/samples/apps_v1alpha1_nemoguardrails.yaml
+++ b/config/samples/apps_v1alpha1_nemoguardrails.yaml
@@ -10,9 +10,7 @@ spec:
       name: gr-config
   env:
     - name: NIM_ENDPOINT_URL
-      value: http://<NIM_SERVICE_ENDPOINT>:<NIM_SERVICE_PORT>/v1
-    - name: NIM_ENDPOINT_API_KEY
-      value: dummy
+      value: "http://<NIM_SERVICE_ENDPOINT>:<NIM_SERVICE_PORT>/v1"
   expose:
     service:
       type: ClusterIP

--- a/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nemoguardrails.yaml
+++ b/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nemoguardrails.yaml
@@ -57,7 +57,7 @@ spec:
                 type: array
               authSecret:
                 description: The name of an secret that contains authn for the NGC
-                  NIM service API
+                  NIM service API, required when the NIM is hosted by NGC
                 type: string
               command:
                 items:
@@ -2143,7 +2143,6 @@ spec:
                 format: int64
                 type: integer
             required:
-            - authSecret
             - image
             type: object
           status:


### PR DESCRIPTION
This MR injects the `NIM_ENDPOINT_API_KEY` environment variable into the NeMo Guardrail container from a Kubernetes Secret.

Before creating the Guardrail service, a Secret with key `NIM_ENDPOINT_API_KEY` must be created. 

`.spec.authSecret` in NemoGuardrail is now optional, as it's only required when the NIM is NGC hosted.