### PR TITLE
Remove non needed Holodeck steps

### DIFF
--- a/test/e2e/infra/aws.yml
+++ b/test/e2e/infra/aws.yml
@@ -26,10 +26,6 @@ spec:
   containerRuntime:
     install: true
     name: containerd
-  nvidiaContainerToolkit:
-    install: true
-  nvidiaDriver:
-    install: true
   kubernetes:
     install: true
     installer: kubeadm


### PR DESCRIPTION
This pull request includes a change to the `test/e2e/infra/aws.yml` file, specifically within the `spec` section. The change involves removing the installation of NVIDIA container toolkit and NVIDIA driver. We deploy the GPU Operator as part of the E2E suite, so there's no need to do it via the infra provisioner. 

Changes in `spec` section:

* [`test/e2e/infra/aws.yml`](diffhunk://#diff-a53740647e538040c422862c6fb9f066891b14f0d792f33abf2a29f353061180L29-L32): Removed the installation of `nvidiaContainerToolkit` and `nvidiaDriver`.