### PR TITLE
Fix a typo in Milvus OC RBAC template

### DIFF
--- a/test/e2e/nemo-dependencies/evaluator/templates/milvus-oc-rbac.yaml.j2
+++ b/test/e2e/nemo-dependencies/evaluator/templates/milvus-oc-rbac.yaml.j2
@@ -29,6 +29,6 @@ subjects:
   name: milvus
   namespace: {{ namespace }}
 roleRef:
-  kind: ClusterRole
+  kind: Role
   name: scc-anyuid
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
The RoleBinding `milvus-scc-anyuid-binding` was mistakenly referring to the `ClusterRole` rather than `Role`.
Fixing in this PR