### PR TITLE
Allow configurable sizeLimit for shared memory (emptyDir) Volumes

### DIFF
--- a/api/apps/v1alpha1/nemo_customizer_types.go
+++ b/api/apps/v1alpha1/nemo_customizer_types.go
@@ -29,6 +29,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
@@ -150,6 +151,8 @@ type TrainingConfig struct {
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 	// PodAffinity for the training jobs
 	PodAffinity *corev1.PodAffinity `json:"podAffinity,omitempty"`
+	// SharedMemorySizeLimit sets the max size of the shared memory volume (emptyDir) used by the training jobs for fast model runtime I/O.
+	SharedMemorySizeLimit *resource.Quantity `json:"sharedMemorySizeLimit,omitempty"`
 	// Resources for the training jobs
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
 }

--- a/api/apps/v1alpha1/nimservice_types.go
+++ b/api/apps/v1alpha1/nimservice_types.go
@@ -26,6 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
@@ -135,6 +136,8 @@ type NIMServiceList struct {
 // NIMServiceStorage defines the attributes of various storage targets used to store the model.
 type NIMServiceStorage struct {
 	NIMCache NIMCacheVolSpec `json:"nimCache,omitempty"`
+	// SharedMemorySizeLimit sets the max size of the shared memory volume (emptyDir) used by NIMs for fast model runtime I/O.
+	SharedMemorySizeLimit *resource.Quantity `json:"sharedMemorySizeLimit,omitempty"`
 	// PersistentVolumeClaim is the pvc volume used for caching NIM
 	PVC PersistentVolumeClaim `json:"pvc,omitempty"`
 	// HostPath is the host path volume for caching NIM
@@ -449,7 +452,8 @@ func (n *NIMService) GetVolumes(modelPVC PersistentVolumeClaim) []corev1.Volume 
 			Name: "dshm",
 			VolumeSource: corev1.VolumeSource{
 				EmptyDir: &corev1.EmptyDirVolumeSource{
-					Medium: corev1.StorageMediumMemory,
+					Medium:    corev1.StorageMediumMemory,
+					SizeLimit: n.Spec.Storage.SharedMemorySizeLimit,
 				},
 			},
 		},

--- a/api/apps/v1alpha1/zz_generated.deepcopy.go
+++ b/api/apps/v1alpha1/zz_generated.deepcopy.go
@@ -1134,6 +1134,11 @@ func (in *NIMServiceStatus) DeepCopy() *NIMServiceStatus {
 func (in *NIMServiceStorage) DeepCopyInto(out *NIMServiceStorage) {
 	*out = *in
 	out.NIMCache = in.NIMCache
+	if in.SharedMemorySizeLimit != nil {
+		in, out := &in.SharedMemorySizeLimit, &out.SharedMemorySizeLimit
+		x := (*in).DeepCopy()
+		*out = &x
+	}
 	in.PVC.DeepCopyInto(&out.PVC)
 	if in.HostPath != nil {
 		in, out := &in.HostPath, &out.HostPath
@@ -2382,6 +2387,11 @@ func (in *TrainingConfig) DeepCopyInto(out *TrainingConfig) {
 		in, out := &in.PodAffinity, &out.PodAffinity
 		*out = new(corev1.PodAffinity)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.SharedMemorySizeLimit != nil {
+		in, out := &in.SharedMemorySizeLimit, &out.SharedMemorySizeLimit
+		x := (*in).DeepCopy()
+		*out = &x
 	}
 	if in.Resources != nil {
 		in, out := &in.Resources, &out.Resources

--- a/bundle/manifests/apps.nvidia.com_nemocustomizers.yaml
+++ b/bundle/manifests/apps.nvidia.com_nemocustomizers.yaml
@@ -25,7 +25,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: NemoCustomizer is the Schema for the NemoCustomizer API
+        description: NemoCustomizer is the Schema for the NemoCustomizer API.
         properties:
           apiVersion:
             description: |-
@@ -45,7 +45,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: NemoCustomizerSpec defines the desired state of NemoCustomizer
+            description: NemoCustomizerSpec defines the desired state of NemoCustomizer.
             properties:
               annotations:
                 additionalProperties:
@@ -254,7 +254,7 @@ spec:
                   type: object
                 type: array
               expose:
-                description: ExposeV1 defines attributes to expose the service
+                description: ExposeV1 defines attributes to expose the service.
                 properties:
                   ingress:
                     description: IngressV1 defines attributes for ingress
@@ -275,7 +275,7 @@ spec:
                           paths:
                             items:
                               description: IngressPath defines attributes for ingress
-                                paths
+                                paths.
                               properties:
                                 path:
                                   default: /
@@ -296,7 +296,7 @@ spec:
                       rule: (has(self.spec) && has(self.enabled) && self.enabled)
                         || !has(self.enabled) || !self.enabled
                   service:
-                    description: Service defines attributes to create a service
+                    description: Service defines attributes to create a service.
                     properties:
                       annotations:
                         additionalProperties:
@@ -323,7 +323,7 @@ spec:
                 format: int64
                 type: integer
               image:
-                description: Image defines image attributes
+                description: Image defines image attributes.
                 properties:
                   pullPolicy:
                     type: string
@@ -344,7 +344,7 @@ spec:
                   type: string
                 type: object
               metrics:
-                description: Metrics defines attributes to setup metrics collection
+                description: Metrics defines attributes to setup metrics collection.
                 properties:
                   enabled:
                     type: boolean
@@ -1145,7 +1145,7 @@ spec:
                 type: string
               scale:
                 description: Autoscaling defines attributes to automatically scale
-                  the service based on metrics
+                  the service based on metrics.
                 properties:
                   annotations:
                     additionalProperties:
@@ -1155,7 +1155,7 @@ spec:
                     type: boolean
                   hpa:
                     description: HorizontalPodAutoscalerSpec defines the parameters
-                      required to setup HPA
+                      required to setup HPA.
                     properties:
                       behavior:
                         description: |-
@@ -2525,6 +2525,15 @@ spec:
                       RunAIQueue is the Run.AI's scheduler queue to be used for training jobs.
                       Used only if the scheduler is set to runai.
                     type: string
+                  sharedMemorySizeLimit:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: SharedMemorySizeLimit sets the max size of the shared
+                      memory volume (emptyDir) used by the training jobs for fast
+                      model runtime I/O.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
                   timeout:
                     description: Timeout for the training job to complete
                     type: integer
@@ -2655,7 +2664,7 @@ spec:
             - wandb
             type: object
           status:
-            description: NemoCustomizerStatus defines the observed state of NemoCustomizer
+            description: NemoCustomizerStatus defines the observed state of NemoCustomizer.
             properties:
               availableReplicas:
                 format: int32

--- a/bundle/manifests/apps.nvidia.com_nemodatastores.yaml
+++ b/bundle/manifests/apps.nvidia.com_nemodatastores.yaml
@@ -25,7 +25,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: NemoDatastore is the Schema for the NemoDatastore API
+        description: NemoDatastore is the Schema for the NemoDatastore API.
         properties:
           apiVersion:
             description: |-
@@ -45,7 +45,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: NemoDatastoreSpec defines the desired state of NemoDatastore
+            description: NemoDatastoreSpec defines the desired state of NemoDatastore.
             properties:
               annotations:
                 additionalProperties:
@@ -234,7 +234,7 @@ spec:
                   type: object
                 type: array
               expose:
-                description: ExposeV1 defines attributes to expose the service
+                description: ExposeV1 defines attributes to expose the service.
                 properties:
                   ingress:
                     description: IngressV1 defines attributes for ingress
@@ -255,7 +255,7 @@ spec:
                           paths:
                             items:
                               description: IngressPath defines attributes for ingress
-                                paths
+                                paths.
                               properties:
                                 path:
                                   default: /
@@ -276,7 +276,7 @@ spec:
                       rule: (has(self.spec) && has(self.enabled) && self.enabled)
                         || !has(self.enabled) || !self.enabled
                   service:
-                    description: Service defines attributes to create a service
+                    description: Service defines attributes to create a service.
                     properties:
                       annotations:
                         additionalProperties:
@@ -303,7 +303,7 @@ spec:
                 format: int64
                 type: integer
               image:
-                description: Image defines image attributes
+                description: Image defines image attributes.
                 properties:
                   pullPolicy:
                     type: string
@@ -324,7 +324,7 @@ spec:
                   type: string
                 type: object
               metrics:
-                description: Metrics defines attributes to setup metrics collection
+                description: Metrics defines attributes to setup metrics collection.
                 properties:
                   enabled:
                     type: boolean
@@ -857,7 +857,7 @@ spec:
                 type: string
               scale:
                 description: Autoscaling defines attributes to automatically scale
-                  the service based on metrics
+                  the service based on metrics.
                 properties:
                   annotations:
                     additionalProperties:
@@ -867,7 +867,7 @@ spec:
                     type: boolean
                   hpa:
                     description: HorizontalPodAutoscalerSpec defines the parameters
-                      required to setup HPA
+                      required to setup HPA.
                     properties:
                       behavior:
                         description: |-
@@ -1529,7 +1529,7 @@ spec:
             - secrets
             type: object
           status:
-            description: NemoDatastoreStatus defines the observed state of NemoDatastore
+            description: NemoDatastoreStatus defines the observed state of NemoDatastore.
             properties:
               availableReplicas:
                 format: int32

--- a/bundle/manifests/apps.nvidia.com_nemoentitystores.yaml
+++ b/bundle/manifests/apps.nvidia.com_nemoentitystores.yaml
@@ -25,7 +25,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: NemoEntitystore is the Schema for the NemoEntitystore API
+        description: NemoEntitystore is the Schema for the NemoEntitystore API.
         properties:
           apiVersion:
             description: |-
@@ -45,7 +45,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: NemoEntitystoreSpec defines the desired state of NemoEntitystore
+            description: NemoEntitystoreSpec defines the desired state of NemoEntitystore.
             properties:
               annotations:
                 additionalProperties:
@@ -246,7 +246,7 @@ spec:
                   type: object
                 type: array
               expose:
-                description: ExposeV1 defines attributes to expose the service
+                description: ExposeV1 defines attributes to expose the service.
                 properties:
                   ingress:
                     description: IngressV1 defines attributes for ingress
@@ -267,7 +267,7 @@ spec:
                           paths:
                             items:
                               description: IngressPath defines attributes for ingress
-                                paths
+                                paths.
                               properties:
                                 path:
                                   default: /
@@ -288,7 +288,7 @@ spec:
                       rule: (has(self.spec) && has(self.enabled) && self.enabled)
                         || !has(self.enabled) || !self.enabled
                   service:
-                    description: Service defines attributes to create a service
+                    description: Service defines attributes to create a service.
                     properties:
                       annotations:
                         additionalProperties:
@@ -315,7 +315,7 @@ spec:
                 format: int64
                 type: integer
               image:
-                description: Image defines image attributes
+                description: Image defines image attributes.
                 properties:
                   pullPolicy:
                     type: string
@@ -336,7 +336,7 @@ spec:
                   type: string
                 type: object
               metrics:
-                description: Metrics defines attributes to setup metrics collection
+                description: Metrics defines attributes to setup metrics collection.
                 properties:
                   enabled:
                     type: boolean
@@ -795,7 +795,7 @@ spec:
                 type: string
               scale:
                 description: Autoscaling defines attributes to automatically scale
-                  the service based on metrics
+                  the service based on metrics.
                 properties:
                   annotations:
                     additionalProperties:
@@ -805,7 +805,7 @@ spec:
                     type: boolean
                   hpa:
                     description: HorizontalPodAutoscalerSpec defines the parameters
-                      required to setup HPA
+                      required to setup HPA.
                     properties:
                       behavior:
                         description: |-
@@ -1446,7 +1446,7 @@ spec:
             - image
             type: object
           status:
-            description: NemoEntitystoreStatus defines the observed state of NemoEntitystore
+            description: NemoEntitystoreStatus defines the observed state of NemoEntitystore.
             properties:
               availableReplicas:
                 format: int32

--- a/bundle/manifests/apps.nvidia.com_nemoevaluators.yaml
+++ b/bundle/manifests/apps.nvidia.com_nemoevaluators.yaml
@@ -25,7 +25,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: NemoEvaluator is the Schema for the NemoEvaluator API
+        description: NemoEvaluator is the Schema for the NemoEvaluator API.
         properties:
           apiVersion:
             description: |-
@@ -45,7 +45,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: NemoEvaluatorSpec defines the desired state of NemoEvaluator
+            description: NemoEvaluatorSpec defines the desired state of NemoEvaluator.
             properties:
               annotations:
                 additionalProperties:
@@ -322,7 +322,7 @@ spec:
                 - similarityMetrics
                 type: object
               expose:
-                description: ExposeV1 defines attributes to expose the service
+                description: ExposeV1 defines attributes to expose the service.
                 properties:
                   ingress:
                     description: IngressV1 defines attributes for ingress
@@ -343,7 +343,7 @@ spec:
                           paths:
                             items:
                               description: IngressPath defines attributes for ingress
-                                paths
+                                paths.
                               properties:
                                 path:
                                   default: /
@@ -364,7 +364,7 @@ spec:
                       rule: (has(self.spec) && has(self.enabled) && self.enabled)
                         || !has(self.enabled) || !self.enabled
                   service:
-                    description: Service defines attributes to create a service
+                    description: Service defines attributes to create a service.
                     properties:
                       annotations:
                         additionalProperties:
@@ -391,7 +391,7 @@ spec:
                 format: int64
                 type: integer
               image:
-                description: Image defines image attributes
+                description: Image defines image attributes.
                 properties:
                   pullPolicy:
                     type: string
@@ -422,7 +422,7 @@ spec:
                 - file
                 type: string
               metrics:
-                description: Metrics defines attributes to setup metrics collection
+                description: Metrics defines attributes to setup metrics collection.
                 properties:
                   enabled:
                     type: boolean
@@ -942,7 +942,7 @@ spec:
                 type: string
               scale:
                 description: Autoscaling defines attributes to automatically scale
-                  the service based on metrics
+                  the service based on metrics.
                 properties:
                   annotations:
                     additionalProperties:
@@ -952,7 +952,7 @@ spec:
                     type: boolean
                   hpa:
                     description: HorizontalPodAutoscalerSpec defines the parameters
-                      required to setup HPA
+                      required to setup HPA.
                     properties:
                       behavior:
                         description: |-
@@ -1607,7 +1607,7 @@ spec:
             - vectorDB
             type: object
           status:
-            description: NemoEvaluatorStatus defines the observed state of NemoEvaluator
+            description: NemoEvaluatorStatus defines the observed state of NemoEvaluator.
             properties:
               availableReplicas:
                 format: int32

--- a/bundle/manifests/apps.nvidia.com_nemoguardrails.yaml
+++ b/bundle/manifests/apps.nvidia.com_nemoguardrails.yaml
@@ -25,7 +25,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: NemoGuardrail is the Schema for the NemoGuardrail API
+        description: NemoGuardrail is the Schema for the NemoGuardrail API.
         properties:
           apiVersion:
             description: |-
@@ -45,7 +45,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: NemoGuardrailSpec defines the desired state of NemoGuardrail
+            description: NemoGuardrailSpec defines the desired state of NemoGuardrail.
             properties:
               annotations:
                 additionalProperties:
@@ -63,7 +63,7 @@ spec:
                 description: ConfigStore stores the config of the guardrail service
                 properties:
                   configMap:
-                    description: ConfigMapRef with a valid config map name
+                    description: ConfigMapRef with a valid config map name.
                     properties:
                       name:
                         minLength: 1
@@ -73,7 +73,7 @@ spec:
                     type: object
                   pvc:
                     description: PersistentVolumeClaim defines the attributes of PVC
-                      used as a source for caching NIM model
+                      used as a source for caching NIM model.
                     properties:
                       create:
                         description: Create indicates to create a new PVC
@@ -221,7 +221,7 @@ spec:
                   type: object
                 type: array
               expose:
-                description: ExposeV1 defines attributes to expose the service
+                description: ExposeV1 defines attributes to expose the service.
                 properties:
                   ingress:
                     description: IngressV1 defines attributes for ingress
@@ -242,7 +242,7 @@ spec:
                           paths:
                             items:
                               description: IngressPath defines attributes for ingress
-                                paths
+                                paths.
                               properties:
                                 path:
                                   default: /
@@ -263,7 +263,7 @@ spec:
                       rule: (has(self.spec) && has(self.enabled) && self.enabled)
                         || !has(self.enabled) || !self.enabled
                   service:
-                    description: Service defines attributes to create a service
+                    description: Service defines attributes to create a service.
                     properties:
                       annotations:
                         additionalProperties:
@@ -290,7 +290,7 @@ spec:
                 format: int64
                 type: integer
               image:
-                description: Image defines image attributes
+                description: Image defines image attributes.
                 properties:
                   pullPolicy:
                     type: string
@@ -311,7 +311,7 @@ spec:
                   type: string
                 type: object
               metrics:
-                description: Metrics defines attributes to setup metrics collection
+                description: Metrics defines attributes to setup metrics collection.
                 properties:
                   enabled:
                     type: boolean
@@ -793,7 +793,7 @@ spec:
                 type: string
               scale:
                 description: Autoscaling defines attributes to automatically scale
-                  the service based on metrics
+                  the service based on metrics.
                 properties:
                   annotations:
                     additionalProperties:
@@ -803,7 +803,7 @@ spec:
                     type: boolean
                   hpa:
                     description: HorizontalPodAutoscalerSpec defines the parameters
-                      required to setup HPA
+                      required to setup HPA.
                     properties:
                       behavior:
                         description: |-
@@ -1442,7 +1442,7 @@ spec:
             - image
             type: object
           status:
-            description: NemoGuardrailStatus defines the observed state of NemoGuardrail
+            description: NemoGuardrailStatus defines the observed state of NemoGuardrail.
             properties:
               availableReplicas:
                 format: int32

--- a/bundle/manifests/apps.nvidia.com_nimcaches.yaml
+++ b/bundle/manifests/apps.nvidia.com_nimcaches.yaml
@@ -28,7 +28,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: NIMCache is the Schema for the nimcaches API
+        description: NIMCache is the Schema for the nimcaches API.
         properties:
           apiVersion:
             description: |-
@@ -48,7 +48,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: NIMCacheSpec defines the desired state of NIMCache
+            description: NIMCacheSpec defines the desired state of NIMCache.
             properties:
               certConfig:
                 description: |-
@@ -198,7 +198,7 @@ spec:
                   the caching job.
                 type: object
               proxy:
-                description: ProxySpec defines the proxy configuration for NIMService
+                description: ProxySpec defines the proxy configuration for NIMService.
                 properties:
                   certConfigMap:
                     type: string
@@ -293,7 +293,7 @@ spec:
                               optimized models
                             items:
                               description: GPUSpec is the spec required to cache models
-                                for selected gpu type
+                                for selected gpu type.
                               properties:
                                 ids:
                                   description: IDs are the device-ids for a specific
@@ -430,7 +430,7 @@ spec:
             - storage
             type: object
           status:
-            description: NIMCacheStatus defines the observed state of NIMCache
+            description: NIMCacheStatus defines the observed state of NIMCache.
             properties:
               conditions:
                 items:
@@ -490,7 +490,7 @@ spec:
                 type: array
               profiles:
                 items:
-                  description: NIMProfile defines the profiles that were cached
+                  description: NIMProfile defines the profiles that were cached.
                   properties:
                     config:
                       additionalProperties:

--- a/bundle/manifests/apps.nvidia.com_nimpipelines.yaml
+++ b/bundle/manifests/apps.nvidia.com_nimpipelines.yaml
@@ -25,7 +25,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: NIMPipeline is the Schema for the nimpipelines API
+        description: NIMPipeline is the Schema for the nimpipelines API.
         properties:
           apiVersion:
             description: |-
@@ -45,18 +45,18 @@ spec:
           metadata:
             type: object
           spec:
-            description: NIMPipelineSpec defines the desired state of NIMPipeline
+            description: NIMPipelineSpec defines the desired state of NIMPipeline.
             properties:
               services:
                 description: NIMService configures attributes to deploy a NIM service
                   as part of the pipeline
                 items:
                   description: NIMServicePipelineSpec defines the desired state of
-                    NIMService as part of the NIMPipeline
+                    NIMService as part of the NIMPipeline.
                   properties:
                     dependencies:
                       items:
-                        description: ServiceDependency defines service dependencies
+                        description: ServiceDependency defines service dependencies.
                         properties:
                           envName:
                             description: EnvName is the dependent service endpoint
@@ -83,7 +83,7 @@ spec:
                     name:
                       type: string
                     spec:
-                      description: NIMServiceSpec defines the desired state of NIMService
+                      description: NIMServiceSpec defines the desired state of NIMService.
                       properties:
                         annotations:
                           additionalProperties:
@@ -221,11 +221,11 @@ spec:
                             type: object
                           type: array
                         expose:
-                          description: Expose defines attributes to expose the service
+                          description: Expose defines attributes to expose the service.
                           properties:
                             ingress:
                               description: Ingress defines attributes to enable ingress
-                                for the service
+                                for the service.
                               properties:
                                 annotations:
                                   additionalProperties:
@@ -516,7 +516,7 @@ spec:
                               type: object
                             service:
                               description: Service defines attributes to create a
-                                service
+                                service.
                               properties:
                                 annotations:
                                   additionalProperties:
@@ -543,7 +543,7 @@ spec:
                           format: int64
                           type: integer
                         image:
-                          description: Image defines image attributes
+                          description: Image defines image attributes.
                           properties:
                             pullPolicy:
                               type: string
@@ -565,7 +565,7 @@ spec:
                           type: object
                         livenessProbe:
                           description: Probe defines attributes for startup/liveness/readiness
-                            probes
+                            probes.
                           properties:
                             enabled:
                               type: boolean
@@ -728,7 +728,7 @@ spec:
                           type: object
                         metrics:
                           description: Metrics defines attributes to setup metrics
-                            collection
+                            collection.
                           properties:
                             enabled:
                               type: boolean
@@ -1127,7 +1127,7 @@ spec:
                           type: object
                         proxy:
                           description: ProxySpec defines the proxy configuration for
-                            NIMService
+                            NIMService.
                           properties:
                             certConfigMap:
                               type: string
@@ -1140,7 +1140,7 @@ spec:
                           type: object
                         readinessProbe:
                           description: Probe defines attributes for startup/liveness/readiness
-                            probes
+                            probes.
                           properties:
                             enabled:
                               type: boolean
@@ -1370,7 +1370,7 @@ spec:
                           type: string
                         scale:
                           description: Autoscaling defines attributes to automatically
-                            scale the service based on metrics
+                            scale the service based on metrics.
                           properties:
                             annotations:
                               additionalProperties:
@@ -1380,7 +1380,7 @@ spec:
                               type: boolean
                             hpa:
                               description: HorizontalPodAutoscalerSpec defines the
-                                parameters required to setup HPA
+                                parameters required to setup HPA.
                               properties:
                                 behavior:
                                   description: |-
@@ -1994,7 +1994,7 @@ spec:
                           type: object
                         startupProbe:
                           description: Probe defines attributes for startup/liveness/readiness
-                            probes
+                            probes.
                           properties:
                             enabled:
                               type: boolean
@@ -2165,7 +2165,7 @@ spec:
                               type: string
                             nimCache:
                               description: NIMCacheVolSpec defines the spec to use
-                                NIMCache volume
+                                NIMCache volume.
                               properties:
                                 name:
                                   type: string
@@ -2204,6 +2204,15 @@ spec:
                               description: ReadOnly mode indicates if the volume should
                                 be mounted as read-only
                               type: boolean
+                            sharedMemorySizeLimit:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: SharedMemorySizeLimit sets the max size
+                                of the shared memory volume (emptyDir) used by NIMs
+                                for fast model runtime I/O.
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                           type: object
                         tolerations:
                           items:
@@ -2254,7 +2263,7 @@ spec:
                 type: array
             type: object
           status:
-            description: NIMPipelineStatus defines the observed state of NIMPipeline
+            description: NIMPipelineStatus defines the observed state of NIMPipeline.
             properties:
               conditions:
                 description: |-

--- a/bundle/manifests/apps.nvidia.com_nimservices.yaml
+++ b/bundle/manifests/apps.nvidia.com_nimservices.yaml
@@ -25,7 +25,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: NIMService is the Schema for the nimservices API
+        description: NIMService is the Schema for the nimservices API.
         properties:
           apiVersion:
             description: |-
@@ -45,7 +45,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: NIMServiceSpec defines the desired state of NIMService
+            description: NIMServiceSpec defines the desired state of NIMService.
             properties:
               annotations:
                 additionalProperties:
@@ -180,11 +180,11 @@ spec:
                   type: object
                 type: array
               expose:
-                description: Expose defines attributes to expose the service
+                description: Expose defines attributes to expose the service.
                 properties:
                   ingress:
                     description: Ingress defines attributes to enable ingress for
-                      the service
+                      the service.
                     properties:
                       annotations:
                         additionalProperties:
@@ -466,7 +466,7 @@ spec:
                         type: object
                     type: object
                   service:
-                    description: Service defines attributes to create a service
+                    description: Service defines attributes to create a service.
                     properties:
                       annotations:
                         additionalProperties:
@@ -493,7 +493,7 @@ spec:
                 format: int64
                 type: integer
               image:
-                description: Image defines image attributes
+                description: Image defines image attributes.
                 properties:
                   pullPolicy:
                     type: string
@@ -515,7 +515,7 @@ spec:
                 type: object
               livenessProbe:
                 description: Probe defines attributes for startup/liveness/readiness
-                  probes
+                  probes.
                 properties:
                   enabled:
                     type: boolean
@@ -675,7 +675,7 @@ spec:
                     type: object
                 type: object
               metrics:
-                description: Metrics defines attributes to setup metrics collection
+                description: Metrics defines attributes to setup metrics collection.
                 properties:
                   enabled:
                     type: boolean
@@ -1068,7 +1068,7 @@ spec:
                     x-kubernetes-list-type: atomic
                 type: object
               proxy:
-                description: ProxySpec defines the proxy configuration for NIMService
+                description: ProxySpec defines the proxy configuration for NIMService.
                 properties:
                   certConfigMap:
                     type: string
@@ -1081,7 +1081,7 @@ spec:
                 type: object
               readinessProbe:
                 description: Probe defines attributes for startup/liveness/readiness
-                  probes
+                  probes.
                 properties:
                   enabled:
                     type: boolean
@@ -1307,7 +1307,7 @@ spec:
                 type: string
               scale:
                 description: Autoscaling defines attributes to automatically scale
-                  the service based on metrics
+                  the service based on metrics.
                 properties:
                   annotations:
                     additionalProperties:
@@ -1317,7 +1317,7 @@ spec:
                     type: boolean
                   hpa:
                     description: HorizontalPodAutoscalerSpec defines the parameters
-                      required to setup HPA
+                      required to setup HPA.
                     properties:
                       behavior:
                         description: |-
@@ -1913,7 +1913,7 @@ spec:
                 type: object
               startupProbe:
                 description: Probe defines attributes for startup/liveness/readiness
-                  probes
+                  probes.
                 properties:
                   enabled:
                     type: boolean
@@ -2081,7 +2081,7 @@ spec:
                     type: string
                   nimCache:
                     description: NIMCacheVolSpec defines the spec to use NIMCache
-                      volume
+                      volume.
                     properties:
                       name:
                         type: string
@@ -2120,6 +2120,15 @@ spec:
                     description: ReadOnly mode indicates if the volume should be mounted
                       as read-only
                     type: boolean
+                  sharedMemorySizeLimit:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: SharedMemorySizeLimit sets the max size of the shared
+                      memory volume (emptyDir) used by NIMs for fast model runtime
+                      I/O.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
                 type: object
               tolerations:
                 items:
@@ -2167,7 +2176,7 @@ spec:
             - image
             type: object
           status:
-            description: NIMServiceStatus defines the observed state of NIMService
+            description: NIMServiceStatus defines the observed state of NIMService.
             properties:
               availableReplicas:
                 format: int32

--- a/config/crd/bases/apps.nvidia.com_nemocustomizers.yaml
+++ b/config/crd/bases/apps.nvidia.com_nemocustomizers.yaml
@@ -2525,6 +2525,15 @@ spec:
                       RunAIQueue is the Run.AI's scheduler queue to be used for training jobs.
                       Used only if the scheduler is set to runai.
                     type: string
+                  sharedMemorySizeLimit:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: SharedMemorySizeLimit sets the max size of the shared
+                      memory volume (emptyDir) used by the training jobs for fast
+                      model runtime I/O.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
                   timeout:
                     description: Timeout for the training job to complete
                     type: integer

--- a/config/crd/bases/apps.nvidia.com_nimpipelines.yaml
+++ b/config/crd/bases/apps.nvidia.com_nimpipelines.yaml
@@ -2204,6 +2204,15 @@ spec:
                               description: ReadOnly mode indicates if the volume should
                                 be mounted as read-only
                               type: boolean
+                            sharedMemorySizeLimit:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: SharedMemorySizeLimit sets the max size
+                                of the shared memory volume (emptyDir) used by NIMs
+                                for fast model runtime I/O.
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                           type: object
                         tolerations:
                           items:

--- a/config/crd/bases/apps.nvidia.com_nimservices.yaml
+++ b/config/crd/bases/apps.nvidia.com_nimservices.yaml
@@ -2120,6 +2120,15 @@ spec:
                     description: ReadOnly mode indicates if the volume should be mounted
                       as read-only
                     type: boolean
+                  sharedMemorySizeLimit:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: SharedMemorySizeLimit sets the max size of the shared
+                      memory volume (emptyDir) used by NIMs for fast model runtime
+                      I/O.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
                 type: object
               tolerations:
                 items:

--- a/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nemocustomizers.yaml
+++ b/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nemocustomizers.yaml
@@ -25,7 +25,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: NemoCustomizer is the Schema for the NemoCustomizer API
+        description: NemoCustomizer is the Schema for the NemoCustomizer API.
         properties:
           apiVersion:
             description: |-
@@ -45,7 +45,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: NemoCustomizerSpec defines the desired state of NemoCustomizer
+            description: NemoCustomizerSpec defines the desired state of NemoCustomizer.
             properties:
               annotations:
                 additionalProperties:
@@ -254,7 +254,7 @@ spec:
                   type: object
                 type: array
               expose:
-                description: ExposeV1 defines attributes to expose the service
+                description: ExposeV1 defines attributes to expose the service.
                 properties:
                   ingress:
                     description: IngressV1 defines attributes for ingress
@@ -275,7 +275,7 @@ spec:
                           paths:
                             items:
                               description: IngressPath defines attributes for ingress
-                                paths
+                                paths.
                               properties:
                                 path:
                                   default: /
@@ -296,7 +296,7 @@ spec:
                       rule: (has(self.spec) && has(self.enabled) && self.enabled)
                         || !has(self.enabled) || !self.enabled
                   service:
-                    description: Service defines attributes to create a service
+                    description: Service defines attributes to create a service.
                     properties:
                       annotations:
                         additionalProperties:
@@ -323,7 +323,7 @@ spec:
                 format: int64
                 type: integer
               image:
-                description: Image defines image attributes
+                description: Image defines image attributes.
                 properties:
                   pullPolicy:
                     type: string
@@ -344,7 +344,7 @@ spec:
                   type: string
                 type: object
               metrics:
-                description: Metrics defines attributes to setup metrics collection
+                description: Metrics defines attributes to setup metrics collection.
                 properties:
                   enabled:
                     type: boolean
@@ -1145,7 +1145,7 @@ spec:
                 type: string
               scale:
                 description: Autoscaling defines attributes to automatically scale
-                  the service based on metrics
+                  the service based on metrics.
                 properties:
                   annotations:
                     additionalProperties:
@@ -1155,7 +1155,7 @@ spec:
                     type: boolean
                   hpa:
                     description: HorizontalPodAutoscalerSpec defines the parameters
-                      required to setup HPA
+                      required to setup HPA.
                     properties:
                       behavior:
                         description: |-
@@ -2525,6 +2525,15 @@ spec:
                       RunAIQueue is the Run.AI's scheduler queue to be used for training jobs.
                       Used only if the scheduler is set to runai.
                     type: string
+                  sharedMemorySizeLimit:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: SharedMemorySizeLimit sets the max size of the shared
+                      memory volume (emptyDir) used by the training jobs for fast
+                      model runtime I/O.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
                   timeout:
                     description: Timeout for the training job to complete
                     type: integer
@@ -2655,7 +2664,7 @@ spec:
             - wandb
             type: object
           status:
-            description: NemoCustomizerStatus defines the observed state of NemoCustomizer
+            description: NemoCustomizerStatus defines the observed state of NemoCustomizer.
             properties:
               availableReplicas:
                 format: int32

--- a/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nemodatastores.yaml
+++ b/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nemodatastores.yaml
@@ -25,7 +25,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: NemoDatastore is the Schema for the NemoDatastore API
+        description: NemoDatastore is the Schema for the NemoDatastore API.
         properties:
           apiVersion:
             description: |-
@@ -45,7 +45,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: NemoDatastoreSpec defines the desired state of NemoDatastore
+            description: NemoDatastoreSpec defines the desired state of NemoDatastore.
             properties:
               annotations:
                 additionalProperties:
@@ -234,7 +234,7 @@ spec:
                   type: object
                 type: array
               expose:
-                description: ExposeV1 defines attributes to expose the service
+                description: ExposeV1 defines attributes to expose the service.
                 properties:
                   ingress:
                     description: IngressV1 defines attributes for ingress
@@ -255,7 +255,7 @@ spec:
                           paths:
                             items:
                               description: IngressPath defines attributes for ingress
-                                paths
+                                paths.
                               properties:
                                 path:
                                   default: /
@@ -276,7 +276,7 @@ spec:
                       rule: (has(self.spec) && has(self.enabled) && self.enabled)
                         || !has(self.enabled) || !self.enabled
                   service:
-                    description: Service defines attributes to create a service
+                    description: Service defines attributes to create a service.
                     properties:
                       annotations:
                         additionalProperties:
@@ -303,7 +303,7 @@ spec:
                 format: int64
                 type: integer
               image:
-                description: Image defines image attributes
+                description: Image defines image attributes.
                 properties:
                   pullPolicy:
                     type: string
@@ -324,7 +324,7 @@ spec:
                   type: string
                 type: object
               metrics:
-                description: Metrics defines attributes to setup metrics collection
+                description: Metrics defines attributes to setup metrics collection.
                 properties:
                   enabled:
                     type: boolean
@@ -857,7 +857,7 @@ spec:
                 type: string
               scale:
                 description: Autoscaling defines attributes to automatically scale
-                  the service based on metrics
+                  the service based on metrics.
                 properties:
                   annotations:
                     additionalProperties:
@@ -867,7 +867,7 @@ spec:
                     type: boolean
                   hpa:
                     description: HorizontalPodAutoscalerSpec defines the parameters
-                      required to setup HPA
+                      required to setup HPA.
                     properties:
                       behavior:
                         description: |-
@@ -1529,7 +1529,7 @@ spec:
             - secrets
             type: object
           status:
-            description: NemoDatastoreStatus defines the observed state of NemoDatastore
+            description: NemoDatastoreStatus defines the observed state of NemoDatastore.
             properties:
               availableReplicas:
                 format: int32

--- a/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nemoentitystores.yaml
+++ b/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nemoentitystores.yaml
@@ -25,7 +25,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: NemoEntitystore is the Schema for the NemoEntitystore API
+        description: NemoEntitystore is the Schema for the NemoEntitystore API.
         properties:
           apiVersion:
             description: |-
@@ -45,7 +45,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: NemoEntitystoreSpec defines the desired state of NemoEntitystore
+            description: NemoEntitystoreSpec defines the desired state of NemoEntitystore.
             properties:
               annotations:
                 additionalProperties:
@@ -246,7 +246,7 @@ spec:
                   type: object
                 type: array
               expose:
-                description: ExposeV1 defines attributes to expose the service
+                description: ExposeV1 defines attributes to expose the service.
                 properties:
                   ingress:
                     description: IngressV1 defines attributes for ingress
@@ -267,7 +267,7 @@ spec:
                           paths:
                             items:
                               description: IngressPath defines attributes for ingress
-                                paths
+                                paths.
                               properties:
                                 path:
                                   default: /
@@ -288,7 +288,7 @@ spec:
                       rule: (has(self.spec) && has(self.enabled) && self.enabled)
                         || !has(self.enabled) || !self.enabled
                   service:
-                    description: Service defines attributes to create a service
+                    description: Service defines attributes to create a service.
                     properties:
                       annotations:
                         additionalProperties:
@@ -315,7 +315,7 @@ spec:
                 format: int64
                 type: integer
               image:
-                description: Image defines image attributes
+                description: Image defines image attributes.
                 properties:
                   pullPolicy:
                     type: string
@@ -336,7 +336,7 @@ spec:
                   type: string
                 type: object
               metrics:
-                description: Metrics defines attributes to setup metrics collection
+                description: Metrics defines attributes to setup metrics collection.
                 properties:
                   enabled:
                     type: boolean
@@ -795,7 +795,7 @@ spec:
                 type: string
               scale:
                 description: Autoscaling defines attributes to automatically scale
-                  the service based on metrics
+                  the service based on metrics.
                 properties:
                   annotations:
                     additionalProperties:
@@ -805,7 +805,7 @@ spec:
                     type: boolean
                   hpa:
                     description: HorizontalPodAutoscalerSpec defines the parameters
-                      required to setup HPA
+                      required to setup HPA.
                     properties:
                       behavior:
                         description: |-
@@ -1446,7 +1446,7 @@ spec:
             - image
             type: object
           status:
-            description: NemoEntitystoreStatus defines the observed state of NemoEntitystore
+            description: NemoEntitystoreStatus defines the observed state of NemoEntitystore.
             properties:
               availableReplicas:
                 format: int32

--- a/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nemoevaluators.yaml
+++ b/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nemoevaluators.yaml
@@ -25,7 +25,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: NemoEvaluator is the Schema for the NemoEvaluator API
+        description: NemoEvaluator is the Schema for the NemoEvaluator API.
         properties:
           apiVersion:
             description: |-
@@ -45,7 +45,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: NemoEvaluatorSpec defines the desired state of NemoEvaluator
+            description: NemoEvaluatorSpec defines the desired state of NemoEvaluator.
             properties:
               annotations:
                 additionalProperties:
@@ -322,7 +322,7 @@ spec:
                 - similarityMetrics
                 type: object
               expose:
-                description: ExposeV1 defines attributes to expose the service
+                description: ExposeV1 defines attributes to expose the service.
                 properties:
                   ingress:
                     description: IngressV1 defines attributes for ingress
@@ -343,7 +343,7 @@ spec:
                           paths:
                             items:
                               description: IngressPath defines attributes for ingress
-                                paths
+                                paths.
                               properties:
                                 path:
                                   default: /
@@ -364,7 +364,7 @@ spec:
                       rule: (has(self.spec) && has(self.enabled) && self.enabled)
                         || !has(self.enabled) || !self.enabled
                   service:
-                    description: Service defines attributes to create a service
+                    description: Service defines attributes to create a service.
                     properties:
                       annotations:
                         additionalProperties:
@@ -391,7 +391,7 @@ spec:
                 format: int64
                 type: integer
               image:
-                description: Image defines image attributes
+                description: Image defines image attributes.
                 properties:
                   pullPolicy:
                     type: string
@@ -422,7 +422,7 @@ spec:
                 - file
                 type: string
               metrics:
-                description: Metrics defines attributes to setup metrics collection
+                description: Metrics defines attributes to setup metrics collection.
                 properties:
                   enabled:
                     type: boolean
@@ -942,7 +942,7 @@ spec:
                 type: string
               scale:
                 description: Autoscaling defines attributes to automatically scale
-                  the service based on metrics
+                  the service based on metrics.
                 properties:
                   annotations:
                     additionalProperties:
@@ -952,7 +952,7 @@ spec:
                     type: boolean
                   hpa:
                     description: HorizontalPodAutoscalerSpec defines the parameters
-                      required to setup HPA
+                      required to setup HPA.
                     properties:
                       behavior:
                         description: |-
@@ -1607,7 +1607,7 @@ spec:
             - vectorDB
             type: object
           status:
-            description: NemoEvaluatorStatus defines the observed state of NemoEvaluator
+            description: NemoEvaluatorStatus defines the observed state of NemoEvaluator.
             properties:
               availableReplicas:
                 format: int32

--- a/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nemoguardrails.yaml
+++ b/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nemoguardrails.yaml
@@ -25,7 +25,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: NemoGuardrail is the Schema for the NemoGuardrail API
+        description: NemoGuardrail is the Schema for the NemoGuardrail API.
         properties:
           apiVersion:
             description: |-
@@ -45,7 +45,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: NemoGuardrailSpec defines the desired state of NemoGuardrail
+            description: NemoGuardrailSpec defines the desired state of NemoGuardrail.
             properties:
               annotations:
                 additionalProperties:
@@ -63,7 +63,7 @@ spec:
                 description: ConfigStore stores the config of the guardrail service
                 properties:
                   configMap:
-                    description: ConfigMapRef with a valid config map name
+                    description: ConfigMapRef with a valid config map name.
                     properties:
                       name:
                         minLength: 1
@@ -73,7 +73,7 @@ spec:
                     type: object
                   pvc:
                     description: PersistentVolumeClaim defines the attributes of PVC
-                      used as a source for caching NIM model
+                      used as a source for caching NIM model.
                     properties:
                       create:
                         description: Create indicates to create a new PVC
@@ -221,7 +221,7 @@ spec:
                   type: object
                 type: array
               expose:
-                description: ExposeV1 defines attributes to expose the service
+                description: ExposeV1 defines attributes to expose the service.
                 properties:
                   ingress:
                     description: IngressV1 defines attributes for ingress
@@ -242,7 +242,7 @@ spec:
                           paths:
                             items:
                               description: IngressPath defines attributes for ingress
-                                paths
+                                paths.
                               properties:
                                 path:
                                   default: /
@@ -263,7 +263,7 @@ spec:
                       rule: (has(self.spec) && has(self.enabled) && self.enabled)
                         || !has(self.enabled) || !self.enabled
                   service:
-                    description: Service defines attributes to create a service
+                    description: Service defines attributes to create a service.
                     properties:
                       annotations:
                         additionalProperties:
@@ -290,7 +290,7 @@ spec:
                 format: int64
                 type: integer
               image:
-                description: Image defines image attributes
+                description: Image defines image attributes.
                 properties:
                   pullPolicy:
                     type: string
@@ -311,7 +311,7 @@ spec:
                   type: string
                 type: object
               metrics:
-                description: Metrics defines attributes to setup metrics collection
+                description: Metrics defines attributes to setup metrics collection.
                 properties:
                   enabled:
                     type: boolean
@@ -793,7 +793,7 @@ spec:
                 type: string
               scale:
                 description: Autoscaling defines attributes to automatically scale
-                  the service based on metrics
+                  the service based on metrics.
                 properties:
                   annotations:
                     additionalProperties:
@@ -803,7 +803,7 @@ spec:
                     type: boolean
                   hpa:
                     description: HorizontalPodAutoscalerSpec defines the parameters
-                      required to setup HPA
+                      required to setup HPA.
                     properties:
                       behavior:
                         description: |-
@@ -1442,7 +1442,7 @@ spec:
             - image
             type: object
           status:
-            description: NemoGuardrailStatus defines the observed state of NemoGuardrail
+            description: NemoGuardrailStatus defines the observed state of NemoGuardrail.
             properties:
               availableReplicas:
                 format: int32

--- a/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nimcaches.yaml
+++ b/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nimcaches.yaml
@@ -28,7 +28,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: NIMCache is the Schema for the nimcaches API
+        description: NIMCache is the Schema for the nimcaches API.
         properties:
           apiVersion:
             description: |-
@@ -48,7 +48,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: NIMCacheSpec defines the desired state of NIMCache
+            description: NIMCacheSpec defines the desired state of NIMCache.
             properties:
               certConfig:
                 description: |-
@@ -198,7 +198,7 @@ spec:
                   the caching job.
                 type: object
               proxy:
-                description: ProxySpec defines the proxy configuration for NIMService
+                description: ProxySpec defines the proxy configuration for NIMService.
                 properties:
                   certConfigMap:
                     type: string
@@ -293,7 +293,7 @@ spec:
                               optimized models
                             items:
                               description: GPUSpec is the spec required to cache models
-                                for selected gpu type
+                                for selected gpu type.
                               properties:
                                 ids:
                                   description: IDs are the device-ids for a specific
@@ -430,7 +430,7 @@ spec:
             - storage
             type: object
           status:
-            description: NIMCacheStatus defines the observed state of NIMCache
+            description: NIMCacheStatus defines the observed state of NIMCache.
             properties:
               conditions:
                 items:
@@ -490,7 +490,7 @@ spec:
                 type: array
               profiles:
                 items:
-                  description: NIMProfile defines the profiles that were cached
+                  description: NIMProfile defines the profiles that were cached.
                   properties:
                     config:
                       additionalProperties:

--- a/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nimpipelines.yaml
+++ b/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nimpipelines.yaml
@@ -25,7 +25,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: NIMPipeline is the Schema for the nimpipelines API
+        description: NIMPipeline is the Schema for the nimpipelines API.
         properties:
           apiVersion:
             description: |-
@@ -45,18 +45,18 @@ spec:
           metadata:
             type: object
           spec:
-            description: NIMPipelineSpec defines the desired state of NIMPipeline
+            description: NIMPipelineSpec defines the desired state of NIMPipeline.
             properties:
               services:
                 description: NIMService configures attributes to deploy a NIM service
                   as part of the pipeline
                 items:
                   description: NIMServicePipelineSpec defines the desired state of
-                    NIMService as part of the NIMPipeline
+                    NIMService as part of the NIMPipeline.
                   properties:
                     dependencies:
                       items:
-                        description: ServiceDependency defines service dependencies
+                        description: ServiceDependency defines service dependencies.
                         properties:
                           envName:
                             description: EnvName is the dependent service endpoint
@@ -83,7 +83,7 @@ spec:
                     name:
                       type: string
                     spec:
-                      description: NIMServiceSpec defines the desired state of NIMService
+                      description: NIMServiceSpec defines the desired state of NIMService.
                       properties:
                         annotations:
                           additionalProperties:
@@ -221,11 +221,11 @@ spec:
                             type: object
                           type: array
                         expose:
-                          description: Expose defines attributes to expose the service
+                          description: Expose defines attributes to expose the service.
                           properties:
                             ingress:
                               description: Ingress defines attributes to enable ingress
-                                for the service
+                                for the service.
                               properties:
                                 annotations:
                                   additionalProperties:
@@ -516,7 +516,7 @@ spec:
                               type: object
                             service:
                               description: Service defines attributes to create a
-                                service
+                                service.
                               properties:
                                 annotations:
                                   additionalProperties:
@@ -543,7 +543,7 @@ spec:
                           format: int64
                           type: integer
                         image:
-                          description: Image defines image attributes
+                          description: Image defines image attributes.
                           properties:
                             pullPolicy:
                               type: string
@@ -565,7 +565,7 @@ spec:
                           type: object
                         livenessProbe:
                           description: Probe defines attributes for startup/liveness/readiness
-                            probes
+                            probes.
                           properties:
                             enabled:
                               type: boolean
@@ -728,7 +728,7 @@ spec:
                           type: object
                         metrics:
                           description: Metrics defines attributes to setup metrics
-                            collection
+                            collection.
                           properties:
                             enabled:
                               type: boolean
@@ -1127,7 +1127,7 @@ spec:
                           type: object
                         proxy:
                           description: ProxySpec defines the proxy configuration for
-                            NIMService
+                            NIMService.
                           properties:
                             certConfigMap:
                               type: string
@@ -1140,7 +1140,7 @@ spec:
                           type: object
                         readinessProbe:
                           description: Probe defines attributes for startup/liveness/readiness
-                            probes
+                            probes.
                           properties:
                             enabled:
                               type: boolean
@@ -1370,7 +1370,7 @@ spec:
                           type: string
                         scale:
                           description: Autoscaling defines attributes to automatically
-                            scale the service based on metrics
+                            scale the service based on metrics.
                           properties:
                             annotations:
                               additionalProperties:
@@ -1380,7 +1380,7 @@ spec:
                               type: boolean
                             hpa:
                               description: HorizontalPodAutoscalerSpec defines the
-                                parameters required to setup HPA
+                                parameters required to setup HPA.
                               properties:
                                 behavior:
                                   description: |-
@@ -1994,7 +1994,7 @@ spec:
                           type: object
                         startupProbe:
                           description: Probe defines attributes for startup/liveness/readiness
-                            probes
+                            probes.
                           properties:
                             enabled:
                               type: boolean
@@ -2165,7 +2165,7 @@ spec:
                               type: string
                             nimCache:
                               description: NIMCacheVolSpec defines the spec to use
-                                NIMCache volume
+                                NIMCache volume.
                               properties:
                                 name:
                                   type: string
@@ -2204,6 +2204,15 @@ spec:
                               description: ReadOnly mode indicates if the volume should
                                 be mounted as read-only
                               type: boolean
+                            sharedMemorySizeLimit:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: SharedMemorySizeLimit sets the max size
+                                of the shared memory volume (emptyDir) used by NIMs
+                                for fast model runtime I/O.
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                           type: object
                         tolerations:
                           items:
@@ -2254,7 +2263,7 @@ spec:
                 type: array
             type: object
           status:
-            description: NIMPipelineStatus defines the observed state of NIMPipeline
+            description: NIMPipelineStatus defines the observed state of NIMPipeline.
             properties:
               conditions:
                 description: |-

--- a/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nimservices.yaml
+++ b/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nimservices.yaml
@@ -25,7 +25,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: NIMService is the Schema for the nimservices API
+        description: NIMService is the Schema for the nimservices API.
         properties:
           apiVersion:
             description: |-
@@ -45,7 +45,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: NIMServiceSpec defines the desired state of NIMService
+            description: NIMServiceSpec defines the desired state of NIMService.
             properties:
               annotations:
                 additionalProperties:
@@ -180,11 +180,11 @@ spec:
                   type: object
                 type: array
               expose:
-                description: Expose defines attributes to expose the service
+                description: Expose defines attributes to expose the service.
                 properties:
                   ingress:
                     description: Ingress defines attributes to enable ingress for
-                      the service
+                      the service.
                     properties:
                       annotations:
                         additionalProperties:
@@ -466,7 +466,7 @@ spec:
                         type: object
                     type: object
                   service:
-                    description: Service defines attributes to create a service
+                    description: Service defines attributes to create a service.
                     properties:
                       annotations:
                         additionalProperties:
@@ -493,7 +493,7 @@ spec:
                 format: int64
                 type: integer
               image:
-                description: Image defines image attributes
+                description: Image defines image attributes.
                 properties:
                   pullPolicy:
                     type: string
@@ -515,7 +515,7 @@ spec:
                 type: object
               livenessProbe:
                 description: Probe defines attributes for startup/liveness/readiness
-                  probes
+                  probes.
                 properties:
                   enabled:
                     type: boolean
@@ -675,7 +675,7 @@ spec:
                     type: object
                 type: object
               metrics:
-                description: Metrics defines attributes to setup metrics collection
+                description: Metrics defines attributes to setup metrics collection.
                 properties:
                   enabled:
                     type: boolean
@@ -1068,7 +1068,7 @@ spec:
                     x-kubernetes-list-type: atomic
                 type: object
               proxy:
-                description: ProxySpec defines the proxy configuration for NIMService
+                description: ProxySpec defines the proxy configuration for NIMService.
                 properties:
                   certConfigMap:
                     type: string
@@ -1081,7 +1081,7 @@ spec:
                 type: object
               readinessProbe:
                 description: Probe defines attributes for startup/liveness/readiness
-                  probes
+                  probes.
                 properties:
                   enabled:
                     type: boolean
@@ -1307,7 +1307,7 @@ spec:
                 type: string
               scale:
                 description: Autoscaling defines attributes to automatically scale
-                  the service based on metrics
+                  the service based on metrics.
                 properties:
                   annotations:
                     additionalProperties:
@@ -1317,7 +1317,7 @@ spec:
                     type: boolean
                   hpa:
                     description: HorizontalPodAutoscalerSpec defines the parameters
-                      required to setup HPA
+                      required to setup HPA.
                     properties:
                       behavior:
                         description: |-
@@ -1913,7 +1913,7 @@ spec:
                 type: object
               startupProbe:
                 description: Probe defines attributes for startup/liveness/readiness
-                  probes
+                  probes.
                 properties:
                   enabled:
                     type: boolean
@@ -2081,7 +2081,7 @@ spec:
                     type: string
                   nimCache:
                     description: NIMCacheVolSpec defines the spec to use NIMCache
-                      volume
+                      volume.
                     properties:
                       name:
                         type: string
@@ -2120,6 +2120,15 @@ spec:
                     description: ReadOnly mode indicates if the volume should be mounted
                       as read-only
                     type: boolean
+                  sharedMemorySizeLimit:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: SharedMemorySizeLimit sets the max size of the shared
+                      memory volume (emptyDir) used by NIMs for fast model runtime
+                      I/O.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
                 type: object
               tolerations:
                 items:
@@ -2167,7 +2176,7 @@ spec:
             - image
             type: object
           status:
-            description: NIMServiceStatus defines the observed state of NIMService
+            description: NIMServiceStatus defines the observed state of NIMService.
             properties:
               availableReplicas:
                 format: int32

--- a/internal/controller/nemocustomizer_controller.go
+++ b/internal/controller/nemocustomizer_controller.go
@@ -628,6 +628,12 @@ func (r *NemoCustomizerReconciler) addTrainingConfig(ctx context.Context, cfg ma
 	// Add PVC configuration
 	r.addWorkspacePVCConfig(ctx, trainingCfg, n)
 
+	emptyDir := map[string]interface{}{
+		"medium": "Memory",
+	}
+	if n.Spec.Training.SharedMemorySizeLimit != nil {
+		emptyDir["sizeLimit"] = n.Spec.Training.SharedMemorySizeLimit.String()
+	}
 	trainingCfg["volumes"] = []map[string]interface{}{
 		{
 			"name": "models",
@@ -637,10 +643,8 @@ func (r *NemoCustomizerReconciler) addTrainingConfig(ctx context.Context, cfg ma
 			},
 		},
 		{
-			"name": "dshm",
-			"emptyDir": map[string]interface{}{
-				"medium": "Memory",
-			},
+			"name":     "dshm",
+			"emptyDir": emptyDir,
 		},
 	}
 

--- a/manifests/deployment.yaml
+++ b/manifests/deployment.yaml
@@ -121,6 +121,9 @@ spec:
         {{- if .EmptyDir }}
         emptyDir:
           medium: {{ .EmptyDir.Medium }}
+          {{- if .EmptyDir.SizeLimit }}
+          sizeLimit: {{ .EmptyDir.SizeLimit }}
+          {{- end }}
         {{- end }}
         {{- if .PersistentVolumeClaim }}
         persistentVolumeClaim:


### PR DESCRIPTION
This PR allows the size of emptyDir volumes to be limited
- For NIMs, the size can be specified in `.spec.storage.sharedMemorySizeLimit` for NIMServices; and in `.spec.services[].spec.storage.sharedMemorySizeLimit` for NIMPipelines
- For Customizer training jobs, the limit can be specified in `.spec.trainingConfig.sharedMemorySizeLimit`

