### PR TITLE
Use g6.xlarge EC2 instance type for E2E jobs

### DIFF
--- a/test/e2e/infra/aws.yml
+++ b/test/e2e/infra/aws.yml
@@ -9,7 +9,7 @@ spec:
     keyName: cnt-ci-east-1
     privateKey: HOLODECK_PRIVATE_KEY
   instance:
-    type: g6e.xlarge
+    type: g6.xlarge
     region: us-east-1
     ingressIpRanges:
     - 18.190.12.32/32


### PR DESCRIPTION
This pull request includes a change to the `test/e2e/infra/aws.yml` file, where the instance type has been updated to a different model.

* [`test/e2e/infra/aws.yml`](diffhunk://#diff-a53740647e538040c422862c6fb9f066891b14f0d792f33abf2a29f353061180L12-R12): Changed the instance type from `g6e.xlarge` to `g6.xlarge` which are `NVIDIA L4 Tensor Core GPUs`.