### PR TITLE
kubebuilder validations for DRAResources

### DIFF
--- a/api/apps/v1alpha1/common_types.go
+++ b/api/apps/v1alpha1/common_types.go
@@ -245,12 +245,17 @@ type PersistentVolumeClaim struct {
 //
 // When creating the NIMService pods, it adds a name (`DNS_LABEL` format) to it
 // that uniquely identifies the DRA resource.
+// +kubebuilder:validation:XValidation:rule="has(self.resourceClaimName) != has(self.resourceClaimTemplateName)",message="exactly one of spec.resourceClaimName and spec.resourceClaimTemplateName must be set."
 type DRAResource struct {
 	// ResourceClaimName is the name of a ResourceClaim object in the same
 	// namespace as the NIMService.
 	//
 	// Exactly one of ResourceClaimName and ResourceClaimTemplateName must
 	// be set.
+	//
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=253
+	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*`
 	ResourceClaimName *string `json:"resourceClaimName,omitempty"`
 
 	// ResourceClaimTemplateName is the name of a ResourceClaimTemplate
@@ -261,6 +266,10 @@ type DRAResource struct {
 	//
 	// Exactly one of ResourceClaimName and ResourceClaimTemplateName must
 	// be set.
+	//
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=253
+	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*`
 	ResourceClaimTemplateName *string `json:"resourceClaimTemplateName,omitempty"`
 
 	// Requests is the list of requests in the referenced ResourceClaim/ResourceClaimTemplate
@@ -268,5 +277,7 @@ type DRAResource struct {
 	//
 	// If empty, everything from the claim is made available, otherwise
 	// only the result of this subset of requests.
+	//
+	// +kubebuilder:validation:items:MinLength=1
 	Requests []string `json:"requests,omitempty"`
 }

--- a/bundle/manifests/apps.nvidia.com_nimpipelines.yaml
+++ b/bundle/manifests/apps.nvidia.com_nimpipelines.yaml
@@ -120,6 +120,7 @@ spec:
                                   If empty, everything from the claim is made available, otherwise
                                   only the result of this subset of requests.
                                 items:
+                                  minLength: 1
                                   type: string
                                 type: array
                               resourceClaimName:
@@ -129,6 +130,9 @@ spec:
 
                                   Exactly one of ResourceClaimName and ResourceClaimTemplateName must
                                   be set.
+                                maxLength: 253
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*
                                 type: string
                               resourceClaimTemplateName:
                                 description: |-
@@ -140,8 +144,15 @@ spec:
 
                                   Exactly one of ResourceClaimName and ResourceClaimTemplateName must
                                   be set.
+                                maxLength: 253
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*
                                 type: string
                             type: object
+                            x-kubernetes-validations:
+                            - message: exactly one of spec.resourceClaimName and spec.resourceClaimTemplateName
+                                must be set.
+                              rule: has(self.resourceClaimName) != has(self.resourceClaimTemplateName)
                           type: array
                         env:
                           items:

--- a/bundle/manifests/apps.nvidia.com_nimservices.yaml
+++ b/bundle/manifests/apps.nvidia.com_nimservices.yaml
@@ -81,6 +81,7 @@ spec:
                         If empty, everything from the claim is made available, otherwise
                         only the result of this subset of requests.
                       items:
+                        minLength: 1
                         type: string
                       type: array
                     resourceClaimName:
@@ -90,6 +91,9 @@ spec:
 
                         Exactly one of ResourceClaimName and ResourceClaimTemplateName must
                         be set.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*
                       type: string
                     resourceClaimTemplateName:
                       description: |-
@@ -101,8 +105,15 @@ spec:
 
                         Exactly one of ResourceClaimName and ResourceClaimTemplateName must
                         be set.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*
                       type: string
                   type: object
+                  x-kubernetes-validations:
+                  - message: exactly one of spec.resourceClaimName and spec.resourceClaimTemplateName
+                      must be set.
+                    rule: has(self.resourceClaimName) != has(self.resourceClaimTemplateName)
                 type: array
               env:
                 items:

--- a/config/crd/bases/apps.nvidia.com_nimpipelines.yaml
+++ b/config/crd/bases/apps.nvidia.com_nimpipelines.yaml
@@ -120,6 +120,7 @@ spec:
                                   If empty, everything from the claim is made available, otherwise
                                   only the result of this subset of requests.
                                 items:
+                                  minLength: 1
                                   type: string
                                 type: array
                               resourceClaimName:
@@ -129,6 +130,9 @@ spec:
 
                                   Exactly one of ResourceClaimName and ResourceClaimTemplateName must
                                   be set.
+                                maxLength: 253
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*
                                 type: string
                               resourceClaimTemplateName:
                                 description: |-
@@ -140,8 +144,15 @@ spec:
 
                                   Exactly one of ResourceClaimName and ResourceClaimTemplateName must
                                   be set.
+                                maxLength: 253
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*
                                 type: string
                             type: object
+                            x-kubernetes-validations:
+                            - message: exactly one of spec.resourceClaimName and spec.resourceClaimTemplateName
+                                must be set.
+                              rule: has(self.resourceClaimName) != has(self.resourceClaimTemplateName)
                           type: array
                         env:
                           items:

--- a/config/crd/bases/apps.nvidia.com_nimservices.yaml
+++ b/config/crd/bases/apps.nvidia.com_nimservices.yaml
@@ -81,6 +81,7 @@ spec:
                         If empty, everything from the claim is made available, otherwise
                         only the result of this subset of requests.
                       items:
+                        minLength: 1
                         type: string
                       type: array
                     resourceClaimName:
@@ -90,6 +91,9 @@ spec:
 
                         Exactly one of ResourceClaimName and ResourceClaimTemplateName must
                         be set.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*
                       type: string
                     resourceClaimTemplateName:
                       description: |-
@@ -101,8 +105,15 @@ spec:
 
                         Exactly one of ResourceClaimName and ResourceClaimTemplateName must
                         be set.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*
                       type: string
                   type: object
+                  x-kubernetes-validations:
+                  - message: exactly one of spec.resourceClaimName and spec.resourceClaimTemplateName
+                      must be set.
+                    rule: has(self.resourceClaimName) != has(self.resourceClaimTemplateName)
                 type: array
               env:
                 items:

--- a/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nimpipelines.yaml
+++ b/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nimpipelines.yaml
@@ -120,6 +120,7 @@ spec:
                                   If empty, everything from the claim is made available, otherwise
                                   only the result of this subset of requests.
                                 items:
+                                  minLength: 1
                                   type: string
                                 type: array
                               resourceClaimName:
@@ -129,6 +130,9 @@ spec:
 
                                   Exactly one of ResourceClaimName and ResourceClaimTemplateName must
                                   be set.
+                                maxLength: 253
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*
                                 type: string
                               resourceClaimTemplateName:
                                 description: |-
@@ -140,8 +144,15 @@ spec:
 
                                   Exactly one of ResourceClaimName and ResourceClaimTemplateName must
                                   be set.
+                                maxLength: 253
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*
                                 type: string
                             type: object
+                            x-kubernetes-validations:
+                            - message: exactly one of spec.resourceClaimName and spec.resourceClaimTemplateName
+                                must be set.
+                              rule: has(self.resourceClaimName) != has(self.resourceClaimTemplateName)
                           type: array
                         env:
                           items:

--- a/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nimservices.yaml
+++ b/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nimservices.yaml
@@ -81,6 +81,7 @@ spec:
                         If empty, everything from the claim is made available, otherwise
                         only the result of this subset of requests.
                       items:
+                        minLength: 1
                         type: string
                       type: array
                     resourceClaimName:
@@ -90,6 +91,9 @@ spec:
 
                         Exactly one of ResourceClaimName and ResourceClaimTemplateName must
                         be set.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*
                       type: string
                     resourceClaimTemplateName:
                       description: |-
@@ -101,8 +105,15 @@ spec:
 
                         Exactly one of ResourceClaimName and ResourceClaimTemplateName must
                         be set.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*
                       type: string
                   type: object
+                  x-kubernetes-validations:
+                  - message: exactly one of spec.resourceClaimName and spec.resourceClaimTemplateName
+                      must be set.
+                    rule: has(self.resourceClaimName) != has(self.resourceClaimTemplateName)
                 type: array
               env:
                 items:


### PR DESCRIPTION
This change adds basic validation markers to the DRAResource api fields.

TODO:
* Comprehensive validations via a webhook:
  * unique resource claim names 
  * only resource claim templates should be specified when autoscaling is enabled or multiple replicas requested
  * reject `spec.draResources[]` for cluster versions < v1.33