### PR TITLE
Add optional grpc,metrics ports to NIMService

### DIFF
--- a/api/apps/v1alpha1/common_types.go
+++ b/api/apps/v1alpha1/common_types.go
@@ -25,10 +25,14 @@ import (
 )
 
 const (
-	// DefaultAPIPort is the default api  port.
+	// DefaultAPIPort is the default api port.
 	DefaultAPIPort = 8000
 	// DefaultNamedPortAPI is the default name for api port.
 	DefaultNamedPortAPI = "api"
+	// DefaultNamedPortGRPC is the default name for grpc port.
+	DefaultNamedPortGRPC = "grpc"
+	// DefaultNamedPortMetrics is the default name for metrics port.
+	DefaultNamedPortMetrics = "metrics"
 )
 
 // Expose defines attributes to expose the service.
@@ -40,13 +44,26 @@ type Expose struct {
 // Service defines attributes to create a service.
 type Service struct {
 	Type corev1.ServiceType `json:"type,omitempty"`
-	// override the default service name
+	// Override the default service name
 	Name string `json:"name,omitempty"`
 	// Port is the main api serving port (default: 8000)
+	//
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=65535
 	// +kubebuilder:default:=8000
-	Port        *int32            `json:"port,omitempty"`
+	Port *int32 `json:"port,omitempty"`
+	// GRPCPort is the GRPC serving port
+	// Note: This port is only applicable for NIMs that runs a Triton GRPC Inference Server.
+	//
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=65535
+	GRPCPort *int32 `json:"grpcPort,omitempty"`
+	// MetricsPort is the port for metrics
+	// Note: This port is only applicable for NIMs that runs a separate metrics endpoint on Triton Inference Server.
+	//
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=65535
+	MetricsPort *int32            `json:"metricsPort,omitempty"`
 	Annotations map[string]string `json:"annotations,omitempty"`
 }
 

--- a/api/apps/v1alpha1/nemo_customizer_types.go
+++ b/api/apps/v1alpha1/nemo_customizer_types.go
@@ -77,9 +77,11 @@ type NemoCustomizerSpec struct {
 	Tolerations  []corev1.Toleration          `json:"tolerations,omitempty"`
 	PodAffinity  *corev1.PodAffinity          `json:"podAffinity,omitempty"`
 	Resources    *corev1.ResourceRequirements `json:"resources,omitempty"`
-	Expose       ExposeV1                     `json:"expose,omitempty"`
-	Scale        Autoscaling                  `json:"scale,omitempty"`
-	Metrics      Metrics                      `json:"metrics,omitempty"`
+	// +kubebuilder:validation:XValidation:rule="!(has(self.service.grpcPort))", message="unsupported field: spec.expose.service.grpcPort"
+	// +kubebuilder:validation:XValidation:rule="!(has(self.service.metricsPort))", message="unsupported field: spec.expose.service.metricsPort"
+	Expose  ExposeV1    `json:"expose,omitempty"`
+	Scale   Autoscaling `json:"scale,omitempty"`
+	Metrics Metrics     `json:"metrics,omitempty"`
 
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:default:=1

--- a/api/apps/v1alpha1/nemo_datastore_types.go
+++ b/api/apps/v1alpha1/nemo_datastore_types.go
@@ -68,9 +68,11 @@ type NemoDatastoreSpec struct {
 	Tolerations  []corev1.Toleration          `json:"tolerations,omitempty"`
 	PodAffinity  *corev1.PodAffinity          `json:"podAffinity,omitempty"`
 	Resources    *corev1.ResourceRequirements `json:"resources,omitempty"`
-	Expose       ExposeV1                     `json:"expose,omitempty"`
-	Scale        Autoscaling                  `json:"scale,omitempty"`
-	Metrics      Metrics                      `json:"metrics,omitempty"`
+	// +kubebuilder:validation:XValidation:rule="!(has(self.service.grpcPort))", message="unsupported field: spec.expose.service.grpcPort"
+	// +kubebuilder:validation:XValidation:rule="!(has(self.service.metricsPort))", message="unsupported field: spec.expose.service.metricsPort"
+	Expose  ExposeV1    `json:"expose,omitempty"`
+	Scale   Autoscaling `json:"scale,omitempty"`
+	Metrics Metrics     `json:"metrics,omitempty"`
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:default:=1
 	Replicas     int    `json:"replicas,omitempty"`

--- a/api/apps/v1alpha1/nemo_entitystore_types.go
+++ b/api/apps/v1alpha1/nemo_entitystore_types.go
@@ -69,9 +69,11 @@ type NemoEntitystoreSpec struct {
 	Tolerations  []corev1.Toleration          `json:"tolerations,omitempty"`
 	PodAffinity  *corev1.PodAffinity          `json:"podAffinity,omitempty"`
 	Resources    *corev1.ResourceRequirements `json:"resources,omitempty"`
-	Expose       ExposeV1                     `json:"expose,omitempty"`
-	Scale        Autoscaling                  `json:"scale,omitempty"`
-	Metrics      Metrics                      `json:"metrics,omitempty"`
+	// +kubebuilder:validation:XValidation:rule="!(has(self.service.grpcPort))", message="unsupported field: spec.expose.service.grpcPort"
+	// +kubebuilder:validation:XValidation:rule="!(has(self.service.metricsPort))", message="unsupported field: spec.expose.service.metricsPort"
+	Expose  ExposeV1    `json:"expose,omitempty"`
+	Scale   Autoscaling `json:"scale,omitempty"`
+	Metrics Metrics     `json:"metrics,omitempty"`
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:default:=1
 	Replicas     int    `json:"replicas,omitempty"`

--- a/api/apps/v1alpha1/nemo_evaluator_types.go
+++ b/api/apps/v1alpha1/nemo_evaluator_types.go
@@ -68,9 +68,11 @@ type NemoEvaluatorSpec struct {
 	Tolerations  []corev1.Toleration          `json:"tolerations,omitempty"`
 	PodAffinity  *corev1.PodAffinity          `json:"podAffinity,omitempty"`
 	Resources    *corev1.ResourceRequirements `json:"resources,omitempty"`
-	Expose       ExposeV1                     `json:"expose,omitempty"`
-	Scale        Autoscaling                  `json:"scale,omitempty"`
-	Metrics      Metrics                      `json:"metrics,omitempty"`
+	// +kubebuilder:validation:XValidation:rule="!(has(self.service.grpcPort))", message="unsupported field: spec.expose.service.grpcPort"
+	// +kubebuilder:validation:XValidation:rule="!(has(self.service.metricsPort))", message="unsupported field: spec.expose.service.metricsPort"
+	Expose  ExposeV1    `json:"expose,omitempty"`
+	Scale   Autoscaling `json:"scale,omitempty"`
+	Metrics Metrics     `json:"metrics,omitempty"`
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:default:=1
 	Replicas     int    `json:"replicas,omitempty"`

--- a/api/apps/v1alpha1/nemo_guardrails_types.go
+++ b/api/apps/v1alpha1/nemo_guardrails_types.go
@@ -70,9 +70,11 @@ type NemoGuardrailSpec struct {
 	Tolerations  []corev1.Toleration          `json:"tolerations,omitempty"`
 	PodAffinity  *corev1.PodAffinity          `json:"podAffinity,omitempty"`
 	Resources    *corev1.ResourceRequirements `json:"resources,omitempty"`
-	Expose       ExposeV1                     `json:"expose,omitempty"`
-	Scale        Autoscaling                  `json:"scale,omitempty"`
-	Metrics      Metrics                      `json:"metrics,omitempty"`
+	// +kubebuilder:validation:XValidation:rule="!(has(self.service.grpcPort))", message="unsupported field: spec.expose.service.grpcPort"
+	// +kubebuilder:validation:XValidation:rule="!(has(self.service.metricsPort))", message="unsupported field: spec.expose.service.metricsPort"
+	Expose  ExposeV1    `json:"expose,omitempty"`
+	Scale   Autoscaling `json:"scale,omitempty"`
+	Metrics Metrics     `json:"metrics,omitempty"`
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:default:=1
 	Replicas     int    `json:"replicas,omitempty"`

--- a/api/apps/v1alpha1/zz_generated.deepcopy.go
+++ b/api/apps/v1alpha1/zz_generated.deepcopy.go
@@ -2271,6 +2271,16 @@ func (in *Service) DeepCopyInto(out *Service) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.GRPCPort != nil {
+		in, out := &in.GRPCPort, &out.GRPCPort
+		*out = new(int32)
+		**out = **in
+	}
+	if in.MetricsPort != nil {
+		in, out := &in.MetricsPort, &out.MetricsPort
+		*out = new(int32)
+		**out = **in
+	}
 	if in.Annotations != nil {
 		in, out := &in.Annotations, &out.Annotations
 		*out = make(map[string]string, len(*in))

--- a/bundle/manifests/apps.nvidia.com_nemocustomizers.yaml
+++ b/bundle/manifests/apps.nvidia.com_nemocustomizers.yaml
@@ -335,6 +335,11 @@ spec:
                         type: string
                     type: object
                 type: object
+                x-kubernetes-validations:
+                - message: 'unsupported field: spec.expose.service.grpcPort'
+                  rule: '!(has(self.service.grpcPort))'
+                - message: 'unsupported field: spec.expose.service.metricsPort'
+                  rule: '!(has(self.service.metricsPort))'
               groupID:
                 format: int64
                 type: integer

--- a/bundle/manifests/apps.nvidia.com_nemocustomizers.yaml
+++ b/bundle/manifests/apps.nvidia.com_nemocustomizers.yaml
@@ -302,8 +302,24 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
+                      grpcPort:
+                        description: |-
+                          GRPCPort is the GRPC serving port
+                          Note: This port is only applicable for NIMs that runs a Triton GRPC Inference Server.
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
+                      metricsPort:
+                        description: |-
+                          MetricsPort is the port for metrics
+                          Note: This port is only applicable for NIMs that runs a separate metrics endpoint on Triton Inference Server.
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
                       name:
-                        description: override the default service name
+                        description: Override the default service name
                         type: string
                       port:
                         default: 8000

--- a/bundle/manifests/apps.nvidia.com_nemodatastores.yaml
+++ b/bundle/manifests/apps.nvidia.com_nemodatastores.yaml
@@ -315,6 +315,11 @@ spec:
                         type: string
                     type: object
                 type: object
+                x-kubernetes-validations:
+                - message: 'unsupported field: spec.expose.service.grpcPort'
+                  rule: '!(has(self.service.grpcPort))'
+                - message: 'unsupported field: spec.expose.service.metricsPort'
+                  rule: '!(has(self.service.metricsPort))'
               groupID:
                 format: int64
                 type: integer

--- a/bundle/manifests/apps.nvidia.com_nemodatastores.yaml
+++ b/bundle/manifests/apps.nvidia.com_nemodatastores.yaml
@@ -282,8 +282,24 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
+                      grpcPort:
+                        description: |-
+                          GRPCPort is the GRPC serving port
+                          Note: This port is only applicable for NIMs that runs a Triton GRPC Inference Server.
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
+                      metricsPort:
+                        description: |-
+                          MetricsPort is the port for metrics
+                          Note: This port is only applicable for NIMs that runs a separate metrics endpoint on Triton Inference Server.
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
                       name:
-                        description: override the default service name
+                        description: Override the default service name
                         type: string
                       port:
                         default: 8000

--- a/bundle/manifests/apps.nvidia.com_nemoentitystores.yaml
+++ b/bundle/manifests/apps.nvidia.com_nemoentitystores.yaml
@@ -294,8 +294,24 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
+                      grpcPort:
+                        description: |-
+                          GRPCPort is the GRPC serving port
+                          Note: This port is only applicable for NIMs that runs a Triton GRPC Inference Server.
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
+                      metricsPort:
+                        description: |-
+                          MetricsPort is the port for metrics
+                          Note: This port is only applicable for NIMs that runs a separate metrics endpoint on Triton Inference Server.
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
                       name:
-                        description: override the default service name
+                        description: Override the default service name
                         type: string
                       port:
                         default: 8000

--- a/bundle/manifests/apps.nvidia.com_nemoentitystores.yaml
+++ b/bundle/manifests/apps.nvidia.com_nemoentitystores.yaml
@@ -327,6 +327,11 @@ spec:
                         type: string
                     type: object
                 type: object
+                x-kubernetes-validations:
+                - message: 'unsupported field: spec.expose.service.grpcPort'
+                  rule: '!(has(self.service.grpcPort))'
+                - message: 'unsupported field: spec.expose.service.metricsPort'
+                  rule: '!(has(self.service.metricsPort))'
               groupID:
                 format: int64
                 type: integer

--- a/bundle/manifests/apps.nvidia.com_nemoevaluators.yaml
+++ b/bundle/manifests/apps.nvidia.com_nemoevaluators.yaml
@@ -403,6 +403,11 @@ spec:
                         type: string
                     type: object
                 type: object
+                x-kubernetes-validations:
+                - message: 'unsupported field: spec.expose.service.grpcPort'
+                  rule: '!(has(self.service.grpcPort))'
+                - message: 'unsupported field: spec.expose.service.metricsPort'
+                  rule: '!(has(self.service.metricsPort))'
               groupID:
                 format: int64
                 type: integer

--- a/bundle/manifests/apps.nvidia.com_nemoevaluators.yaml
+++ b/bundle/manifests/apps.nvidia.com_nemoevaluators.yaml
@@ -370,8 +370,24 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
+                      grpcPort:
+                        description: |-
+                          GRPCPort is the GRPC serving port
+                          Note: This port is only applicable for NIMs that runs a Triton GRPC Inference Server.
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
+                      metricsPort:
+                        description: |-
+                          MetricsPort is the port for metrics
+                          Note: This port is only applicable for NIMs that runs a separate metrics endpoint on Triton Inference Server.
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
                       name:
-                        description: override the default service name
+                        description: Override the default service name
                         type: string
                       port:
                         default: 8000

--- a/bundle/manifests/apps.nvidia.com_nemoguardrails.yaml
+++ b/bundle/manifests/apps.nvidia.com_nemoguardrails.yaml
@@ -269,8 +269,24 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
+                      grpcPort:
+                        description: |-
+                          GRPCPort is the GRPC serving port
+                          Note: This port is only applicable for NIMs that runs a Triton GRPC Inference Server.
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
+                      metricsPort:
+                        description: |-
+                          MetricsPort is the port for metrics
+                          Note: This port is only applicable for NIMs that runs a separate metrics endpoint on Triton Inference Server.
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
                       name:
-                        description: override the default service name
+                        description: Override the default service name
                         type: string
                       port:
                         default: 8000

--- a/bundle/manifests/apps.nvidia.com_nemoguardrails.yaml
+++ b/bundle/manifests/apps.nvidia.com_nemoguardrails.yaml
@@ -302,6 +302,11 @@ spec:
                         type: string
                     type: object
                 type: object
+                x-kubernetes-validations:
+                - message: 'unsupported field: spec.expose.service.grpcPort'
+                  rule: '!(has(self.service.grpcPort))'
+                - message: 'unsupported field: spec.expose.service.metricsPort'
+                  rule: '!(has(self.service.metricsPort))'
               groupID:
                 format: int64
                 type: integer

--- a/bundle/manifests/apps.nvidia.com_nimpipelines.yaml
+++ b/bundle/manifests/apps.nvidia.com_nimpipelines.yaml
@@ -522,8 +522,24 @@ spec:
                                   additionalProperties:
                                     type: string
                                   type: object
+                                grpcPort:
+                                  description: |-
+                                    GRPCPort is the GRPC serving port
+                                    Note: This port is only applicable for NIMs that runs a Triton GRPC Inference Server.
+                                  format: int32
+                                  maximum: 65535
+                                  minimum: 1
+                                  type: integer
+                                metricsPort:
+                                  description: |-
+                                    MetricsPort is the port for metrics
+                                    Note: This port is only applicable for NIMs that runs a separate metrics endpoint on Triton Inference Server.
+                                  format: int32
+                                  maximum: 65535
+                                  minimum: 1
+                                  type: integer
                                 name:
-                                  description: override the default service name
+                                  description: Override the default service name
                                   type: string
                                 port:
                                   default: 8000

--- a/bundle/manifests/apps.nvidia.com_nimservices.yaml
+++ b/bundle/manifests/apps.nvidia.com_nimservices.yaml
@@ -472,8 +472,24 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
+                      grpcPort:
+                        description: |-
+                          GRPCPort is the GRPC serving port
+                          Note: This port is only applicable for NIMs that runs a Triton GRPC Inference Server.
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
+                      metricsPort:
+                        description: |-
+                          MetricsPort is the port for metrics
+                          Note: This port is only applicable for NIMs that runs a separate metrics endpoint on Triton Inference Server.
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
                       name:
-                        description: override the default service name
+                        description: Override the default service name
                         type: string
                       port:
                         default: 8000

--- a/config/crd/bases/apps.nvidia.com_nemocustomizers.yaml
+++ b/config/crd/bases/apps.nvidia.com_nemocustomizers.yaml
@@ -335,6 +335,11 @@ spec:
                         type: string
                     type: object
                 type: object
+                x-kubernetes-validations:
+                - message: 'unsupported field: spec.expose.service.grpcPort'
+                  rule: '!(has(self.service.grpcPort))'
+                - message: 'unsupported field: spec.expose.service.metricsPort'
+                  rule: '!(has(self.service.metricsPort))'
               groupID:
                 format: int64
                 type: integer

--- a/config/crd/bases/apps.nvidia.com_nemocustomizers.yaml
+++ b/config/crd/bases/apps.nvidia.com_nemocustomizers.yaml
@@ -302,8 +302,24 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
+                      grpcPort:
+                        description: |-
+                          GRPCPort is the GRPC serving port
+                          Note: This port is only applicable for NIMs that runs a Triton GRPC Inference Server.
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
+                      metricsPort:
+                        description: |-
+                          MetricsPort is the port for metrics
+                          Note: This port is only applicable for NIMs that runs a separate metrics endpoint on Triton Inference Server.
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
                       name:
-                        description: override the default service name
+                        description: Override the default service name
                         type: string
                       port:
                         default: 8000

--- a/config/crd/bases/apps.nvidia.com_nemodatastores.yaml
+++ b/config/crd/bases/apps.nvidia.com_nemodatastores.yaml
@@ -315,6 +315,11 @@ spec:
                         type: string
                     type: object
                 type: object
+                x-kubernetes-validations:
+                - message: 'unsupported field: spec.expose.service.grpcPort'
+                  rule: '!(has(self.service.grpcPort))'
+                - message: 'unsupported field: spec.expose.service.metricsPort'
+                  rule: '!(has(self.service.metricsPort))'
               groupID:
                 format: int64
                 type: integer

--- a/config/crd/bases/apps.nvidia.com_nemodatastores.yaml
+++ b/config/crd/bases/apps.nvidia.com_nemodatastores.yaml
@@ -282,8 +282,24 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
+                      grpcPort:
+                        description: |-
+                          GRPCPort is the GRPC serving port
+                          Note: This port is only applicable for NIMs that runs a Triton GRPC Inference Server.
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
+                      metricsPort:
+                        description: |-
+                          MetricsPort is the port for metrics
+                          Note: This port is only applicable for NIMs that runs a separate metrics endpoint on Triton Inference Server.
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
                       name:
-                        description: override the default service name
+                        description: Override the default service name
                         type: string
                       port:
                         default: 8000

--- a/config/crd/bases/apps.nvidia.com_nemoentitystores.yaml
+++ b/config/crd/bases/apps.nvidia.com_nemoentitystores.yaml
@@ -294,8 +294,24 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
+                      grpcPort:
+                        description: |-
+                          GRPCPort is the GRPC serving port
+                          Note: This port is only applicable for NIMs that runs a Triton GRPC Inference Server.
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
+                      metricsPort:
+                        description: |-
+                          MetricsPort is the port for metrics
+                          Note: This port is only applicable for NIMs that runs a separate metrics endpoint on Triton Inference Server.
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
                       name:
-                        description: override the default service name
+                        description: Override the default service name
                         type: string
                       port:
                         default: 8000

--- a/config/crd/bases/apps.nvidia.com_nemoentitystores.yaml
+++ b/config/crd/bases/apps.nvidia.com_nemoentitystores.yaml
@@ -327,6 +327,11 @@ spec:
                         type: string
                     type: object
                 type: object
+                x-kubernetes-validations:
+                - message: 'unsupported field: spec.expose.service.grpcPort'
+                  rule: '!(has(self.service.grpcPort))'
+                - message: 'unsupported field: spec.expose.service.metricsPort'
+                  rule: '!(has(self.service.metricsPort))'
               groupID:
                 format: int64
                 type: integer

--- a/config/crd/bases/apps.nvidia.com_nemoevaluators.yaml
+++ b/config/crd/bases/apps.nvidia.com_nemoevaluators.yaml
@@ -403,6 +403,11 @@ spec:
                         type: string
                     type: object
                 type: object
+                x-kubernetes-validations:
+                - message: 'unsupported field: spec.expose.service.grpcPort'
+                  rule: '!(has(self.service.grpcPort))'
+                - message: 'unsupported field: spec.expose.service.metricsPort'
+                  rule: '!(has(self.service.metricsPort))'
               groupID:
                 format: int64
                 type: integer

--- a/config/crd/bases/apps.nvidia.com_nemoevaluators.yaml
+++ b/config/crd/bases/apps.nvidia.com_nemoevaluators.yaml
@@ -370,8 +370,24 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
+                      grpcPort:
+                        description: |-
+                          GRPCPort is the GRPC serving port
+                          Note: This port is only applicable for NIMs that runs a Triton GRPC Inference Server.
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
+                      metricsPort:
+                        description: |-
+                          MetricsPort is the port for metrics
+                          Note: This port is only applicable for NIMs that runs a separate metrics endpoint on Triton Inference Server.
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
                       name:
-                        description: override the default service name
+                        description: Override the default service name
                         type: string
                       port:
                         default: 8000

--- a/config/crd/bases/apps.nvidia.com_nemoguardrails.yaml
+++ b/config/crd/bases/apps.nvidia.com_nemoguardrails.yaml
@@ -269,8 +269,24 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
+                      grpcPort:
+                        description: |-
+                          GRPCPort is the GRPC serving port
+                          Note: This port is only applicable for NIMs that runs a Triton GRPC Inference Server.
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
+                      metricsPort:
+                        description: |-
+                          MetricsPort is the port for metrics
+                          Note: This port is only applicable for NIMs that runs a separate metrics endpoint on Triton Inference Server.
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
                       name:
-                        description: override the default service name
+                        description: Override the default service name
                         type: string
                       port:
                         default: 8000

--- a/config/crd/bases/apps.nvidia.com_nemoguardrails.yaml
+++ b/config/crd/bases/apps.nvidia.com_nemoguardrails.yaml
@@ -302,6 +302,11 @@ spec:
                         type: string
                     type: object
                 type: object
+                x-kubernetes-validations:
+                - message: 'unsupported field: spec.expose.service.grpcPort'
+                  rule: '!(has(self.service.grpcPort))'
+                - message: 'unsupported field: spec.expose.service.metricsPort'
+                  rule: '!(has(self.service.metricsPort))'
               groupID:
                 format: int64
                 type: integer

--- a/config/crd/bases/apps.nvidia.com_nimpipelines.yaml
+++ b/config/crd/bases/apps.nvidia.com_nimpipelines.yaml
@@ -522,8 +522,24 @@ spec:
                                   additionalProperties:
                                     type: string
                                   type: object
+                                grpcPort:
+                                  description: |-
+                                    GRPCPort is the GRPC serving port
+                                    Note: This port is only applicable for NIMs that runs a Triton GRPC Inference Server.
+                                  format: int32
+                                  maximum: 65535
+                                  minimum: 1
+                                  type: integer
+                                metricsPort:
+                                  description: |-
+                                    MetricsPort is the port for metrics
+                                    Note: This port is only applicable for NIMs that runs a separate metrics endpoint on Triton Inference Server.
+                                  format: int32
+                                  maximum: 65535
+                                  minimum: 1
+                                  type: integer
                                 name:
-                                  description: override the default service name
+                                  description: Override the default service name
                                   type: string
                                 port:
                                   default: 8000

--- a/config/crd/bases/apps.nvidia.com_nimservices.yaml
+++ b/config/crd/bases/apps.nvidia.com_nimservices.yaml
@@ -472,8 +472,24 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
+                      grpcPort:
+                        description: |-
+                          GRPCPort is the GRPC serving port
+                          Note: This port is only applicable for NIMs that runs a Triton GRPC Inference Server.
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
+                      metricsPort:
+                        description: |-
+                          MetricsPort is the port for metrics
+                          Note: This port is only applicable for NIMs that runs a separate metrics endpoint on Triton Inference Server.
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
                       name:
-                        description: override the default service name
+                        description: Override the default service name
                         type: string
                       port:
                         default: 8000

--- a/config/samples/nim/rag/rag-pipeline.yaml
+++ b/config/samples/nim/rag/rag-pipeline.yaml
@@ -48,6 +48,8 @@ spec:
           service:
             type: ClusterIP
             port: 8000
+            grpcPort: 8001
+            metricsPort: 8002
     - name: nv-rerankqa-1b-v2
       enabled: true
       spec:
@@ -70,3 +72,5 @@ spec:
           service:
             type: ClusterIP
             port: 8000
+            grpcPort: 8001
+            metricsPort: 8002

--- a/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nemocustomizers.yaml
+++ b/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nemocustomizers.yaml
@@ -335,6 +335,11 @@ spec:
                         type: string
                     type: object
                 type: object
+                x-kubernetes-validations:
+                - message: 'unsupported field: spec.expose.service.grpcPort'
+                  rule: '!(has(self.service.grpcPort))'
+                - message: 'unsupported field: spec.expose.service.metricsPort'
+                  rule: '!(has(self.service.metricsPort))'
               groupID:
                 format: int64
                 type: integer

--- a/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nemocustomizers.yaml
+++ b/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nemocustomizers.yaml
@@ -302,8 +302,24 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
+                      grpcPort:
+                        description: |-
+                          GRPCPort is the GRPC serving port
+                          Note: This port is only applicable for NIMs that runs a Triton GRPC Inference Server.
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
+                      metricsPort:
+                        description: |-
+                          MetricsPort is the port for metrics
+                          Note: This port is only applicable for NIMs that runs a separate metrics endpoint on Triton Inference Server.
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
                       name:
-                        description: override the default service name
+                        description: Override the default service name
                         type: string
                       port:
                         default: 8000

--- a/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nemodatastores.yaml
+++ b/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nemodatastores.yaml
@@ -315,6 +315,11 @@ spec:
                         type: string
                     type: object
                 type: object
+                x-kubernetes-validations:
+                - message: 'unsupported field: spec.expose.service.grpcPort'
+                  rule: '!(has(self.service.grpcPort))'
+                - message: 'unsupported field: spec.expose.service.metricsPort'
+                  rule: '!(has(self.service.metricsPort))'
               groupID:
                 format: int64
                 type: integer

--- a/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nemodatastores.yaml
+++ b/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nemodatastores.yaml
@@ -282,8 +282,24 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
+                      grpcPort:
+                        description: |-
+                          GRPCPort is the GRPC serving port
+                          Note: This port is only applicable for NIMs that runs a Triton GRPC Inference Server.
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
+                      metricsPort:
+                        description: |-
+                          MetricsPort is the port for metrics
+                          Note: This port is only applicable for NIMs that runs a separate metrics endpoint on Triton Inference Server.
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
                       name:
-                        description: override the default service name
+                        description: Override the default service name
                         type: string
                       port:
                         default: 8000

--- a/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nemoentitystores.yaml
+++ b/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nemoentitystores.yaml
@@ -294,8 +294,24 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
+                      grpcPort:
+                        description: |-
+                          GRPCPort is the GRPC serving port
+                          Note: This port is only applicable for NIMs that runs a Triton GRPC Inference Server.
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
+                      metricsPort:
+                        description: |-
+                          MetricsPort is the port for metrics
+                          Note: This port is only applicable for NIMs that runs a separate metrics endpoint on Triton Inference Server.
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
                       name:
-                        description: override the default service name
+                        description: Override the default service name
                         type: string
                       port:
                         default: 8000

--- a/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nemoentitystores.yaml
+++ b/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nemoentitystores.yaml
@@ -327,6 +327,11 @@ spec:
                         type: string
                     type: object
                 type: object
+                x-kubernetes-validations:
+                - message: 'unsupported field: spec.expose.service.grpcPort'
+                  rule: '!(has(self.service.grpcPort))'
+                - message: 'unsupported field: spec.expose.service.metricsPort'
+                  rule: '!(has(self.service.metricsPort))'
               groupID:
                 format: int64
                 type: integer

--- a/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nemoevaluators.yaml
+++ b/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nemoevaluators.yaml
@@ -403,6 +403,11 @@ spec:
                         type: string
                     type: object
                 type: object
+                x-kubernetes-validations:
+                - message: 'unsupported field: spec.expose.service.grpcPort'
+                  rule: '!(has(self.service.grpcPort))'
+                - message: 'unsupported field: spec.expose.service.metricsPort'
+                  rule: '!(has(self.service.metricsPort))'
               groupID:
                 format: int64
                 type: integer

--- a/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nemoevaluators.yaml
+++ b/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nemoevaluators.yaml
@@ -370,8 +370,24 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
+                      grpcPort:
+                        description: |-
+                          GRPCPort is the GRPC serving port
+                          Note: This port is only applicable for NIMs that runs a Triton GRPC Inference Server.
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
+                      metricsPort:
+                        description: |-
+                          MetricsPort is the port for metrics
+                          Note: This port is only applicable for NIMs that runs a separate metrics endpoint on Triton Inference Server.
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
                       name:
-                        description: override the default service name
+                        description: Override the default service name
                         type: string
                       port:
                         default: 8000

--- a/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nemoguardrails.yaml
+++ b/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nemoguardrails.yaml
@@ -269,8 +269,24 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
+                      grpcPort:
+                        description: |-
+                          GRPCPort is the GRPC serving port
+                          Note: This port is only applicable for NIMs that runs a Triton GRPC Inference Server.
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
+                      metricsPort:
+                        description: |-
+                          MetricsPort is the port for metrics
+                          Note: This port is only applicable for NIMs that runs a separate metrics endpoint on Triton Inference Server.
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
                       name:
-                        description: override the default service name
+                        description: Override the default service name
                         type: string
                       port:
                         default: 8000

--- a/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nemoguardrails.yaml
+++ b/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nemoguardrails.yaml
@@ -302,6 +302,11 @@ spec:
                         type: string
                     type: object
                 type: object
+                x-kubernetes-validations:
+                - message: 'unsupported field: spec.expose.service.grpcPort'
+                  rule: '!(has(self.service.grpcPort))'
+                - message: 'unsupported field: spec.expose.service.metricsPort'
+                  rule: '!(has(self.service.metricsPort))'
               groupID:
                 format: int64
                 type: integer

--- a/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nimpipelines.yaml
+++ b/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nimpipelines.yaml
@@ -522,8 +522,24 @@ spec:
                                   additionalProperties:
                                     type: string
                                   type: object
+                                grpcPort:
+                                  description: |-
+                                    GRPCPort is the GRPC serving port
+                                    Note: This port is only applicable for NIMs that runs a Triton GRPC Inference Server.
+                                  format: int32
+                                  maximum: 65535
+                                  minimum: 1
+                                  type: integer
+                                metricsPort:
+                                  description: |-
+                                    MetricsPort is the port for metrics
+                                    Note: This port is only applicable for NIMs that runs a separate metrics endpoint on Triton Inference Server.
+                                  format: int32
+                                  maximum: 65535
+                                  minimum: 1
+                                  type: integer
                                 name:
-                                  description: override the default service name
+                                  description: Override the default service name
                                   type: string
                                 port:
                                   default: 8000

--- a/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nimservices.yaml
+++ b/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nimservices.yaml
@@ -472,8 +472,24 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
+                      grpcPort:
+                        description: |-
+                          GRPCPort is the GRPC serving port
+                          Note: This port is only applicable for NIMs that runs a Triton GRPC Inference Server.
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
+                      metricsPort:
+                        description: |-
+                          MetricsPort is the port for metrics
+                          Note: This port is only applicable for NIMs that runs a separate metrics endpoint on Triton Inference Server.
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
                       name:
-                        description: override the default service name
+                        description: Override the default service name
                         type: string
                       port:
                         default: 8000

--- a/internal/controller/platform/standalone/nimservice_test.go
+++ b/internal/controller/platform/standalone/nimservice_test.go
@@ -192,6 +192,10 @@ var _ = Describe("NIMServiceReconciler for a standalone platform", func() {
 						Value: "9000",
 					},
 					{
+						Name:  "NIM_HTTP_API_PORT",
+						Value: "9000",
+					},
+					{
 						Name:  "NIM_JSONL_LOGGING",
 						Value: "1",
 					},


### PR DESCRIPTION
This change introduces 2 new ports to the NIMService API spec:
* `spec.expose.service.grpcPort`: sets the application env `NIM_TRITION_GRPC_PORT`
* `spec.expose.service.metricsPort`: sets the application env `NIM_TRITON_METRICS_PORT`
