### PR TITLE
fix model status for NIMs incompatible with openapi schema

### DIFF
--- a/internal/nimmodels/errors.go
+++ b/internal/nimmodels/errors.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nimmodels
+
+import (
+	"net/http"
+)
+
+type APIError struct {
+	StatusCode int
+	Status     string
+}
+
+func (e APIError) Error() string {
+	return e.Status
+}
+
+func newAPIError(resp *http.Response) *APIError {
+	return &APIError{
+		StatusCode: resp.StatusCode,
+		Status:     resp.Status,
+	}
+}
+
+func IsNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	apiErr, ok := err.(*APIError)
+	return ok && (apiErr.StatusCode == http.StatusNotFound)
+}

--- a/internal/nimmodels/errors_test.go
+++ b/internal/nimmodels/errors_test.go
@@ -1,0 +1,45 @@
+package nimmodels
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+func TestIsNotFound(t *testing.T) {
+	tests := []struct {
+		description string
+		err         error
+		expected    bool
+	}{
+		{
+			description: "no error",
+			err:         nil,
+			expected:    false,
+		},
+		{
+			description: "404 HTTP StatusCode",
+			err:         &APIError{StatusCode: http.StatusNotFound, Status: "404 Not Found"},
+			expected:    true,
+		},
+		{
+			description: "500 HTTP StatusCode",
+			err:         &APIError{StatusCode: http.StatusInternalServerError, Status: "500 Internal Server Error"},
+			expected:    false,
+		},
+		{
+			description: "generic error",
+			err:         fmt.Errorf("some other error"),
+			expected:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			result := IsNotFound(tt.err)
+			if result != tt.expected {
+				t.Errorf("IsNotFound() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fallback to using `/v1/metadata` API endpoint to get the model name for NIMs incompatible with openapi schema

The workflow:
* Try /v1/models API
* if it errors out with a 404 HTTP error, then use /v1/metadata API