### PR TITLE
Revert "Use g6.xlarge EC2 instance type for E2E jobs"

### DIFF
--- a/test/e2e/infra/aws.yml
+++ b/test/e2e/infra/aws.yml
@@ -9,7 +9,7 @@ spec:
     keyName: cnt-ci-east-1
     privateKey: HOLODECK_PRIVATE_KEY
   instance:
-    type: g6.xlarge
+    type: g6e.xlarge
     region: us-east-1
     ingressIpRanges:
     - 18.190.12.32/32


### PR DESCRIPTION
Reverts NVIDIA/k8s-nim-operator#389 - The problem was found at the AWS control plane, we should be ready to resume using g6e instances