### PR TITLE
Allow custom scheduler to be specified in NIMService and NIMPipeline

### DIFF
--- a/api/apps/v1alpha1/nimservice_types.go
+++ b/api/apps/v1alpha1/nimservice_types.go
@@ -76,6 +76,7 @@ type NIMServiceSpec struct {
 	ReadinessProbe Probe                        `json:"readinessProbe,omitempty"`
 	StartupProbe   Probe                        `json:"startupProbe,omitempty"`
 	Scale          Autoscaling                  `json:"scale,omitempty"`
+	SchedulerName  string                       `json:"schedulerName,omitempty"`
 	Metrics        Metrics                      `json:"metrics,omitempty"`
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:default:=1
@@ -693,6 +694,9 @@ func (n *NIMService) GetDeploymentParams() *rendertypes.DeploymentParams {
 	// Set runtime class
 	params.RuntimeClassName = n.GetRuntimeClassName()
 
+	// Set scheduler
+	params.SchedulerName = n.GetSchedulerName()
+
 	// Setup container ports for nimservice
 	params.Ports = []corev1.ContainerPort{
 		{
@@ -716,6 +720,11 @@ func (n *NIMService) GetDeploymentParams() *rendertypes.DeploymentParams {
 		})
 	}
 	return params
+}
+
+// GetSchedulerName returns the scheduler name for the NIMService deployment.
+func (n *NIMService) GetSchedulerName() string {
+	return n.Spec.SchedulerName
 }
 
 // GetStatefulSetParams returns params to render StatefulSet from templates.

--- a/bundle/manifests/apps.nvidia.com_nimpipelines.yaml
+++ b/bundle/manifests/apps.nvidia.com_nimpipelines.yaml
@@ -2008,6 +2008,8 @@ spec:
                               - maxReplicas
                               type: object
                           type: object
+                        schedulerName:
+                          type: string
                         startupProbe:
                           description: Probe defines attributes for startup/liveness/readiness
                             probes.

--- a/bundle/manifests/apps.nvidia.com_nimservices.yaml
+++ b/bundle/manifests/apps.nvidia.com_nimservices.yaml
@@ -1927,6 +1927,8 @@ spec:
                     - maxReplicas
                     type: object
                 type: object
+              schedulerName:
+                type: string
               startupProbe:
                 description: Probe defines attributes for startup/liveness/readiness
                   probes.

--- a/config/crd/bases/apps.nvidia.com_nimpipelines.yaml
+++ b/config/crd/bases/apps.nvidia.com_nimpipelines.yaml
@@ -2008,6 +2008,8 @@ spec:
                               - maxReplicas
                               type: object
                           type: object
+                        schedulerName:
+                          type: string
                         startupProbe:
                           description: Probe defines attributes for startup/liveness/readiness
                             probes.

--- a/config/crd/bases/apps.nvidia.com_nimservices.yaml
+++ b/config/crd/bases/apps.nvidia.com_nimservices.yaml
@@ -1927,6 +1927,8 @@ spec:
                     - maxReplicas
                     type: object
                 type: object
+              schedulerName:
+                type: string
               startupProbe:
                 description: Probe defines attributes for startup/liveness/readiness
                   probes.

--- a/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nimpipelines.yaml
+++ b/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nimpipelines.yaml
@@ -2008,6 +2008,8 @@ spec:
                               - maxReplicas
                               type: object
                           type: object
+                        schedulerName:
+                          type: string
                         startupProbe:
                           description: Probe defines attributes for startup/liveness/readiness
                             probes.

--- a/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nimservices.yaml
+++ b/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nimservices.yaml
@@ -1927,6 +1927,8 @@ spec:
                     - maxReplicas
                     type: object
                 type: object
+              schedulerName:
+                type: string
               startupProbe:
                 description: Probe defines attributes for startup/liveness/readiness
                   probes.

--- a/internal/render/types/types.go
+++ b/internal/render/types/types.go
@@ -66,6 +66,7 @@ type DeploymentParams struct {
 	Image              string
 	ImagePullSecrets   []string
 	ImagePullPolicy    string
+	SchedulerName      string
 	Volumes            []corev1.Volume
 	VolumeMounts       []corev1.VolumeMount
 	Env                []corev1.EnvVar

--- a/manifests/deployment.yaml
+++ b/manifests/deployment.yaml
@@ -35,6 +35,9 @@ spec:
         {{- .PodAnnotations | yaml | nindent 8 }}
       {{- end }}
     spec:
+      {{- if .SchedulerName }}
+      schedulerName: {{ .SchedulerName }}
+      {{- end }}
       serviceAccountName: {{ .ServiceAccountName }}
       runtimeClassName: {{ .RuntimeClassName }}
       initContainers:


### PR DESCRIPTION
This PR adds allows NIMs to be scheduled with a custom scheduler.
- custom scheduler can be specified in `.spec.services[].spec.schedulerName` for NIMPipeline; and in `.spec.schedulerName` for NIMServices.
- Default to `default-scheduler` if the `.schedulerName` is unspecified

# Scheduled with Volcano

```
$ kubectl get nimpipeline llama3-1b-pipeline
NAME                 STATUS   AGE
llama3-1b-pipeline   Ready    31m
$ kubectl get nimpipeline llama3-1b-pipeline -o json | jq '.spec.services[].spec.schedulerName'
{
  "type": "volcano"
}
$ kubectl get pods meta-llama3
-1b-instruct-74cc4c5c9b-dtkdn -o json | jq '.spec.schedulerName'
"volcano"
```


Describing the created NIM pod, we can see that the pod was scheduled with Volcano

```
Events:
  Type     Reason     Age                 From     Message
  ----     ------     ----                ----     -------
  Normal   Scheduled  32m                 volcano  Successfully assigned nemo/meta-llama3-1b-instruct-74cc4c5c9b-dtkdn to nim-operator-9vg0z43
```

# Scheduled with default-scheduler
If the scheduler is unspecified, NIM operator will choose the `default-scheduler` as default.

```
$ kubectl get nimservice meta-llama3-8b-instruct -o json | jq '.spec.scheduler'
null
```

Describing the NIM pod, we can see that the pod was scheduled with default-scheduler
```
Events:
  Type     Reason     Age                   From               Message
  ----     ------     ----                  ----               -------
  Normal   Scheduled  12m                   default-scheduler  Successfully assigned nemo/meta-llama3-8b-instruct-6d95cd589b-qp96s to nim-operator-9vg0z43
```

