### PR TITLE
Remove .spec.authSecret from Guardrail sample

### DIFF
--- a/config/samples/nemo/latest/apps_v1alpha1_nemoguardrails.yaml
+++ b/config/samples/nemo/latest/apps_v1alpha1_nemoguardrails.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: nemo
 spec:
   # required if a NIM endpoint is hosted by NVIDIA
-  authSecret: ""
   configStore:
     pvc:
       name: "pvc-guardrail-config"


### PR DESCRIPTION
`.spec.authSecret` removed after [this MR](https://github.com/NVIDIA/k8s-nim-operator/commit/6f322b5f4443604547272ffd261ad0f4381bbc57). 

Remove the field from the sample