### PR TITLE
Adding validating admission webhooks for NIMService/NIMCache with Helm deployment updates

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -5,6 +5,7 @@
 domain: nvidia.com
 layout:
 - go.kubebuilder.io/v4
+multigroup: true
 projectName: k8s-nim-operator
 repo: github.com/NVIDIA/k8s-nim-operator
 resources:
@@ -17,6 +18,9 @@ resources:
   kind: NIMService
   path: github.com/NVIDIA/k8s-nim-operator/api/apps/v1alpha1
   version: v1alpha1
+  webhooks:
+    validation: true
+    webhookVersion: v1
 - api:
     crdVersion: v1
     namespaced: true
@@ -26,6 +30,9 @@ resources:
   kind: NIMCache
   path: github.com/NVIDIA/k8s-nim-operator/api/apps/v1alpha1
   version: v1alpha1
+  webhooks:
+    validation: true
+    webhookVersion: v1
 - api:
     crdVersion: v1
     namespaced: true

--- a/config/certmanager/certificate-metrics.yaml
+++ b/config/certmanager/certificate-metrics.yaml
@@ -1,0 +1,20 @@
+# The following manifests contain a self-signed issuer CR and a metrics certificate CR.
+# More document can be found at https://docs.cert-manager.io
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app.kubernetes.io/name: k8s-nim-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: metrics-certs  # this name should match the one appeared in kustomizeconfig.yaml
+  namespace: system
+spec:
+  dnsNames:
+  # SERVICE_NAME and SERVICE_NAMESPACE will be substituted by kustomize
+  # replacements in the config/default/kustomization.yaml file.
+  - SERVICE_NAME.SERVICE_NAMESPACE.svc
+  - SERVICE_NAME.SERVICE_NAMESPACE.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: metrics-server-cert

--- a/config/certmanager/certificate-webhook.yaml
+++ b/config/certmanager/certificate-webhook.yaml
@@ -1,0 +1,20 @@
+# The following manifests contain a self-signed issuer CR and a certificate CR.
+# More document can be found at https://docs.cert-manager.io
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app.kubernetes.io/name: k8s-nim-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml
+  namespace: system
+spec:
+  # SERVICE_NAME and SERVICE_NAMESPACE will be substituted by kustomize
+  # replacements in the config/default/kustomization.yaml file.
+  dnsNames:
+  - SERVICE_NAME.SERVICE_NAMESPACE.svc
+  - SERVICE_NAME.SERVICE_NAMESPACE.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: webhook-server-cert

--- a/config/certmanager/issuer.yaml
+++ b/config/certmanager/issuer.yaml
@@ -1,0 +1,13 @@
+# The following manifest contains a self-signed issuer CR.
+# More information can be found at https://docs.cert-manager.io
+# WARNING: Targets CertManager v1.0. Check https://cert-manager.io/docs/installation/upgrading/ for breaking changes.
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    app.kubernetes.io/name: k8s-nim-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: selfsigned-issuer
+  namespace: system
+spec:
+  selfSigned: {}

--- a/config/certmanager/kustomization.yaml
+++ b/config/certmanager/kustomization.yaml
@@ -1,0 +1,7 @@
+resources:
+- issuer.yaml
+- certificate-webhook.yaml
+- certificate-metrics.yaml
+
+configurations:
+- kustomizeconfig.yaml

--- a/config/certmanager/kustomizeconfig.yaml
+++ b/config/certmanager/kustomizeconfig.yaml
@@ -1,0 +1,8 @@
+# This configuration is for teaching kustomize how to update name ref substitution
+nameReference:
+- kind: Issuer
+  group: cert-manager.io
+  fieldSpecs:
+  - kind: Certificate
+    group: cert-manager.io
+    path: spec/issuerRef/name

--- a/config/default/manager_webhook_patch.yaml
+++ b/config/default/manager_webhook_patch.yaml
@@ -1,0 +1,31 @@
+# This patch ensures the webhook certificates are properly mounted in the manager container.
+# It configures the necessary arguments, volumes, volume mounts, and container ports.
+
+# Add the --webhook-cert-path argument for configuring the webhook certificate path
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
+
+# Add the volumeMount for the webhook certificates
+- op: add
+  path: /spec/template/spec/containers/0/volumeMounts/-
+  value:
+    mountPath: /tmp/k8s-webhook-server/serving-certs
+    name: webhook-certs
+    readOnly: true
+
+# Add the port configuration for the webhook server
+- op: add
+  path: /spec/template/spec/containers/0/ports/-
+  value:
+    containerPort: 9443
+    name: webhook-server
+    protocol: TCP
+
+# Add the volume configuration for the webhook certificates
+- op: add
+  path: /spec/template/spec/volumes/-
+  value:
+    name: webhook-certs
+    secret:
+      secretName: webhook-server-cert

--- a/config/network-policy/allow-webhook-traffic.yaml
+++ b/config/network-policy/allow-webhook-traffic.yaml
@@ -1,0 +1,27 @@
+# This NetworkPolicy allows ingress traffic to your webhook server running
+# as part of the controller-manager from specific namespaces and pods. CR(s) which uses webhooks
+# will only work when applied in namespaces labeled with 'webhook: enabled'
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/name: k8s-nim-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: allow-webhook-traffic
+  namespace: system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+      app.kubernetes.io/name: k8s-nim-operator
+  policyTypes:
+    - Ingress
+  ingress:
+    # This allows ingress traffic from any namespace with the label webhook: enabled
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            webhook: enabled # Only from namespaces with this label
+      ports:
+        - port: 443
+          protocol: TCP

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -1,0 +1,6 @@
+resources:
+- manifests.yaml
+- service.yaml
+
+configurations:
+- kustomizeconfig.yaml

--- a/config/webhook/kustomizeconfig.yaml
+++ b/config/webhook/kustomizeconfig.yaml
@@ -1,0 +1,22 @@
+# the following config is for teaching kustomize where to look at when substituting nameReference.
+# It requires kustomize v2.1.0 or newer to work properly.
+nameReference:
+- kind: Service
+  version: v1
+  fieldSpecs:
+  - kind: MutatingWebhookConfiguration
+    group: admissionregistration.k8s.io
+    path: webhooks/clientConfig/service/name
+  - kind: ValidatingWebhookConfiguration
+    group: admissionregistration.k8s.io
+    path: webhooks/clientConfig/service/name
+
+namespace:
+- kind: MutatingWebhookConfiguration
+  group: admissionregistration.k8s.io
+  path: webhooks/clientConfig/service/namespace
+  create: true
+- kind: ValidatingWebhookConfiguration
+  group: admissionregistration.k8s.io
+  path: webhooks/clientConfig/service/namespace
+  create: true

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-apps-nvidia-com-v1alpha1-nimcache
+  failurePolicy: Fail
+  name: vnimcache-v1alpha1.kb.io
+  rules:
+  - apiGroups:
+    - apps.nvidia.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - nimcaches
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-apps-nvidia-com-v1alpha1-nimservice
+  failurePolicy: Fail
+  name: vnimservice-v1alpha1.kb.io
+  rules:
+  - apiGroups:
+    - apps.nvidia.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - nimservices
+  sideEffects: None

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: k8s-nim-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: webhook-service
+  namespace: system
+spec:
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 9443
+  selector:
+    control-plane: controller-manager
+    app.kubernetes.io/name: k8s-nim-operator

--- a/deployments/helm/k8s-nim-operator/templates/admission-controller.yaml
+++ b/deployments/helm/k8s-nim-operator/templates/admission-controller.yaml
@@ -1,0 +1,113 @@
+---
+{{- if .Values.operator.admissionController.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "k8s-nim-operator.fullname" . }}-webhook-service
+  namespace: {{ .Release.Namespace }}
+  labels:
+    control-plane: controller-manager
+    {{- include "k8s-nim-operator.selectorLabels" . | nindent 4 }}
+spec:
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 9443
+  selector:
+    control-plane: controller-manager
+    app.kubernetes.io/name: {{ include "k8s-nim-operator.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+---
+{{- if and .Values.operator.admissionController.enabled .Values.operator.admissionController.useCertManager }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "k8s-nim-operator.fullname" . }}-serving-cert
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: k8s-nim-operator
+    app.kubernetes.io/managed-by: helm
+spec:
+  dnsNames:
+    - {{ include "k8s-nim-operator.fullname" . }}-webhook-service.{{ .Release.Namespace }}.svc
+    - {{ include "k8s-nim-operator.fullname" . }}-webhook-service.{{ .Release.Namespace }}.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: {{ include "k8s-nim-operator.fullname" . }}-selfsigned-issuer
+  secretName: {{ include "k8s-nim-operator.fullname" . }}-webhook-server-cert
+{{- end }}
+---
+{{- if and .Values.operator.admissionController.enabled .Values.operator.admissionController.useCertManager }}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "k8s-nim-operator.fullname" . }}-selfsigned-issuer
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: k8s-nim-operator
+    app.kubernetes.io/managed-by: helm
+spec:
+  selfSigned: {}
+{{- end}}
+---
+{{- if .Values.operator.admissionController.enabled }}
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: {{ include "k8s-nim-operator.fullname" . }}-validating-webhook-configuration
+  {{- if .Values.operator.admissionController.useCertManager }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "k8s-nim-operator.fullname" . }}-serving-cert
+  {{- end }}
+  labels:
+    app.kubernetes.io/name: k8s-nim-operator
+    app.kubernetes.io/managed-by: helm
+webhooks:
+  - name: vnimcache-v1alpha1.kb.io
+    admissionReviewVersions: ["v1"]
+    clientConfig:
+      service:
+        name: {{ include "k8s-nim-operator.fullname" . }}-webhook-service
+        namespace: {{ .Release.Namespace }}
+        path: /validate-apps-nvidia-com-v1alpha1-nimcache
+      {{- if not .Values.operator.admissionController.useCertManager }}
+      caBundle: {{ .Values.operator.admissionController.certificate.caCrt | b64enc | quote }}
+      {{- end }}
+    failurePolicy: Fail
+    rules:
+      - apiGroups: ["apps.nvidia.com"]
+        apiVersions: ["v1alpha1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["nimcaches"]
+    sideEffects: None
+  - name: vnimservice-v1alpha1.kb.io
+    admissionReviewVersions: ["v1"]
+    clientConfig:
+      service:
+        name: {{ include "k8s-nim-operator.fullname" . }}-webhook-service
+        namespace: {{ .Release.Namespace }}
+        path: /validate-apps-nvidia-com-v1alpha1-nimservice
+      {{- if not .Values.operator.admissionController.useCertManager }}
+      caBundle: {{ .Values.operator.admissionController.certificate.caCrt | b64enc | quote }}
+      {{- end }}
+    failurePolicy: Fail
+    rules:
+      - apiGroups: ["apps.nvidia.com"]
+        apiVersions: ["v1alpha1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["nimservices"]
+    sideEffects: None
+{{- end }} 
+---
+{{- if and .Values.operator.admissionController.enabled (not .Values.operator.admissionController.useCertManager) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: webhook-server-cert
+  namespace: {{ .Release.Namespace }}
+type: Opaque
+data:
+  tls.crt: {{ .Values.operator.admissionController.certificate.tlsCrt | b64enc | quote }}
+  tls.key: {{ .Values.operator.admissionController.certificate.tlsKey | b64enc | quote }}
+{{- end }}

--- a/deployments/helm/k8s-nim-operator/templates/deployment.yaml
+++ b/deployments/helm/k8s-nim-operator/templates/deployment.yaml
@@ -33,6 +33,16 @@ spec:
         - /manager
         image: {{ include "k8s-nim-operator.fullimage" . }}
         imagePullPolicy: {{ .Values.operator.image.pullPolicy }}
+        {{- if .Values.operator.admissionController.enabled }}
+        ports:
+          - containerPort: 9443
+            name: webhook-server
+            protocol: TCP
+        volumeMounts:
+          - mountPath: /tmp/k8s-webhook-server/serving-certs
+            name: cert
+            readOnly: true
+        {{- end }}
         env:
           - name: WATCH_NAMESPACE
             value: ""
@@ -40,6 +50,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: ENABLE_WEBHOOKS
+            value: "{{ .Values.operator.admissionController.enabled }}"
         livenessProbe:
           httpGet:
             path: /healthz
@@ -62,6 +74,13 @@ spec:
       securityContext: {{- toYaml .Values.operator.podSecurityContext | nindent 8 }}
       serviceAccountName: k8s-nim-operator
       terminationGracePeriodSeconds: 10
+      {{- if .Values.operator.admissionController.enabled }}
+      volumes:
+        - name: cert
+          secret:
+            secretName: {{ include "k8s-nim-operator.fullname" . }}-webhook-server-cert
+            defaultMode: 420
+      {{- end }}
     {{- with .Values.operator.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deployments/helm/k8s-nim-operator/templates/manager-rbac.yaml
+++ b/deployments/helm/k8s-nim-operator/templates/manager-rbac.yaml
@@ -560,6 +560,28 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - leaderworkerset.x-k8s.io
+  resources:
+  - leaderworkersets
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - validatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+  - update
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deployments/helm/k8s-nim-operator/values.yaml
+++ b/deployments/helm/k8s-nim-operator/values.yaml
@@ -44,6 +44,15 @@ operator:
     capabilities:
       drop:
         - ALL
+  admissionController:
+    # -- Deploy with admission controller.
+    enabled: false
+    # -- Use cert-manager for generating self-signed certificate.
+    useCertManager: true
+    # certificate:
+    #   caCrt: |-
+    #   tlsCrt: |-
+    #   tlsKey: |-
 
 metricsService:
   ports:

--- a/internal/webhook/apps/v1alpha1/nimcache_webhook.go
+++ b/internal/webhook/apps/v1alpha1/nimcache_webhook.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	appsv1alpha1 "github.com/NVIDIA/k8s-nim-operator/api/apps/v1alpha1"
+)
+
+// nolint:unused
+// log is for logging in this package.
+var nimcachelog = logf.Log.WithName("webhooks").WithName("NIMCache")
+
+// SetupNIMCacheWebhookWithManager registers the webhook for NIMCache in the manager.
+func SetupNIMCacheWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).For(&appsv1alpha1.NIMCache{}).
+		WithValidator(&NIMCacheCustomValidator{}).
+		Complete()
+}
+
+// TODO(user): EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
+
+// TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
+// NOTE: The 'path' attribute must follow a specific pattern and should not be modified directly here.
+// Modifying the path for an invalid path can cause API server errors; failing to locate the webhook.
+// +kubebuilder:webhook:path=/validate-apps-nvidia-com-v1alpha1-nimcache,mutating=false,failurePolicy=fail,sideEffects=None,groups=apps.nvidia.com,resources=nimcaches,verbs=create;update,versions=v1alpha1,name=vnimcache-v1alpha1.kb.io,admissionReviewVersions=v1
+
+// NIMCacheCustomValidator struct is responsible for validating the NIMCache resource
+// when it is created, updated, or deleted.
+//
+// NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
+// as this struct is used only for temporary operations and does not need to be deeply copied.
+type NIMCacheCustomValidator struct {
+	// TODO(user): Add more fields as needed for validation
+}
+
+var _ webhook.CustomValidator = &NIMCacheCustomValidator{}
+
+// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type NIMCache.
+// Validate initial resource configuration, required fields, resource limits.
+func (v *NIMCacheCustomValidator) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
+	nimcache, ok := obj.(*appsv1alpha1.NIMCache)
+	if !ok {
+		return nil, fmt.Errorf("expected a NIMCache object but got %T", obj)
+	}
+	nimcachelog.V(4).Info("Validation for NIMCache upon creation", "name", nimcache.GetName())
+
+	fldPath := field.NewPath("nimcache").Child("spec")
+	// Perform structural validation via helper.
+	errList := validateNIMCacheSpec(&nimcache.Spec, fldPath)
+
+	if len(errList) > 0 {
+		return nil, errList.ToAggregate()
+	}
+
+	return nil, nil
+}
+
+// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type NIMCache.
+// Check immutable fields haven't changed, validate transitions between states, ensure updates don't break existing functionality.
+func (v *NIMCacheCustomValidator) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+	nimcache, ok := newObj.(*appsv1alpha1.NIMCache)
+	if !ok {
+		return nil, fmt.Errorf("expected a NIMCache object for the newObj but got %T", newObj)
+	}
+	nimcachelog.V(4).Info("Validation for NIMCache upon update", "name", nimcache.GetName())
+
+	fldPath := field.NewPath("nimcache").Child("spec")
+
+	// Begin by validating the new spec structurally.
+	errList := validateNIMCacheSpec(&nimcache.Spec, fldPath)
+
+	oldNIMCache, ok := oldObj.(*appsv1alpha1.NIMCache)
+	if !ok {
+		return nil, fmt.Errorf("expected a NIMCache object for oldObj but got %T", oldObj)
+	}
+	newNIMCache, ok := newObj.(*appsv1alpha1.NIMCache)
+	if !ok {
+		return nil, fmt.Errorf("expected a NIMCache object for newObj but got %T", newObj)
+	}
+
+	// Append immutability errors after structural checks.
+	errList = append(errList, validateImmutableNIMCacheSpec(oldNIMCache, newNIMCache, field.NewPath("nimcache"))...)
+
+	if len(errList) > 0 {
+		return nil, errList.ToAggregate()
+	}
+
+	return nil, nil
+}
+
+// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type NIMCache.
+// Verify safe deletion conditions, check for dependent resources, ensure cleanup requirements.
+func (v *NIMCacheCustomValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	return nil, nil
+}

--- a/internal/webhook/apps/v1alpha1/nimcache_webhook_test.go
+++ b/internal/webhook/apps/v1alpha1/nimcache_webhook_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	appsv1alpha1 "github.com/NVIDIA/k8s-nim-operator/api/apps/v1alpha1"
+	// TODO (user): Add any additional imports if needed.
+)
+
+var _ = Describe("NIMCache Webhook", func() {
+	var (
+		obj       *appsv1alpha1.NIMCache
+		oldObj    *appsv1alpha1.NIMCache
+		validator NIMCacheCustomValidator
+	)
+
+	BeforeEach(func() {
+		obj = &appsv1alpha1.NIMCache{}
+		oldObj = &appsv1alpha1.NIMCache{}
+		validator = NIMCacheCustomValidator{}
+		Expect(validator).NotTo(BeNil(), "Expected validator to be initialized")
+		Expect(oldObj).NotTo(BeNil(), "Expected oldObj to be initialized")
+		Expect(obj).NotTo(BeNil(), "Expected obj to be initialized")
+		// TODO (user): Add any setup logic common to all tests
+	})
+
+	AfterEach(func() {
+		// TODO (user): Add any teardown logic common to all tests
+	})
+
+	Context("When creating or updating NIMCache under Validating Webhook", func() {
+		// TODO (user): Add logic for validating webhooks
+		// Example:
+		// It("Should deny creation if a required field is missing", func() {
+		//     By("simulating an invalid creation scenario")
+		//     obj.SomeRequiredField = ""
+		//     Expect(validator.ValidateCreate(ctx, obj)).Error().To(HaveOccurred())
+		// })
+		//
+		// It("Should admit creation if all required fields are present", func() {
+		//     By("simulating an invalid creation scenario")
+		//     obj.SomeRequiredField = "valid_value"
+		//     Expect(validator.ValidateCreate(ctx, obj)).To(BeNil())
+		// })
+		//
+		// It("Should validate updates correctly", func() {
+		//     By("simulating a valid update scenario")
+		//     oldObj.SomeRequiredField = "updated_value"
+		//     obj.SomeRequiredField = "updated_value"
+		//     Expect(validator.ValidateUpdate(ctx, oldObj, obj)).To(BeNil())
+		// })
+	})
+
+})

--- a/internal/webhook/apps/v1alpha1/nimcache_webhook_validation_helper.go
+++ b/internal/webhook/apps/v1alpha1/nimcache_webhook_validation_helper.go
@@ -1,0 +1,231 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"fmt"
+	"reflect"
+	"regexp"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	appsv1alpha1 "github.com/NVIDIA/k8s-nim-operator/api/apps/v1alpha1"
+)
+
+var (
+	reHostname = regexp.MustCompile(`^\.?[a-zA-Z0-9.-]+$`)             // .example.com or example.com
+	reIPv4     = regexp.MustCompile(`^(\d{1,3}\.){3}\d{1,3}(:\d+)?$`)  // 10.1.2.3 or 10.1.2.3:8080
+	reIPv6     = regexp.MustCompile(`^\[[0-9a-fA-F:]+\](?::\d+)?$`)    // [2001:db8::1] or [2001:db8::1]:443
+	reCIDR4    = regexp.MustCompile(`^(\d{1,3}\.){3}\d{1,3}/\d{1,2}$`) // 10.0.0.0/8
+	reCIDR6    = regexp.MustCompile(`^\[[0-9a-fA-F:]+\]/\d{1,3}$`)     // [2001:db8::]/32
+)
+
+var validQoSProfiles = []string{"latency", "throughput"}
+
+// validateNIMSourceConfiguration validates the NIMSource configuration in the NIMCache spec.
+func validateNIMSourceConfiguration(source *appsv1alpha1.NIMSource, fldPath *field.Path) field.ErrorList {
+	errList := field.ErrorList{}
+	// Evalutate NGCSource if it is set. NemoDataStoreSource and HuggingFaceHubSource do not require any additional validation.
+	errList = append(errList, validateNGCSource(source.NGC, fldPath.Child("ngc"))...)
+	return errList
+}
+
+// ValidateNGCSource checks the NGCSource configuration.
+func validateNGCSource(ngcSource *appsv1alpha1.NGCSource, fldPath *field.Path) field.ErrorList {
+	errList := field.ErrorList{}
+
+	// Return early if NGCSource is nil
+	if ngcSource == nil {
+		return nil
+	}
+
+	// Ensure AuthSecret is a non-empty string
+	if ngcSource.AuthSecret == "" {
+		errList = append(errList, field.Required(fldPath.Child("authSecret"), "must be non-empty"))
+	}
+
+	// Ensure ModelPuller is a non-empty string
+	if ngcSource.ModelPuller == "" {
+		errList = append(errList, field.Required(fldPath.Child("modelPuller"), "must be non-empty"))
+	}
+
+	// Evaluate NGCSource.Model fields
+	errList = append(errList, validateModel(ngcSource.Model, fldPath.Child("model"))...)
+
+	return errList
+}
+
+func validateModel(model *appsv1alpha1.ModelSpec, fldPath *field.Path) field.ErrorList {
+	errList := field.ErrorList{}
+
+	// If Model.Profiles is not empty, ensure all other Model fields are empty. If Model.Profiles contains "all", length must be 1
+	if len(model.Profiles) > 0 {
+
+		for _, profile := range model.Profiles {
+			if profile == "all" && len(model.Profiles) != 1 {
+				errList = append(errList, field.Invalid(fldPath.Child("profiles"), model.Profiles, "must only have a single entry when it contains 'all'"))
+				break
+			}
+		}
+
+		// Ensure all other Model fields are empty
+		if model.Precision != "" {
+			errList = append(errList, field.Forbidden(fldPath.Child("precision"), fmt.Sprintf("must be empty if %s is provided", fldPath.Child("profiles"))))
+		}
+		if model.Engine != "" {
+			errList = append(errList, field.Forbidden(fldPath.Child("engine"), fmt.Sprintf("must be empty if %s is provided", fldPath.Child("profiles"))))
+		}
+		if model.TensorParallelism != "" {
+			errList = append(errList, field.Forbidden(fldPath.Child("tensorParallelism"), fmt.Sprintf("must be empty if %s is provided", fldPath.Child("profiles"))))
+		}
+		if model.QoSProfile != "" {
+			errList = append(errList, field.Forbidden(fldPath.Child("qosProfile"), fmt.Sprintf("must be empty if %s is provided", fldPath.Child("profiles"))))
+		}
+		if len(model.GPUs) > 0 {
+			errList = append(errList, field.Forbidden(fldPath.Child("gpus"), fmt.Sprintf("must be empty if %s is provided", fldPath.Child("profiles"))))
+		}
+		if model.Lora != nil {
+			errList = append(errList, field.Forbidden(fldPath.Child("lora"), fmt.Sprintf("must be empty if %s is provided", fldPath.Child("profiles"))))
+		}
+		if model.Buildable != nil {
+			errList = append(errList, field.Forbidden(fldPath.Child("buildable"), fmt.Sprintf("must be empty if %s is provided", fldPath.Child("profiles"))))
+		}
+	}
+
+	if model.QoSProfile != "" && !isValidQoSProfile(model.QoSProfile) {
+		errList = append(errList, field.NotSupported(fldPath.Child("qosProfile"), model.QoSProfile, validQoSProfiles))
+	}
+
+	return errList
+}
+
+func isValidQoSProfile(profile string) bool {
+	for _, p := range validQoSProfiles {
+		if profile == p {
+			return true
+		}
+	}
+	return false
+}
+
+func validateNIMCacheStorageConfiguration(storage *appsv1alpha1.NIMCacheStorage, fldPath *field.Path) field.ErrorList {
+	errList := field.ErrorList{}
+
+	// Spec.Storage must not be empty
+	if reflect.DeepEqual(storage.PVC, appsv1alpha1.PersistentVolumeClaim{}) {
+		errList = append(errList, field.Required(fldPath, "must not be empty"))
+		// Don't validate PVC configuration if storage is completely empty
+		return errList
+	}
+
+	errList = append(errList, validatePVCConfiguration(&storage.PVC, fldPath.Child("pvc"))...)
+
+	return errList
+}
+
+func validatePVCConfiguration(pvc *appsv1alpha1.PersistentVolumeClaim, fldPath *field.Path) field.ErrorList {
+	errList := field.ErrorList{}
+
+	// If PVC.Create is False, PVC.Name cannot be empty
+	if (pvc.Create == nil || !*pvc.Create) && pvc.Name == "" {
+		errList = append(errList, field.Required(fldPath.Child("name"), fmt.Sprintf("must be provided when %s is false", fldPath.Child("create"))))
+	}
+
+	// If PVC.VolumeAccessMode is defined, it must be one of the valid modes
+	if pvc.VolumeAccessMode != "" {
+		found := false
+		for _, vm := range validPVCAccessModeStrs {
+			if pvc.VolumeAccessMode == vm {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			errList = append(errList, field.Invalid(fldPath.Child("volumeAccessMode"), pvc.VolumeAccessMode, "unrecognized volumeAccessMode"))
+		}
+	}
+
+	return errList
+}
+
+func validateProxyConfiguration(proxy *appsv1alpha1.ProxySpec, fldPath *field.Path) field.ErrorList {
+	errList := field.ErrorList{}
+	if proxy == nil {
+		return nil
+	}
+
+	// If Proxy is not nil, ensure Proxy.NoProxy is a valid proxy string
+	if proxy.NoProxy != "" {
+		for i, token := range strings.Split(proxy.NoProxy, ",") {
+			token = strings.TrimSpace(token)
+			if token == "" {
+				continue
+			}
+			if reHostname.MatchString(token) || reIPv4.MatchString(token) || reIPv6.MatchString(token) || reCIDR4.MatchString(token) || reCIDR6.MatchString(token) {
+				continue
+			}
+			errList = append(errList, field.Invalid(fldPath.Child("noProxy").Index(i), token, "invalid token"))
+		}
+	}
+
+	// Ensure Http or Https proxy is valid
+	re := regexp.MustCompile(`^https?://`)
+	if proxy.HttpsProxy != "" && !re.MatchString(proxy.HttpsProxy) {
+		errList = append(errList, field.Invalid(fldPath.Child("httpsProxy"), proxy.HttpsProxy, "must start with http:// or https://"))
+	}
+	if proxy.HttpProxy != "" && !re.MatchString(proxy.HttpProxy) {
+		errList = append(errList, field.Invalid(fldPath.Child("httpProxy"), proxy.HttpProxy, "must start with http:// or https://"))
+	}
+
+	return errList
+}
+
+// validateNIMCacheSpec aggregates all structural validation rules for a NIMCache
+// resource. This central function is intended for use by both webhook
+// ValidateCreate and ValidateUpdate methods so that they share identical
+// well-formedness checks.
+//
+// Parameters:
+//
+//	– spec:  pointer to the NIMCacheSpec being validated.
+//	– fldPath: field path pointing at the root of the spec (typically
+//	  field.NewPath("nimcache").Child("spec")).
+//
+// Returns a field.ErrorList with any validation errors encountered.
+func validateNIMCacheSpec(spec *appsv1alpha1.NIMCacheSpec, fldPath *field.Path) field.ErrorList {
+	errList := field.ErrorList{}
+
+	// Delegate to existing granular validators.
+	errList = append(errList, validateNIMSourceConfiguration(&spec.Source, fldPath.Child("source"))...)
+	errList = append(errList, validateNIMCacheStorageConfiguration(&spec.Storage, fldPath.Child("storage"))...)
+	errList = append(errList, validateProxyConfiguration(spec.Proxy, fldPath.Child("proxy"))...)
+
+	return errList
+}
+
+func validateImmutableNIMCacheSpec(oldNIMCache, newNIMCache *appsv1alpha1.NIMCache, fldPath *field.Path) field.ErrorList {
+	errList := field.ErrorList{}
+
+	if !equality.Semantic.DeepEqual(oldNIMCache.Spec, newNIMCache.Spec) {
+		errList = append(errList, field.Forbidden(fldPath.Child("spec"), "is immutable once the object is created"))
+	}
+
+	return errList
+}

--- a/internal/webhook/apps/v1alpha1/nimcache_webhook_validation_helper_test.go
+++ b/internal/webhook/apps/v1alpha1/nimcache_webhook_validation_helper_test.go
@@ -1,0 +1,355 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	appsv1alpha1 "github.com/NVIDIA/k8s-nim-operator/api/apps/v1alpha1"
+)
+
+// TestValidateNGCSource covers the edge-cases and success path of validateNGCSource.
+func TestValidateNGCSource(t *testing.T) {
+	fldPath := field.NewPath("spec").Child("source").Child("ngc")
+
+	tests := []struct {
+		name     string
+		src      *appsv1alpha1.NGCSource
+		wantErrs int
+	}{
+		{
+			name:     "nil source",
+			src:      nil,
+			wantErrs: 0,
+		},
+		{
+			name: "missing secrets and puller",
+			src: &appsv1alpha1.NGCSource{
+				Model: &appsv1alpha1.ModelSpec{},
+			},
+			wantErrs: 2,
+		},
+		{
+			name: "ngcsource.model.profiles contains 'all' and more values",
+			src: &appsv1alpha1.NGCSource{
+				AuthSecret:  "sec",
+				ModelPuller: "img",
+				Model: &appsv1alpha1.ModelSpec{
+					Profiles: []string{"all", "foo"},
+				},
+			},
+			wantErrs: 1,
+		},
+		{
+			name: "profiles with forbidden additional fields",
+			src: &appsv1alpha1.NGCSource{
+				AuthSecret:  "sec",
+				ModelPuller: "img",
+				Model: &appsv1alpha1.ModelSpec{
+					Profiles:  []string{"foo"},
+					Precision: "fp16",
+					Engine:    "test",
+				},
+			},
+			wantErrs: 2,
+		},
+		{
+			name: "invalid qos profile",
+			src: &appsv1alpha1.NGCSource{
+				AuthSecret:  "sec",
+				ModelPuller: "img",
+				Model: &appsv1alpha1.ModelSpec{
+					QoSProfile: "fast",
+				},
+			},
+			wantErrs: 1,
+		},
+		{
+			name: "valid source",
+			src: &appsv1alpha1.NGCSource{
+				AuthSecret:  "sec",
+				ModelPuller: "img",
+				Model: &appsv1alpha1.ModelSpec{
+					Precision:  "fp16",
+					QoSProfile: "throughput",
+				},
+			},
+			wantErrs: 0,
+		},
+		{
+			name: "valid source #2",
+			src: &appsv1alpha1.NGCSource{
+				AuthSecret:  "sec",
+				ModelPuller: "img",
+				Model: &appsv1alpha1.ModelSpec{
+					Profiles: []string{"foo"},
+				},
+			},
+			wantErrs: 0,
+		},
+		{
+			name: "valid source #3",
+			src: &appsv1alpha1.NGCSource{
+				AuthSecret:  "sec",
+				ModelPuller: "img",
+				Model: &appsv1alpha1.ModelSpec{
+					QoSProfile: "latency",
+				},
+			},
+			wantErrs: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := validateNGCSource(tc.src, fldPath)
+			if got := len(errs); got != tc.wantErrs {
+				t.Logf("Validation errors:")
+				for i, err := range errs {
+					t.Logf("  %d: %s", i+1, err.Error())
+				}
+				t.Fatalf("got %d errs, want %d", got, tc.wantErrs)
+			}
+		})
+	}
+}
+
+// TestValidateNIMCacheStorageConfiguration tests validateNIMCacheStorageConfiguration.
+func TestValidateNIMCacheStorageConfiguration(t *testing.T) {
+	fldPath := field.NewPath("spec").Child("storage")
+
+	falseVal := false
+	trueVal := true
+
+	tests := []struct {
+		name     string
+		storage  *appsv1alpha1.NIMCacheStorage
+		wantErrs int
+	}{
+		{
+			name:     "empty storage",
+			storage:  &appsv1alpha1.NIMCacheStorage{},
+			wantErrs: 1,
+		},
+		{
+			name: "create false name empty",
+			storage: &appsv1alpha1.NIMCacheStorage{
+				PVC: appsv1alpha1.PersistentVolumeClaim{
+					Create: &falseVal,
+				},
+			},
+			wantErrs: 1,
+		},
+		{
+			name: "invalid volume access mode",
+			storage: &appsv1alpha1.NIMCacheStorage{
+				PVC: appsv1alpha1.PersistentVolumeClaim{
+					Create:           &trueVal,
+					VolumeAccessMode: "RandomMode",
+				},
+			},
+			wantErrs: 1,
+		},
+		{
+			name: "valid storage",
+			storage: &appsv1alpha1.NIMCacheStorage{
+				PVC: appsv1alpha1.PersistentVolumeClaim{
+					Create:           &trueVal,
+					StorageClass:     "standard",
+					Size:             "10Gi",
+					VolumeAccessMode: corev1.ReadWriteOnce,
+				},
+			},
+			wantErrs: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := validateNIMCacheStorageConfiguration(tc.storage, fldPath)
+			if got := len(errs); got != tc.wantErrs {
+				t.Logf("Validation errors:")
+				for i, err := range errs {
+					t.Logf("  %d: %s", i+1, err.Error())
+				}
+				t.Fatalf("got %d errs, want %d", got, tc.wantErrs)
+			}
+		})
+	}
+}
+
+// TestValidateProxyConfiguration tests validateProxyConfiguration.
+func TestValidateProxyConfiguration(t *testing.T) {
+	fldPath := field.NewPath("spec").Child("proxy")
+
+	tests := []struct {
+		name     string
+		proxy    *appsv1alpha1.ProxySpec
+		wantErrs int
+	}{
+		{
+			name:     "nil proxy",
+			proxy:    nil,
+			wantErrs: 0,
+		},
+		{
+			name:     "empty proxy",
+			proxy:    &appsv1alpha1.ProxySpec{},
+			wantErrs: 0,
+		},
+		{
+			name: "invalid noProxy token",
+			proxy: &appsv1alpha1.ProxySpec{
+				NoProxy: "invalid_token$",
+			},
+			wantErrs: 1,
+		},
+		{
+			name: "missing scheme http proxy",
+			proxy: &appsv1alpha1.ProxySpec{
+				HttpProxy: "proxy:8080",
+			},
+			wantErrs: 1,
+		},
+		{
+			name: "missing scheme https proxy",
+			proxy: &appsv1alpha1.ProxySpec{
+				HttpsProxy: "proxy:8443",
+			},
+			wantErrs: 1,
+		},
+		{
+			name: "valid proxy spec",
+			proxy: &appsv1alpha1.ProxySpec{
+				HttpProxy:  "http://proxy:8080",
+				HttpsProxy: "https://proxy:8443",
+				NoProxy:    "localhost,.example.com,10.1.2.3",
+			},
+			wantErrs: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := validateProxyConfiguration(tc.proxy, fldPath)
+			if got := len(errs); got != tc.wantErrs {
+				t.Logf("Validation errors:")
+				for i, err := range errs {
+					t.Logf("  %d: %s", i+1, err.Error())
+				}
+				t.Fatalf("got %d errs, want %d", got, tc.wantErrs)
+			}
+		})
+	}
+}
+
+// TestValidateNIMSourceConfiguration ensures validateNIMSourceConfiguration delegates correctly.
+func TestValidateNIMSourceConfiguration(t *testing.T) {
+	fldPath := field.NewPath("spec").Child("source")
+
+	tests := []struct {
+		name     string
+		source   *appsv1alpha1.NIMSource
+		wantErrs int
+	}{
+		{
+			name:     "empty NIMSource (no NGC)",
+			source:   &appsv1alpha1.NIMSource{},
+			wantErrs: 0,
+		},
+		{
+			name: "NGC errors propagate",
+			source: &appsv1alpha1.NIMSource{
+				NGC: &appsv1alpha1.NGCSource{
+					Model: &appsv1alpha1.ModelSpec{
+						Profiles:   []string{"all", "wrong"},
+						Precision:  "fp16",
+						QoSProfile: "throughput",
+					},
+				},
+			},
+			wantErrs: 5, // missing authSecret & modelPuller, profiles should only have one entry. If profiles is defined, all other model fields must be empty
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := validateNIMSourceConfiguration(tc.source, fldPath)
+			if got := len(errs); got != tc.wantErrs {
+				t.Logf("Validation errors:")
+				for i, err := range errs {
+					t.Logf("  %d: %s", i+1, err.Error())
+				}
+				t.Fatalf("got %d errs, want %d", got, tc.wantErrs)
+			}
+		})
+	}
+}
+
+// TestValidateImmutableNIMCacheSpec checks immutability enforcement on NIMCache.Spec.
+func TestValidateImmutableNIMCacheSpec(t *testing.T) {
+	fldPath := field.NewPath("nimcache")
+
+	// helper to build a simple NIMCache with specified PVC size
+	buildCache := func(size string) *appsv1alpha1.NIMCache {
+		return &appsv1alpha1.NIMCache{
+			Spec: appsv1alpha1.NIMCacheSpec{
+				Storage: appsv1alpha1.NIMCacheStorage{
+					PVC: appsv1alpha1.PersistentVolumeClaim{
+						Size: size,
+					},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name     string
+		oldObj   *appsv1alpha1.NIMCache
+		newObj   *appsv1alpha1.NIMCache
+		wantErrs int
+	}{
+		{
+			name:     "spec unchanged",
+			oldObj:   buildCache("10Gi"),
+			newObj:   buildCache("10Gi"),
+			wantErrs: 0,
+		},
+		{
+			name:     "spec changed (PVC size)",
+			oldObj:   buildCache("10Gi"),
+			newObj:   buildCache("20Gi"),
+			wantErrs: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := validateImmutableNIMCacheSpec(tc.oldObj, tc.newObj, fldPath)
+			if got := len(errs); got != tc.wantErrs {
+				t.Logf("Validation errors:")
+				for i, err := range errs {
+					t.Logf("  %d: %s", i+1, err.Error())
+				}
+				t.Fatalf("got %d errs, want %d", got, tc.wantErrs)
+			}
+		})
+	}
+}

--- a/internal/webhook/apps/v1alpha1/nimservice_webhook.go
+++ b/internal/webhook/apps/v1alpha1/nimservice_webhook.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	appsv1alpha1 "github.com/NVIDIA/k8s-nim-operator/api/apps/v1alpha1"
+)
+
+// nolint:unused
+// log is for logging in this package.
+var nimservicelog = logf.Log.WithName("webhooks").WithName("NIMService")
+
+// SetupNIMServiceWebhookWithManager registers the webhook for NIMService in the manager.
+func SetupNIMServiceWebhookWithManager(mgr ctrl.Manager) error {
+	validator, err := NewNIMServiceCustomValidator()
+	if err != nil {
+		return err
+	}
+	return ctrl.NewWebhookManagedBy(mgr).For(&appsv1alpha1.NIMService{}).
+		WithValidator(validator).
+		Complete()
+}
+
+// TODO: make all paths proper then resume where you left off on varuns comments.
+
+// TODO(user): EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
+
+// TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
+// NOTE: The 'path' attribute must follow a specific pattern and should not be modified directly here.
+// Modifying the path for an invalid path can cause API server errors; failing to locate the webhook.
+// +kubebuilder:webhook:path=/validate-apps-nvidia-com-v1alpha1-nimservice,mutating=false,failurePolicy=fail,sideEffects=None,groups=apps.nvidia.com,resources=nimservices,verbs=create;update,versions=v1alpha1,name=vnimservice-v1alpha1.kb.io,admissionReviewVersions=v1
+
+// NIMServiceCustomValidator struct is responsible for validating the NIMService resource
+// when it is created, updated, or deleted.
+//
+// NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
+// as this struct is used only for temporary operations and does not need to be deeply copied.
+type NIMServiceCustomValidator struct {
+	k8sVersion string
+}
+
+var _ webhook.CustomValidator = &NIMServiceCustomValidator{}
+
+// NewNIMServiceCustomValidator fetches and caches the Kubernetes version.
+func NewNIMServiceCustomValidator() (*NIMServiceCustomValidator, error) {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get in-cluster config: %v", err)
+	}
+	disco, err := discovery.NewDiscoveryClientForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create discovery client: %v", err)
+	}
+	versionInfo, err := disco.ServerVersion()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get Kubernetes server version: %v", err)
+	}
+	return &NIMServiceCustomValidator{k8sVersion: versionInfo.GitVersion}, nil
+}
+
+// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type NIMService.
+func (v *NIMServiceCustomValidator) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
+	nimservice, ok := obj.(*appsv1alpha1.NIMService)
+	if !ok {
+		return nil, fmt.Errorf("expected a NIMService object but got %T", obj)
+	}
+	nimservicelog.V(4).Info("Validation for NIMService upon creation", "name", nimservice.GetName())
+
+	fldPath := field.NewPath("nimservice").Child("spec")
+
+	// Perform comprehensive spec validation via helper.
+	errList := validateNIMServiceSpec(&nimservice.Spec, fldPath, v.k8sVersion)
+
+	if len(errList) > 0 {
+		return nil, errList.ToAggregate()
+	}
+
+	return nil, nil
+}
+
+// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type NIMService.
+func (v *NIMServiceCustomValidator) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+	nimservice, ok := newObj.(*appsv1alpha1.NIMService)
+	if !ok {
+		return nil, fmt.Errorf("expected a NIMService object for the newObj but got %T", newObj)
+	}
+	nimservicelog.V(4).Info("Validation for NIMService upon update", "name", nimservice.GetName())
+
+	fldPath := field.NewPath("nimservice").Child("spec")
+	// Start with structural validation to ensure the updated object is well formed.
+	errList := validateNIMServiceSpec(&nimservice.Spec, fldPath, v.k8sVersion)
+
+	// All fields of NIMService.Spec are mutable, except for:
+	// - Spec.MultiNode
+	// - If PVC has been created with PVC.Create = true, reject any updates to any fields of PVC object
+	oldNIMService, ok := oldObj.(*appsv1alpha1.NIMService)
+	if !ok {
+		return nil, fmt.Errorf("expected a NIMService object for oldObj but got %T", oldObj)
+	}
+	newNIMService, ok := newObj.(*appsv1alpha1.NIMService)
+	if !ok {
+		return nil, fmt.Errorf("expected a NIMService object for newObj but got %T", newObj)
+	}
+
+	errList = append(errList, validateMultiNodeImmutability(oldNIMService, newNIMService, field.NewPath("spec").Child("multiNode"))...)
+	errList = append(errList, validatePVCImmutability(oldNIMService, newNIMService, field.NewPath("spec").Child("storage").Child("pvc"))...)
+
+	if len(errList) > 0 {
+		return nil, errList.ToAggregate()
+	}
+
+	return nil, nil
+}
+
+func (v *NIMServiceCustomValidator) ValidateDelete(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
+	// No deletion-time validation logic for NIMService. Returning nil allows deletes without extra checks.
+	return nil, nil
+}

--- a/internal/webhook/apps/v1alpha1/nimservice_webhook_test.go
+++ b/internal/webhook/apps/v1alpha1/nimservice_webhook_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	appsv1alpha1 "github.com/NVIDIA/k8s-nim-operator/api/apps/v1alpha1"
+	// TODO (user): Add any additional imports if needed.
+)
+
+var _ = Describe("NIMService Webhook", func() {
+	var (
+		obj       *appsv1alpha1.NIMService
+		oldObj    *appsv1alpha1.NIMService
+		validator NIMServiceCustomValidator
+	)
+
+	BeforeEach(func() {
+		obj = &appsv1alpha1.NIMService{}
+		oldObj = &appsv1alpha1.NIMService{}
+		validator = NIMServiceCustomValidator{}
+		Expect(validator).NotTo(BeNil(), "Expected validator to be initialized")
+		Expect(oldObj).NotTo(BeNil(), "Expected oldObj to be initialized")
+		Expect(obj).NotTo(BeNil(), "Expected obj to be initialized")
+		// TODO (user): Add any setup logic common to all tests
+	})
+
+	AfterEach(func() {
+		// TODO (user): Add any teardown logic common to all tests
+	})
+
+	Context("When creating or updating NIMService under Validating Webhook", func() {
+		// TODO (user): Add logic for validating webhooks
+		// Example:
+		// It("Should deny creation if a required field is missing", func() {
+		//     By("simulating an invalid creation scenario")
+		//     obj.SomeRequiredField = ""
+		//     Expect(validator.ValidateCreate(ctx, obj)).Error().To(HaveOccurred())
+		// })
+		//
+		// It("Should admit creation if all required fields are present", func() {
+		//     By("simulating an invalid creation scenario")
+		//     obj.SomeRequiredField = "valid_value"
+		//     Expect(validator.ValidateCreate(ctx, obj)).To(BeNil())
+		// })
+		//
+		// It("Should validate updates correctly", func() {
+		//     By("simulating a valid update scenario")
+		//     oldObj.SomeRequiredField = "updated_value"
+		//     obj.SomeRequiredField = "updated_value"
+		//     Expect(validator.ValidateUpdate(ctx, oldObj, obj)).To(BeNil())
+		// })
+	})
+
+})

--- a/internal/webhook/apps/v1alpha1/nimservice_webhook_validation_helper.go
+++ b/internal/webhook/apps/v1alpha1/nimservice_webhook_validation_helper.go
@@ -1,0 +1,249 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"fmt"
+	"reflect"
+
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	appsv1alpha1 "github.com/NVIDIA/k8s-nim-operator/api/apps/v1alpha1"
+	"github.com/NVIDIA/k8s-nim-operator/internal/utils"
+)
+
+var validPVCAccessModeStrs = []corev1.PersistentVolumeAccessMode{
+	corev1.ReadWriteOnce,
+	corev1.ReadOnlyMany,
+	corev1.ReadWriteMany,
+	corev1.ReadWriteOncePod,
+}
+
+func validateImageConfiguration(image *appsv1alpha1.Image, fldPath *field.Path) field.ErrorList {
+	errList := field.ErrorList{}
+	if image.Repository == "" {
+		errList = append(errList, field.Required(fldPath.Child("repository"), "is required"))
+	}
+	if image.Tag == "" {
+		errList = append(errList, field.Required(fldPath.Child("tag"), "is required"))
+	}
+	return errList
+}
+
+func validateServiceStorageConfiguration(storage *appsv1alpha1.NIMServiceStorage, fldPath *field.Path) field.ErrorList {
+	errList := field.ErrorList{}
+	// If size limit is defined, it must be greater than 0
+	if storage.SharedMemorySizeLimit != nil {
+		if storage.SharedMemorySizeLimit.Sign() <= 0 {
+			errList = append(errList, field.Invalid(fldPath.Child("sharedMemorySizeLimit"), storage.SharedMemorySizeLimit.String(), "must be > 0"))
+		}
+	}
+
+	// Check if nimCache is defined (non-empty)
+	nimCacheDefined := storage.NIMCache != (appsv1alpha1.NIMCacheVolSpec{})
+
+	// Check if PVC is defined (non-empty)
+	pvcDefined := storage.PVC.Create != nil || storage.PVC.Name != "" || storage.PVC.StorageClass != "" ||
+		storage.PVC.Size != "" || storage.PVC.VolumeAccessMode != "" || storage.PVC.SubPath != "" ||
+		len(storage.PVC.Annotations) > 0
+
+	// Check if HostPath is defined (non-empty)
+	hostPathDefined := storage.HostPath != nil && *storage.HostPath != ""
+
+	// Count how many are defined
+	definedCount := 0
+	if nimCacheDefined {
+		definedCount++
+	}
+	if pvcDefined {
+		definedCount++
+	}
+	if hostPathDefined {
+		definedCount++
+	}
+
+	// Ensure only one of nimCache, PVC, or HostPath is defined
+	if definedCount == 0 {
+		errList = append(errList, field.Required(fldPath, fmt.Sprintf("one of %s, %s, or %s must be defined", fldPath.Child("nimCache"), fldPath.Child("pvc"), fldPath.Child("hostPath"))))
+	} else if definedCount > 1 {
+		errList = append(errList, field.Invalid(fldPath, "multiple storage sources defined", fmt.Sprintf("only one of %s, %s, or %s must be defined", fldPath.Child("nimCache"), fldPath.Child("pvc"), fldPath.Child("hostPath"))))
+	}
+
+	// If NIMCache is non-nil, NIMCache.Name must not be empty
+	if storage.NIMCache.Profile != "" {
+		if storage.NIMCache.Name == "" {
+			errList = append(errList, field.Required(fldPath.Child("nimCache").Child("name"), fmt.Sprintf("is required when %s is defined", fldPath.Child("nimCache"))))
+		}
+	}
+
+	// Enforcing PVC rules if defined
+	if pvcDefined {
+		errList = append(errList, validatePVCConfiguration(&storage.PVC, fldPath.Child("pvc"))...)
+	}
+
+	return errList
+}
+
+func validateDRAResourcesConfiguration(spec *appsv1alpha1.NIMServiceSpec, fldPath *field.Path, k8sVersion string) field.ErrorList {
+	errList := field.ErrorList{}
+	draResourcesPath := fldPath.Child("draResources")
+
+	// If the length is > 0, check k8s compatibility version
+	if len(spec.DRAResources) > 0 {
+		if !utils.IsVersionGreaterThanOrEqual(k8sVersion, utils.MinSupportedClusterVersionForDRA) {
+			errList = append(errList, field.Forbidden(draResourcesPath, fmt.Sprintf("is not supported by NIM-Operator on this cluster, please upgrade to k8s version '%s' or higher", utils.MinSupportedClusterVersionForDRA)))
+		}
+	}
+
+	seen := make(map[string]struct{})
+
+	for i, dra := range spec.DRAResources {
+		idxPath := draResourcesPath.Index(i)
+
+		hasName := dra.ResourceClaimName != nil && *dra.ResourceClaimName != ""
+		hasTemplate := dra.ResourceClaimTemplateName != nil && *dra.ResourceClaimTemplateName != ""
+
+		// Exactly one of resourceClaimName or resourceClaimTemplateName must be provided
+		if hasName == hasTemplate { // both true or both false
+			errList = append(errList, field.Invalid(
+				idxPath,
+				dra,
+				fmt.Sprintf("must specify exactly one of %s or %s", fldPath.Child("resourceClaimName"), fldPath.Child("resourceClaimTemplateName"))))
+		}
+
+		if hasName {
+			// resourceClaimName: spec.relicas must be <= 1 and spec.scale.enabled must be false.
+			if spec.Replicas > 1 {
+				errList = append(errList, field.Forbidden(
+					idxPath.Child("resourceClaimName"),
+					fmt.Sprintf("must not be set when %s > 1, use %s instead", fldPath.Child("replicas"), idxPath.Child("resourceClaimTemplateName")),
+				))
+			}
+			if spec.Scale.Enabled != nil && *spec.Scale.Enabled {
+				errList = append(errList, field.Forbidden(
+					idxPath.Child("resourceClaimName"),
+					fmt.Sprintf("must not be set when %s is true, use %s instead", fldPath.Child("scale").Child("enabled"), idxPath.Child("resourceClaimTemplateName")),
+				))
+			}
+
+			// Ensure resourceClaimName values are unique within draResources
+			if _, exists := seen[*dra.ResourceClaimName]; exists {
+				errList = append(errList, field.Duplicate(idxPath.Child("resourceClaimName"), *dra.ResourceClaimName))
+			} else {
+				seen[*dra.ResourceClaimName] = struct{}{}
+			}
+		}
+	}
+	return errList
+}
+
+func validateAuthSecret(authSecret *string, fldPath *field.Path) field.ErrorList {
+	errList := field.ErrorList{}
+	if *authSecret == "" {
+		errList = append(errList, field.Required(fldPath, "is required"))
+	}
+	return errList
+}
+
+// If Spec.Expose.Ingress.Enabled is true, Spec.Expose.Ingress.Spec must be non-nil.
+func validateExposeConfiguration(expose *appsv1alpha1.Expose, fldPath *field.Path) field.ErrorList {
+	errList := field.ErrorList{}
+	if expose.Ingress.Enabled != nil && *expose.Ingress.Enabled {
+		if reflect.DeepEqual(expose.Ingress.Spec, networkingv1.IngressSpec{}) {
+			errList = append(errList, field.Required(fldPath.Child("spec"), fmt.Sprintf("must be defined if %s is true", fldPath.Child("enabled"))))
+		}
+	}
+	return errList
+}
+
+// If Spec.Metrics.Enabled is true, Spec.Metrics.ServiceMonitor must not be empty.
+func validateMetricsConfiguration(metrics *appsv1alpha1.Metrics, fldPath *field.Path) field.ErrorList {
+	errList := field.ErrorList{}
+	if metrics.Enabled != nil && *metrics.Enabled {
+		if reflect.DeepEqual(metrics.ServiceMonitor, appsv1alpha1.ServiceMonitor{}) {
+			errList = append(errList, field.Required(fldPath.Child("serviceMonitor"), fmt.Sprintf("must be defined if %s is true", fldPath.Child("enabled"))))
+		}
+	}
+	return errList
+}
+
+// If Spec.Scale.Enabled is true, Spec.Scale.HPA must be non-empty HorizontalPodAutoScaler.
+func validateScaleConfiguration(scale *appsv1alpha1.Autoscaling, fldPath *field.Path) field.ErrorList {
+	errList := field.ErrorList{}
+	if scale.Enabled != nil && *scale.Enabled {
+		if reflect.DeepEqual(scale.HPA, appsv1alpha1.HorizontalPodAutoscalerSpec{}) {
+			errList = append(errList, field.Required(fldPath.Child("hpa"), fmt.Sprintf("must be defined if %s is true", fldPath.Child("enabled"))))
+		}
+	}
+	return errList
+}
+
+// Spec.Resources.Claims must be empty.
+func validateResourcesConfiguration(resources *corev1.ResourceRequirements, fldPath *field.Path) field.ErrorList {
+	errList := field.ErrorList{}
+	if resources != nil {
+		if resources.Claims != nil || len(resources.Claims) != 0 {
+			errList = append(errList, field.Forbidden(fldPath.Child("claims"), "must be empty"))
+		}
+	}
+	return errList
+}
+
+// validateNIMServiceSpec aggregates all structural validation checks for a NIMService
+// object. It is intended to be invoked by both ValidateCreate and ValidateUpdate to
+// ensure the resource is well-formed before any other validation (e.g. immutability)
+// is performed.
+func validateNIMServiceSpec(spec *appsv1alpha1.NIMServiceSpec, fldPath *field.Path, kubeVersion string) field.ErrorList {
+	errList := field.ErrorList{}
+
+	// Validate individual sections of the spec using existing helper functions.
+	errList = append(errList, validateImageConfiguration(&spec.Image, fldPath.Child("image"))...)
+	errList = append(errList, validateAuthSecret(&spec.AuthSecret, fldPath.Child("authSecret"))...)
+	errList = append(errList, validateServiceStorageConfiguration(&spec.Storage, fldPath.Child("storage"))...)
+	errList = append(errList, validateExposeConfiguration(&spec.Expose, fldPath.Child("expose").Child("ingress"))...)
+	errList = append(errList, validateMetricsConfiguration(&spec.Metrics, fldPath.Child("metrics"))...)
+	errList = append(errList, validateScaleConfiguration(&spec.Scale, fldPath.Child("scale"))...)
+	errList = append(errList, validateResourcesConfiguration(spec.Resources, fldPath.Child("resources"))...)
+	errList = append(errList, validateDRAResourcesConfiguration(spec, fldPath, kubeVersion)...)
+
+	return errList
+}
+
+// validateMultiNodeImmutability ensures that the MultiNode field remains unchanged after creation.
+func validateMultiNodeImmutability(oldNs, newNs *appsv1alpha1.NIMService, fldPath *field.Path) field.ErrorList {
+	errList := field.ErrorList{}
+	if !equality.Semantic.DeepEqual(oldNs.Spec.MultiNode, newNs.Spec.MultiNode) {
+		errList = append(errList, field.Forbidden(fldPath, "is immutable once the resource is created"))
+	}
+	return errList
+}
+
+// validatePVCImmutability verifies that once a PVC is created with create: true, no further modifications are allowed.
+func validatePVCImmutability(oldNs, newNs *appsv1alpha1.NIMService, fldPath *field.Path) field.ErrorList {
+	errList := field.ErrorList{}
+	oldPVC := oldNs.Spec.Storage.PVC
+	newPVC := newNs.Spec.Storage.PVC
+	if oldPVC.Create != nil && *oldPVC.Create {
+		if !equality.Semantic.DeepEqual(oldPVC, newPVC) {
+			errList = append(errList, field.Forbidden(fldPath, fmt.Sprintf("is immutable once it is created with %s = true", fldPath.Child("create"))))
+		}
+	}
+	return errList
+}

--- a/internal/webhook/apps/v1alpha1/nimservice_webhook_validation_helper_test.go
+++ b/internal/webhook/apps/v1alpha1/nimservice_webhook_validation_helper_test.go
@@ -1,0 +1,550 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/ptr"
+
+	appsv1alpha1 "github.com/NVIDIA/k8s-nim-operator/api/apps/v1alpha1"
+)
+
+// TestValidateImageConfiguration covers required field checks on Image.
+func TestValidateImageConfiguration(t *testing.T) {
+	fldPath := field.NewPath("spec").Child("image")
+
+	tests := []struct {
+		name     string
+		image    *appsv1alpha1.Image
+		wantErrs int
+	}{
+		{
+			name:     "valid image",
+			image:    &appsv1alpha1.Image{Repository: "repo", Tag: "latest"},
+			wantErrs: 0,
+		},
+		{
+			name:     "missing repository",
+			image:    &appsv1alpha1.Image{Tag: "v1"},
+			wantErrs: 1,
+		},
+		{
+			name:     "missing tag",
+			image:    &appsv1alpha1.Image{Repository: "repo"},
+			wantErrs: 1,
+		},
+		{
+			name:     "missing both",
+			image:    &appsv1alpha1.Image{},
+			wantErrs: 2,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := validateImageConfiguration(tc.image, fldPath)
+			if got := len(errs); got != tc.wantErrs {
+				t.Logf("Validation errors:")
+				for i, err := range errs {
+					t.Logf("  %d: %s", i+1, err.Error())
+				}
+				t.Fatalf("got %d errs, want %d", got, tc.wantErrs)
+			}
+		})
+	}
+}
+
+// Utility to build a minimal valid NIMService object for storage tests.
+func baseNIMService() *appsv1alpha1.NIMService {
+	return &appsv1alpha1.NIMService{
+		Spec: appsv1alpha1.NIMServiceSpec{
+			Image:      appsv1alpha1.Image{Repository: "repo", Tag: "latest"},
+			AuthSecret: "dummy-secret",
+		},
+	}
+}
+
+// TestValidateServiceStorageConfiguration covers storage validation rules.
+func TestValidateServiceStorageConfiguration(t *testing.T) {
+	fldPath := field.NewPath("spec").Child("storage")
+
+	trueVal := true
+	falseVal := false
+	sizeNeg := resource.MustParse("0")
+
+	tests := []struct {
+		name     string
+		modify   func(*appsv1alpha1.NIMService)
+		wantErrs int
+	}{
+		{
+			name:     "missing both nimCache and pvc",
+			modify:   func(ns *appsv1alpha1.NIMService) {},
+			wantErrs: 1,
+		},
+		{
+			name: "both nimCache and pvc defined",
+			modify: func(ns *appsv1alpha1.NIMService) {
+				ns.Spec.Storage.NIMCache = appsv1alpha1.NIMCacheVolSpec{Name: "cache", Profile: "p"}
+				ns.Spec.Storage.PVC = appsv1alpha1.PersistentVolumeClaim{Name: "pvc"}
+			},
+			wantErrs: 1,
+		},
+		{
+			name: "nimCache missing name",
+			modify: func(ns *appsv1alpha1.NIMService) {
+				ns.Spec.Storage.NIMCache = appsv1alpha1.NIMCacheVolSpec{Profile: "p"}
+			},
+			wantErrs: 1,
+		},
+		{
+			name: "pvc create false name empty",
+			modify: func(ns *appsv1alpha1.NIMService) {
+				ns.Spec.Storage.PVC = appsv1alpha1.PersistentVolumeClaim{
+					Create: &falseVal,
+				}
+			},
+			wantErrs: 1,
+		},
+		{
+			name: "pvc invalid volumeaccessmode",
+			modify: func(ns *appsv1alpha1.NIMService) {
+				ns.Spec.Storage.PVC = appsv1alpha1.PersistentVolumeClaim{
+					Create:           &trueVal,
+					VolumeAccessMode: "BadMode",
+				}
+			},
+			wantErrs: 1,
+		},
+		{
+			name: "shared memory size <=0",
+			modify: func(ns *appsv1alpha1.NIMService) {
+				ns.Spec.Storage.PVC = appsv1alpha1.PersistentVolumeClaim{Name: "pvc"}
+				ns.Spec.Storage.SharedMemorySizeLimit = &sizeNeg
+			},
+			wantErrs: 1,
+		},
+		{
+			name: "valid nimCache",
+			modify: func(ns *appsv1alpha1.NIMService) {
+				ns.Spec.Storage.NIMCache = appsv1alpha1.NIMCacheVolSpec{Name: "cache", Profile: "default"}
+			},
+			wantErrs: 0,
+		},
+		{
+			name: "valid pvc",
+			modify: func(ns *appsv1alpha1.NIMService) {
+				ns.Spec.Storage.PVC = appsv1alpha1.PersistentVolumeClaim{
+					Create:           &trueVal,
+					Name:             "",
+					StorageClass:     "standard",
+					Size:             "10Gi",
+					VolumeAccessMode: corev1.ReadWriteOnce,
+				}
+			},
+			wantErrs: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ns := baseNIMService()
+			tc.modify(ns)
+			errs := validateServiceStorageConfiguration(&ns.Spec.Storage, fldPath)
+			if got := len(errs); got != tc.wantErrs {
+				t.Logf("Validation errors:")
+				for i, err := range errs {
+					t.Logf("  %d: %s", i+1, err.Error())
+				}
+				t.Fatalf("got %d errs, want %d", got, tc.wantErrs)
+			}
+		})
+	}
+}
+
+// TestValidateDRAResourcesConfiguration covers DRA resource validation rules and
+// Kubernetes-version compatibility in a single table-driven test.
+func TestValidateDRAResourcesConfiguration(t *testing.T) {
+	fld := field.NewPath("spec")
+
+	cases := []struct {
+		name       string
+		modify     func(*appsv1alpha1.NIMService)
+		k8sVersion string
+		wantErrs   int
+	}{
+		{
+			name:       "no dra resources",
+			modify:     func(ns *appsv1alpha1.NIMService) {},
+			k8sVersion: "v1.34.0",
+			wantErrs:   0,
+		},
+		{
+			name: "unsupported k8s version",
+			modify: func(ns *appsv1alpha1.NIMService) {
+				ns.Spec.DRAResources = []appsv1alpha1.DRAResource{{
+					ResourceClaimTemplateName: ptr.To("tmpl1"),
+				}}
+			},
+			k8sVersion: "v1.32.0", // below MinSupportedClusterVersionForDRA
+			wantErrs:   1,
+		},
+		{
+			name: "both name and template provided",
+			modify: func(ns *appsv1alpha1.NIMService) {
+				ns.Spec.DRAResources = []appsv1alpha1.DRAResource{{
+					ResourceClaimName:         ptr.To("claim1"),
+					ResourceClaimTemplateName: ptr.To("tmpl1"),
+				}}
+			},
+			k8sVersion: "v1.34.0",
+			wantErrs:   1,
+		},
+		{
+			name: "neither name nor template provided",
+			modify: func(ns *appsv1alpha1.NIMService) {
+				ns.Spec.DRAResources = []appsv1alpha1.DRAResource{{}}
+			},
+			k8sVersion: "v1.34.0",
+			wantErrs:   1,
+		},
+		{
+			name: "resourceClaimName with replicas>1",
+			modify: func(ns *appsv1alpha1.NIMService) {
+				ns.Spec.Replicas = 2
+				ns.Spec.DRAResources = []appsv1alpha1.DRAResource{{
+					ResourceClaimName: ptr.To("claim1"),
+				}}
+			},
+			k8sVersion: "v1.34.0",
+			wantErrs:   1,
+		},
+		{
+			name: "resourceClaimName with autoscaling enabled",
+			modify: func(ns *appsv1alpha1.NIMService) {
+				enabled := true
+				ns.Spec.Scale.Enabled = &enabled
+				ns.Spec.DRAResources = []appsv1alpha1.DRAResource{{
+					ResourceClaimName: ptr.To("claim1"),
+				}}
+			},
+			k8sVersion: "v1.34.0",
+			wantErrs:   1,
+		},
+		{
+			name: "duplicate resourceClaimNames",
+			modify: func(ns *appsv1alpha1.NIMService) {
+				ns.Spec.DRAResources = []appsv1alpha1.DRAResource{
+					{ResourceClaimName: ptr.To("dup")},
+					{ResourceClaimName: ptr.To("dup")},
+				}
+			},
+			k8sVersion: "v1.34.0",
+			wantErrs:   1,
+		},
+		{
+			name: "valid template",
+			modify: func(ns *appsv1alpha1.NIMService) {
+				ns.Spec.DRAResources = []appsv1alpha1.DRAResource{{
+					ResourceClaimTemplateName: ptr.To("tmpl1"),
+				}}
+			},
+			k8sVersion: "v1.34.0",
+			wantErrs:   0,
+		},
+		{
+			name: "valid multiple templates",
+			modify: func(ns *appsv1alpha1.NIMService) {
+				ns.Spec.DRAResources = []appsv1alpha1.DRAResource{{
+					ResourceClaimTemplateName: ptr.To("tmpl1"),
+				}, {
+					ResourceClaimTemplateName: ptr.To("tmpl2"),
+				}}
+			},
+			k8sVersion: "v1.34.0",
+			wantErrs:   0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ns := baseNIMService()
+			tc.modify(ns)
+			errs := validateDRAResourcesConfiguration(&ns.Spec, fld, tc.k8sVersion)
+			if got := len(errs); got != tc.wantErrs {
+				t.Logf("Validation errors:")
+				for i, err := range errs {
+					t.Logf("  %d: %s", i+1, err.Error())
+				}
+				t.Fatalf("got %d errs, want %d", got, tc.wantErrs)
+			}
+		})
+	}
+}
+
+// TestValidateAuthSecret verifies required secret enforcement using table-driven cases.
+func TestValidateAuthSecret(t *testing.T) {
+	fld := field.NewPath("spec").Child("authSecret")
+	cases := []struct {
+		name     string
+		value    string
+		wantErrs int
+	}{
+		{"non-empty", "secret", 0},
+		{"empty", "", 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := validateAuthSecret(&tc.value, fld)
+			if got := len(errs); got != tc.wantErrs {
+				t.Logf("Validation errors:")
+				for i, err := range errs {
+					t.Logf("  %d: %s", i+1, err.Error())
+				}
+				t.Fatalf("got %d errs, want %d", got, tc.wantErrs)
+			}
+		})
+	}
+}
+
+// TestValidateExposeIngressConfiguration table-driven.
+func TestValidateExposeIngressConfiguration(t *testing.T) {
+	fld := field.NewPath("spec").Child("expose").Child("ingress")
+	enabled := true
+	class := "nginx"
+
+	cases := []struct {
+		name     string
+		modify   func(*appsv1alpha1.NIMService)
+		wantErrs int
+	}{
+		{
+			name:     "ingress disabled",
+			modify:   func(ns *appsv1alpha1.NIMService) {},
+			wantErrs: 0,
+		},
+		{
+			name: "enabled empty spec",
+			modify: func(ns *appsv1alpha1.NIMService) {
+				ns.Spec.Expose.Ingress.Enabled = &enabled
+			},
+			wantErrs: 1,
+		},
+		{
+			name: "enabled with spec",
+			modify: func(ns *appsv1alpha1.NIMService) {
+				ns.Spec.Expose.Ingress.Enabled = &enabled
+				ns.Spec.Expose.Ingress.Spec.IngressClassName = &class
+			},
+			wantErrs: 0,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ns := baseNIMService()
+			tc.modify(ns)
+			errs := validateExposeConfiguration(&ns.Spec.Expose, fld)
+			if got := len(errs); got != tc.wantErrs {
+				t.Logf("Validation errors:")
+				for i, err := range errs {
+					t.Logf("  %d: %s", i+1, err.Error())
+				}
+				t.Fatalf("got %d errs, want %d", got, tc.wantErrs)
+			}
+		})
+	}
+}
+
+// TestValidateMetricsConfiguration table-driven.
+func TestValidateMetricsConfiguration(t *testing.T) {
+	fld := field.NewPath("spec").Child("metrics")
+	enabled := true
+
+	cases := []struct {
+		name     string
+		modify   func(*appsv1alpha1.NIMService)
+		wantErrs int
+	}{
+		{
+			name:     "metrics disabled",
+			modify:   func(ns *appsv1alpha1.NIMService) {},
+			wantErrs: 0,
+		},
+		{
+			name: "enabled empty monitor",
+			modify: func(ns *appsv1alpha1.NIMService) {
+				ns.Spec.Metrics.Enabled = &enabled
+			},
+			wantErrs: 1,
+		},
+		{
+			name: "enabled valid",
+			modify: func(ns *appsv1alpha1.NIMService) {
+				ns.Spec.Metrics.Enabled = &enabled
+				ns.Spec.Metrics.ServiceMonitor.Interval = "30s"
+			},
+			wantErrs: 0,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ns := baseNIMService()
+			tc.modify(ns)
+			errs := validateMetricsConfiguration(&ns.Spec.Metrics, fld)
+			if got := len(errs); got != tc.wantErrs {
+				t.Logf("Validation errors:")
+				for i, err := range errs {
+					t.Logf("  %d: %s", i+1, err.Error())
+				}
+				t.Fatalf("got %d errs, want %d", got, tc.wantErrs)
+			}
+		})
+	}
+}
+
+// TestValidateScaleConfiguration table-driven.
+func TestValidateScaleConfiguration(t *testing.T) {
+	fld := field.NewPath("spec").Child("scale")
+	enabled := true
+
+	cases := []struct {
+		name     string
+		modify   func(*appsv1alpha1.NIMService)
+		wantErrs int
+	}{
+		{"autoscaling disabled", func(ns *appsv1alpha1.NIMService) {}, 0},
+		{"enabled empty HPA", func(ns *appsv1alpha1.NIMService) { ns.Spec.Scale.Enabled = &enabled }, 1},
+		{"enabled valid HPA", func(ns *appsv1alpha1.NIMService) { ns.Spec.Scale.Enabled = &enabled; ns.Spec.Scale.HPA.MaxReplicas = 3 }, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ns := baseNIMService()
+			tc.modify(ns)
+			errs := validateScaleConfiguration(&ns.Spec.Scale, fld)
+			if got := len(errs); got != tc.wantErrs {
+				t.Logf("Validation errors:")
+				for i, err := range errs {
+					t.Logf("  %d: %s", i+1, err.Error())
+				}
+				t.Fatalf("got %d errs, want %d", got, tc.wantErrs)
+			}
+		})
+	}
+}
+
+// TestValidateResourcesConfiguration table-driven.
+func TestValidateResourcesConfiguration(t *testing.T) {
+	fld := field.NewPath("spec").Child("resources")
+
+	cases := []struct {
+		name     string
+		modify   func(*appsv1alpha1.NIMService)
+		wantErrs int
+	}{
+		{"nil resources", func(ns *appsv1alpha1.NIMService) {}, 0},
+		{"with claims", func(ns *appsv1alpha1.NIMService) {
+			ns.Spec.Resources = &corev1.ResourceRequirements{Claims: []corev1.ResourceClaim{{Name: "c1"}}}
+		}, 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ns := baseNIMService()
+			tc.modify(ns)
+			errs := validateResourcesConfiguration(ns.Spec.Resources, fld)
+			if got := len(errs); got != tc.wantErrs {
+				t.Logf("Validation errors:")
+				for i, err := range errs {
+					t.Logf("  %d: %s", i+1, err.Error())
+				}
+				t.Fatalf("got %d errs, want %d", got, tc.wantErrs)
+			}
+		})
+	}
+}
+
+// TestValidateMultiNodeImmutability table-driven.
+func TestValidateMultiNodeImmutability(t *testing.T) {
+	fld := field.NewPath("spec").Child("multiNode")
+	old := baseNIMService()
+	old.Spec.MultiNode = &appsv1alpha1.NimServiceMultiNodeConfig{Size: 1}
+
+	cases := []struct {
+		name     string
+		newObj   *appsv1alpha1.NIMService
+		wantErrs int
+	}{
+		{"unchanged", func() *appsv1alpha1.NIMService {
+			n := baseNIMService()
+			n.Spec.MultiNode = &appsv1alpha1.NimServiceMultiNodeConfig{Size: 1}
+			return n
+		}(), 0},
+		{"changed", func() *appsv1alpha1.NIMService {
+			n := baseNIMService()
+			n.Spec.MultiNode = &appsv1alpha1.NimServiceMultiNodeConfig{Size: 2}
+			return n
+		}(), 1},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			errs := validateMultiNodeImmutability(old, c.newObj, fld)
+			if got := len(errs); got != c.wantErrs {
+				t.Fatalf("got %d errs, want %d", got, c.wantErrs)
+			}
+		})
+	}
+}
+
+// TestValidatePVCImmutability table-driven.
+func TestValidatePVCImmutability(t *testing.T) {
+	fld := field.NewPath("spec").Child("storage").Child("pvc")
+	trueVal := true
+	old := baseNIMService()
+	old.Spec.Storage.PVC = appsv1alpha1.PersistentVolumeClaim{Create: &trueVal, Size: "10Gi"}
+
+	cases := []struct {
+		name     string
+		newObj   *appsv1alpha1.NIMService
+		wantErrs int
+	}{
+		{"no change", func() *appsv1alpha1.NIMService {
+			n := baseNIMService()
+			n.Spec.Storage.PVC = old.Spec.Storage.PVC
+			return n
+		}(), 0},
+		{"changed size", func() *appsv1alpha1.NIMService {
+			n := baseNIMService()
+			n.Spec.Storage.PVC = appsv1alpha1.PersistentVolumeClaim{Create: &trueVal, Size: "20Gi"}
+			return n
+		}(), 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := validatePVCImmutability(old, tc.newObj, fld)
+			if got := len(errs); got != tc.wantErrs {
+				t.Logf("Validation errors:")
+				for i, err := range errs {
+					t.Logf("  %d: %s", i+1, err.Error())
+				}
+				t.Fatalf("got %d errs, want %d", got, tc.wantErrs)
+			}
+		})
+	}
+}

--- a/internal/webhook/apps/v1alpha1/webhook_suite_test.go
+++ b/internal/webhook/apps/v1alpha1/webhook_suite_test.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	appsv1alpha1 "github.com/NVIDIA/k8s-nim-operator/api/apps/v1alpha1"
+	// +kubebuilder:scaffold:imports
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+var (
+	ctx       context.Context
+	cancel    context.CancelFunc
+	k8sClient client.Client
+	cfg       *rest.Config
+	testEnv   *envtest.Environment
+)
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "Webhook Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	ctx, cancel = context.WithCancel(context.TODO())
+
+	var err error
+	err = appsv1alpha1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	// +kubebuilder:scaffold:scheme
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: false,
+
+		WebhookInstallOptions: envtest.WebhookInstallOptions{
+			Paths: []string{filepath.Join("..", "..", "..", "..", "config", "webhook")},
+		},
+	}
+
+	// Retrieve the first found binary directory to allow running tests from IDEs
+	if getFirstFoundEnvTestBinaryDir() != "" {
+		testEnv.BinaryAssetsDirectory = getFirstFoundEnvTestBinaryDir()
+	}
+
+	// cfg is defined in this file globally.
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+
+	// start webhook server using Manager.
+	webhookInstallOptions := &testEnv.WebhookInstallOptions
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme: scheme.Scheme,
+		WebhookServer: webhook.NewServer(webhook.Options{
+			Host:    webhookInstallOptions.LocalServingHost,
+			Port:    webhookInstallOptions.LocalServingPort,
+			CertDir: webhookInstallOptions.LocalServingCertDir,
+		}),
+		LeaderElection: false,
+		Metrics:        metricsserver.Options{BindAddress: "0"},
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	err = SetupNIMCacheWebhookWithManager(mgr)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = SetupNIMServiceWebhookWithManager(mgr)
+	Expect(err).NotTo(HaveOccurred())
+
+	// +kubebuilder:scaffold:webhook
+
+	go func() {
+		defer GinkgoRecover()
+		err = mgr.Start(ctx)
+		Expect(err).NotTo(HaveOccurred())
+	}()
+
+	// wait for the webhook server to get ready.
+	dialer := &net.Dialer{Timeout: time.Second}
+	addrPort := fmt.Sprintf("%s:%d", webhookInstallOptions.LocalServingHost, webhookInstallOptions.LocalServingPort)
+	Eventually(func() error {
+		conn, err := tls.DialWithDialer(dialer, "tcp", addrPort, &tls.Config{InsecureSkipVerify: true})
+		if err != nil {
+			return err
+		}
+
+		return conn.Close()
+	}).Should(Succeed())
+})
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	cancel()
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})
+
+// getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.
+// ENVTEST-based tests depend on specific binaries, usually located in paths set by
+// controller-runtime. When running tests directly (e.g., via an IDE) without using
+// Makefile targets, the 'BinaryAssetsDirectory' must be explicitly configured.
+//
+// This function streamlines the process by finding the required binaries, similar to
+// setting the 'KUBEBUILDER_ASSETS' environment variable. To ensure the binaries are
+// properly set up, run 'make setup-envtest' beforehand.
+func getFirstFoundEnvTestBinaryDir() string {
+	basePath := filepath.Join("..", "..", "..", "..", "bin", "k8s")
+	entries, err := os.ReadDir(basePath)
+	if err != nil {
+		logf.Log.Error(err, "Failed to read directory", "path", basePath)
+		return ""
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			return filepath.Join(basePath, entry.Name())
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
Adds validating admission webhooks (ValidateCreate and ValidateUpdate) with cert-manager TLS integration for both NIMService and NIMCache CRDs and wires them into the Helm chart so they are deployed automatically with the operator.

Webhook and Helm deployment follows the style of https://github.com/Mellanox/network-operator. 

Specification document: https://docs.google.com/document/d/11pir7oqXmDNUB_BrfCnbj7wa8VNbsos43a-jif01C98/edit?usp=sharing

### Key Changes

1. **Webhook Implementations (each file has a helper file)**
   - `internal/webhook/apps/v1alpha1/nimservice_webhook.go`
   - `internal/webhook/apps/v1alpha1/nimcache_webhook.go`  
   Each file defines:  
   * Detailed validation logic in `ValidateCreate` and `ValidateUpdate`.  
   * A no-op `ValidateDelete` stub (required by `admission.CustomValidator`, but never invoked because the webhook is registered for *create* and *update* only).

2. **Controller Wiring**
   - `SetupNIMServiceWebhookWithManager` and `SetupNIMCacheWebhookWithManager` register the validators with the controller-runtime manager.  
   - `main.go` now invokes both `Setup*WebhookWithManager` helpers so the webhooks start with the operator.

3. **Generated Manifests**
   - Running `make manifests` now produces the corresponding `ValidatingWebhookConfiguration` YAML under `config/webhook/`.  
   - Each rule includes `verbs=create;update`; deletion is intentionally excluded.  
   - Paths follow the required pattern (e.g., `/validate-apps-nvidia-com-v1alpha1-nimservice`).

4. **Helm Chart Updates (TLS + Webhook Packaging)**  

* Align the NIM Operator chart (`deployments/helm/k8s-nim-operator/`) with the Network Operator’s admission-controller pattern.  
* **New template:** `templates/admission_controller.yaml`  
  * Generates the webhook `Service`, `ValidatingWebhookConfiguration`, and TLS assets.  
  * Supports two modes, driven by values:  
    * **`useCertManager: true`** – create `Issuer` and `Certificate` resources for self-signed certs.  
    * **`useCertManager: false`** – load a user-supplied `Secret` containing `caCrt`, `tlsCrt`, `tlsKey`.  
  * Entire block gated by `operator.admissionController.enabled`.  
* **`values.yaml` additions**
  ```yaml
  operator:
    admissionController:
      enabled: true          # enable webhooks by default
      useCertManager: true   # toggle between cert-manager or custom certs
      # certificate:
      #   caCrt: |-
      #   tlsCrt: |-
      #   tlsKey: |-
  ```
* **`deployment.yaml` tweaks**
  * Conditionally expose webhook port `9443`.  
  * Mount the `webhook-server-cert` secret at `/tmp/k8s-webhook-server/serving-certs`.  
  * Add `ENABLE_WEBHOOKS=true` env var when `admissionController.enabled` is set.  
* Static Kubebuilder manifests in `config/certmanager` and `config/webhook` remain for local dev (`make manifests && make deploy`).  

5. **RBAC Adjustments**
   - ClusterRole/Role expanded to allow:  
     * Reading `secrets` for TLS  
     * Reading/writing `validatingwebhookconfigurations` to enable certificate patching

6. **Testing & CI**
   - Manual testing with a variety of YAMLS for every specification in the document has been done