### PR TITLE
Grant anyuid SCC to Milvus using k8s Role and RoleBinding

### DIFF
--- a/test/e2e/nemo-dependencies/evaluator/tasks/milvus.yaml
+++ b/test/e2e/nemo-dependencies/evaluator/tasks/milvus.yaml
@@ -7,13 +7,16 @@
   set_fact:
     is_openshift: "{{ 'routes.route.openshift.io' in api_resources.stdout_lines }}"
 
-- name: OpenShift - Create Milvus service account
-  command: kubectl create serviceaccount milvus -n {{ namespace }}
-  when: is_openshift
 
-- name: OpenShift - Add SCC policy anyuid to Milvus service account
-  command: oc adm policy add-scc-to-user anyuid system:serviceaccount:{{ namespace }}:milvus
-  when: is_openshift
+- name: OpenShift - Prepare RBAC to use anyuid SCC
+  ansible.builtin.template:
+    src: milvus-oc-rbac.yaml.j2
+    dest: milvus-oc-rbac.yaml
+  when: is_openshift 
+
+- name: OpenShift - apply RBAC to use anyuid SCC
+  command: kubectl apply -f milvus-oc-rbac.yaml
+  when: is_openshift 
 
 - name: Add Helm repository for Milvus
   command: helm repo add {{ milvus.helm_repo_name }} {{ milvus.helm_repo_url }}

--- a/test/e2e/nemo-dependencies/evaluator/tasks/uninstall.yaml
+++ b/test/e2e/nemo-dependencies/evaluator/tasks/uninstall.yaml
@@ -20,3 +20,11 @@
 - name: Delete Milvus SA
   command: kubectl delete serviceaccount milvus -n {{ namespace }}
   ignore_errors: true
+
+- name: Delete Milvus role
+  command: kubectl delete role scc-anyuid -n {{ namespace }}
+  ignore_errors: true
+
+- name: Delete Milvus rolebinding
+  command: kubectl delete rolebinding milvus-scc-anyuid-binding -n {{ namespace }}
+  ignore_errors: true

--- a/test/e2e/nemo-dependencies/evaluator/templates/milvus-oc-rbac.yaml.j2
+++ b/test/e2e/nemo-dependencies/evaluator/templates/milvus-oc-rbac.yaml.j2
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: milvus
+  namespace: {{ namespace }}
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: scc-anyuid
+  namespace: {{ namespace }}
+rules:
+- apiGroups: ['security.openshift.io']
+  resources: ['securitycontextconstraints']
+  verbs: ['use']
+  resourceNames: ['anyuid']
+
+--- 
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: milvus-scc-anyuid-binding
+  namespace: {{ namespace }}
+subjects:
+- kind: ServiceAccount
+  name: milvus
+  namespace: {{ namespace }}
+roleRef:
+  kind: ClusterRole
+  name: scc-anyuid
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
This MR grants anyuid SCC to Milvus by using Kubernetes Role and RoleBinding in OpenShift clusters.


This eliminates the extra dependency of using `oc` binary.