### PR TITLE
Bind volcano-scheduler ServiceAccount to hostmount-anyuid SCC

### DIFF
--- a/test/e2e/nemo-dependencies/customizer/tasks/uninstall.yaml
+++ b/test/e2e/nemo-dependencies/customizer/tasks/uninstall.yaml
@@ -13,9 +13,10 @@
   ignore_errors: true
 
 - name: Delete Volcano Kubernetes resources
-  shell: kubectl get {{ item }} | egrep 'volcano|mlflow' | awk '{print $1}' | xargs kubectl delete {{ item }}
+  shell: kubectl get {{ item }} -n {{ namespace }} | egrep 'volcano|mlflow' | awk '{print $1}' | xargs kubectl delete {{ item }} -n {{ namespace }}
   loop:
     - crd
+    - serviceaccount
     - clusterrole
     - clusterrolebinding
     - mutatingwebhookconfiguration

--- a/test/e2e/nemo-dependencies/customizer/tasks/volcano.yaml
+++ b/test/e2e/nemo-dependencies/customizer/tasks/volcano.yaml
@@ -6,16 +6,40 @@
 - name: Update Helm repositories cache
   command: helm repo update
 
+- name: Get Kube API resources
+  command: kubectl api-resources --verbs=list --namespaced -o name
+  register: api_resources
+
+- name: Check if the current cluster is OpenShift
+  set_fact:
+    is_openshift: "{{ 'routes.route.openshift.io' in api_resources.stdout_lines }}"
+
+- name: OpenShift - Prepare RBAC to use hostmount-anyuid SCC
+  ansible.builtin.template:
+    src: volcano-oc-rbac.yaml.j2
+    dest: volcano-oc-rbac.yaml
+  when: is_openshift 
+
+- name: OpenShift - apply RBAC to use hostmount-anyuid SCC
+  command: kubectl apply -f volcano-oc-rbac.yaml
+  when: is_openshift 
+
 - name: Install Volcano Helm chart in Kubernetes cluster
   shell: |
     helm upgrade --install {{ volcano.helm_repo_name }} {{ volcano.chart_name }} \
       --namespace {{ namespace }} \
       --version {{ volcano.chart_version }}
 
-- name: Wait for Volcano pods to be created (timeout = 300s)
-  shell: |
-    timeout 300s bash -c 'until kubectl get pods -n {{ namespace }} | grep -q volcano; do sleep 1; done'
-  register: wait_result
+- name: Wait for Volcano deployments to be available
+  command: kubectl rollout status deployment/{{ item }} -n {{ namespace }} --timeout=300s
+  loop:
+    - volcano-scheduler
+    - volcano-admission
+    - volcano-controllers
+  register: rollout_status
+  retries: 5
+  delay: 10
+  until: rollout_status.rc == 0
 
 - name: Run Volcano Job if validation is enabled
   block:

--- a/test/e2e/nemo-dependencies/customizer/templates/volcano-oc-rbac.yaml.j2
+++ b/test/e2e/nemo-dependencies/customizer/templates/volcano-oc-rbac.yaml.j2
@@ -1,0 +1,26 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: scc-hostmount-anyuid
+  namespace: {{ namespace }}
+rules:
+- apiGroups: ['security.openshift.io']
+  resources: ['securitycontextconstraints']
+  verbs: ['use']
+  resourceNames: ['hostmount-anyuid']
+
+--- 
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: volcano-scc-hostmount-anyuid-binding
+  namespace: {{ namespace }}
+subjects:
+- kind: ServiceAccount
+  name: volcano-scheduler
+  namespace: {{ namespace }}
+roleRef:
+  kind: Role
+  name: scc-hostmount-anyuid
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
This PR binds the `volcano-scheduler` ServiceAccount to `hostmount-anyuid` SCC in OpenShift, to allow hostPath volumes to be used by Volcano Scheduler.