### PR TITLE
Fix guardrail API

### DIFF
--- a/api/apps/v1alpha1/nemo_guardrails_types.go
+++ b/api/apps/v1alpha1/nemo_guardrails_types.go
@@ -415,7 +415,11 @@ func (n *NemoGuardrail) GetVolumeMounts() []corev1.VolumeMount {
 	}
 	if n.Spec.ConfigStore.PVC != nil {
 		volumeMount.MountPath = "/config-store"
-		volumeMount.SubPath = n.Spec.ConfigStore.PVC.SubPath
+		subPath := n.Spec.ConfigStore.PVC.SubPath
+		if subPath == "" {
+			subPath = "guardrails-config-store"
+		}
+		volumeMount.SubPath = subPath
 	}
 
 	return []corev1.VolumeMount{volumeMount}

--- a/api/apps/v1alpha1/zz_generated.deepcopy.go
+++ b/api/apps/v1alpha1/zz_generated.deepcopy.go
@@ -1898,7 +1898,11 @@ func (in *NemoGuardrailSpec) DeepCopyInto(out *NemoGuardrailSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	out.NIMEndpoint = in.NIMEndpoint
+	if in.NIMEndpoint != nil {
+		in, out := &in.NIMEndpoint, &out.NIMEndpoint
+		*out = new(NIMEndpoint)
+		**out = **in
+	}
 	in.ConfigStore.DeepCopyInto(&out.ConfigStore)
 	if in.Labels != nil {
 		in, out := &in.Labels, &out.Labels

--- a/bundle/manifests/apps.nvidia.com_nemoguardrails.yaml
+++ b/bundle/manifests/apps.nvidia.com_nemoguardrails.yaml
@@ -1439,7 +1439,6 @@ spec:
                 type: integer
             required:
             - image
-            - nimEndpoint
             type: object
           status:
             description: NemoGuardrailStatus defines the observed state of NemoGuardrail

--- a/config/crd/bases/apps.nvidia.com_nemoguardrails.yaml
+++ b/config/crd/bases/apps.nvidia.com_nemoguardrails.yaml
@@ -1439,7 +1439,6 @@ spec:
                 type: integer
             required:
             - image
-            - nimEndpoint
             type: object
           status:
             description: NemoGuardrailStatus defines the observed state of NemoGuardrail

--- a/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nemoguardrails.yaml
+++ b/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nemoguardrails.yaml
@@ -1439,7 +1439,6 @@ spec:
                 type: integer
             required:
             - image
-            - nimEndpoint
             type: object
           status:
             description: NemoGuardrailStatus defines the observed state of NemoGuardrail


### PR DESCRIPTION
1. Make nimEndpoint optional to support multiple locally deployed NIMs through a global configstore config for guardrails
2. Fix mountpath when using a configmap for configstore so that its easier to use
3. Use a default `subPath` (guardrails-config-store) if `nemoguardrail.spec.configStore.pvc.subPath` is not specified so that any FS related files (like `lost+found` for ext4) are not present in the configstore path for guardrails.