### PR TITLE
Fix Milvus installation in OpenShift

### DIFF
--- a/test/e2e/nemo-dependencies/evaluator/tasks/milvus.yaml
+++ b/test/e2e/nemo-dependencies/evaluator/tasks/milvus.yaml
@@ -1,4 +1,20 @@
 ---
+- name: Get Kube API resources
+  command: kubectl api-resources --verbs=list --namespaced -o name
+  register: api_resources
+
+- name: Check if the current cluster is OpenShift
+  set_fact:
+    is_openshift: "{{ 'routes.route.openshift.io' in api_resources.stdout_lines }}"
+
+- name: OpenShift - Create Milvus service account
+  command: kubectl create serviceaccount milvus -n {{ namespace }}
+  when: is_openshift
+
+- name: OpenShift - Add SCC policy anyuid to Milvus service account
+  command: oc adm policy add-scc-to-user anyuid system:serviceaccount:{{ namespace }}:milvus
+  when: is_openshift
+
 - name: Add Helm repository for Milvus
   command: helm repo add {{ milvus.helm_repo_name }} {{ milvus.helm_repo_url }}
 
@@ -9,6 +25,17 @@
   ansible.builtin.template:
     src: milvus-values.yaml.j2
     dest: milvus-values.yaml
+
+- name: OpenShift - configure Milvus to use its dedicated service account
+  blockinfile:
+    path: milvus-values.yaml
+    marker: "# {mark} ANSIBLE MANAGED BLOCK"
+    insertafter: "^(.*)$"
+    block: |
+      serviceAccount:
+        create: false
+        name: milvus
+  when: is_openshift
 
 - name: Install Milvus Helm chart
   shell: >

--- a/test/e2e/nemo-dependencies/evaluator/tasks/uninstall.yaml
+++ b/test/e2e/nemo-dependencies/evaluator/tasks/uninstall.yaml
@@ -16,3 +16,7 @@
   loop:
     - crd
   ignore_errors: true
+
+- name: Delete Milvus SA
+  command: kubectl delete serviceaccount milvus -n {{ namespace }}
+  ignore_errors: true


### PR DESCRIPTION
Milvus is crashing when it's installed in a custom namespace OpenShift with the following error message
`2025/02/27 07:46:13 write failed: open /milvus/configs/milvus.yaml: permission denied`

This stems from the `restricted-v2` SCC in OpenShift. 
By default, OpenShift uses the most restricted SCC `restricted-v2` for service accounts in `nemo` namespace. When such SCC is applied, the following securityContext is added to the Milvus container.
```yaml
securityContext:
allowPrivilegeEscalation: false
capabilities:
drop:
- ALL
runAsNonRoot: true
runAsUser: 1000790000
```

This makes the main container unable to read the `/milvus/configs/milvus.yaml` file created by the init container.

This MR fixes the issue by creating a dedicated service account for Milvus, and assigning the SCC `anyuid` to the service account.