### PR TITLE
Add workaround to explicitly specify SC for workspace PVC

### DIFF
--- a/config/samples/nemo/latest/apps_v1alpha1_nemocustomizer.yaml
+++ b/config/samples/nemo/latest/apps_v1alpha1_nemocustomizer.yaml
@@ -84,7 +84,7 @@ spec:
       size: 50Gi
     # Workspace PVC automatically created per job
     workspacePVC:
-      storageClass: ""
+      storageClass: "local-path"
       volumeAccessMode: ReadWriteOnce
       size: 10Gi
       # Mount path for workspace inside container


### PR DESCRIPTION
* This is required until there is a fix in the training operator to avoid setting empty storage class in the PVC spec (which implies manual PV creation)