### PR TITLE
Fix to handle CR cleanup with foreground propagation

### DIFF
--- a/internal/controller/nemo_entitystore_controller.go
+++ b/internal/controller/nemo_entitystore_controller.go
@@ -132,14 +132,13 @@ func (r *NemoEntitystoreReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		}
 	} else {
 		// The instance is being deleted
+		// Perform platform specific cleanup of resources
+		if err := r.cleanupNemoEntitystore(ctx, NemoEntitystore); err != nil {
+			r.GetEventRecorder().Eventf(NemoEntitystore, corev1.EventTypeNormal, "Delete",
+				"NemoEntitystore %s is being deleted", NemoEntitystore.Name)
+			return ctrl.Result{}, err
+		}
 		if controllerutil.ContainsFinalizer(NemoEntitystore, NemoEntitystoreFinalizer) {
-			// Perform platform specific cleanup of resources
-			if err := r.cleanupNemoEntitystore(ctx, NemoEntitystore); err != nil {
-				r.GetEventRecorder().Eventf(NemoEntitystore, corev1.EventTypeNormal, "Delete",
-					"NemoEntitystore %s in deleted", NemoEntitystore.Name)
-				return ctrl.Result{}, err
-			}
-
 			// Remove finalizer to allow for deletion
 			controllerutil.RemoveFinalizer(NemoEntitystore, NemoEntitystoreFinalizer)
 			if err := r.Update(ctx, NemoEntitystore); err != nil {
@@ -147,8 +146,9 @@ func (r *NemoEntitystoreReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 					"NemoEntitystore %s finalizer removed", NemoEntitystore.Name)
 				return ctrl.Result{}, err
 			}
-			return ctrl.Result{}, nil
 		}
+		// return as the cr is being deleted and GC will cleanup owned objects
+		return ctrl.Result{}, nil
 	}
 
 	// Fetch container orchestrator type

--- a/internal/controller/nemo_guardrail_controller.go
+++ b/internal/controller/nemo_guardrail_controller.go
@@ -133,14 +133,14 @@ func (r *NemoGuardrailReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}
 	} else {
 		// The instance is being deleted
-		if controllerutil.ContainsFinalizer(NemoGuardrail, NemoGuardrailFinalizer) {
-			// Perform platform specific cleanup of resources
-			if err := r.cleanupNemoGuardrail(ctx, NemoGuardrail); err != nil {
-				r.GetEventRecorder().Eventf(NemoGuardrail, corev1.EventTypeNormal, "Delete",
-					"NemoGuardrail %s in deleted", NemoGuardrail.Name)
-				return ctrl.Result{}, err
-			}
+		// Perform platform specific cleanup of resources
+		if err := r.cleanupNemoGuardrail(ctx, NemoGuardrail); err != nil {
+			r.GetEventRecorder().Eventf(NemoGuardrail, corev1.EventTypeNormal, "Delete",
+				"NemoGuardrail %s is being deleted", NemoGuardrail.Name)
+			return ctrl.Result{}, err
+		}
 
+		if controllerutil.ContainsFinalizer(NemoGuardrail, NemoGuardrailFinalizer) {
 			// Remove finalizer to allow for deletion
 			controllerutil.RemoveFinalizer(NemoGuardrail, NemoGuardrailFinalizer)
 			if err := r.Update(ctx, NemoGuardrail); err != nil {
@@ -148,8 +148,9 @@ func (r *NemoGuardrailReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 					"NemoGuardrail %s finalizer removed", NemoGuardrail.Name)
 				return ctrl.Result{}, err
 			}
-			return ctrl.Result{}, nil
 		}
+		// return as the cr is being deleted and GC will cleanup owned objects
+		return ctrl.Result{}, nil
 	}
 
 	// Fetch container orchestrator type

--- a/internal/controller/nemocustomizer_controller.go
+++ b/internal/controller/nemocustomizer_controller.go
@@ -147,14 +147,14 @@ func (r *NemoCustomizerReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		}
 	} else {
 		// The instance is being deleted
-		if controllerutil.ContainsFinalizer(NemoCustomizer, NemoCustomizerFinalizer) {
-			// Perform platform specific cleanup of resources
-			if err := r.cleanupNemoCustomizer(ctx, NemoCustomizer); err != nil {
-				r.GetEventRecorder().Eventf(NemoCustomizer, corev1.EventTypeNormal, "Delete",
-					"NemoCustomizer %s in deleted", NemoCustomizer.Name)
-				return ctrl.Result{}, err
-			}
+		// Perform platform specific cleanup of resources
+		if err := r.cleanupNemoCustomizer(ctx, NemoCustomizer); err != nil {
+			r.GetEventRecorder().Eventf(NemoCustomizer, corev1.EventTypeNormal, "Delete",
+				"NemoCustomizer %s in being deleted", NemoCustomizer.Name)
+			return ctrl.Result{}, err
+		}
 
+		if controllerutil.ContainsFinalizer(NemoCustomizer, NemoCustomizerFinalizer) {
 			// Remove finalizer to allow for deletion
 			controllerutil.RemoveFinalizer(NemoCustomizer, NemoCustomizerFinalizer)
 			if err := r.Update(ctx, NemoCustomizer); err != nil {
@@ -162,8 +162,9 @@ func (r *NemoCustomizerReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 					"NemoCustomizer %s finalizer removed", NemoCustomizer.Name)
 				return ctrl.Result{}, err
 			}
-			return ctrl.Result{}, nil
 		}
+		// return as the cr is being deleted and GC will cleanup owned objects
+		return ctrl.Result{}, nil
 	}
 
 	// Fetch container orchestrator type

--- a/internal/controller/nimbuild_controller.go
+++ b/internal/controller/nimbuild_controller.go
@@ -137,18 +137,18 @@ func (r *NIMBuildReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		}
 	} else {
 		// The instance is being deleted
+		// Perform cleanup of resources
+		if err = r.cleanupNIMBuild(ctx, nimBuild); err != nil {
+			return ctrl.Result{}, err
+		}
 		if controllerutil.ContainsFinalizer(nimBuild, NIMBuildFinalizer) {
-			// Perform cleanup of resources
-			if err = r.cleanupNIMBuild(ctx, nimBuild); err != nil {
-				return ctrl.Result{}, err
-			}
-
 			// Remove finalizer to allow for deletion
 			controllerutil.RemoveFinalizer(nimBuild, NIMBuildFinalizer)
 			if err := r.Update(ctx, nimBuild); err != nil {
 				return ctrl.Result{}, err
 			}
 		}
+		// return as the cr is being deleted and GC will cleanup owned objects
 		return ctrl.Result{}, nil
 	}
 

--- a/internal/controller/nimcache_controller.go
+++ b/internal/controller/nimcache_controller.go
@@ -162,19 +162,20 @@ func (r *NIMCacheReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		}
 	} else {
 		// The instance is being deleted
-		if controllerutil.ContainsFinalizer(nimCache, NIMCacheFinalizer) {
-			// Perform cleanup of resources
-			if err = r.cleanupNIMCache(ctx, nimCache); err != nil {
-				return ctrl.Result{}, err
-			}
+		// Perform cleanup of resources
+		if err = r.cleanupNIMCache(ctx, nimCache); err != nil {
+			return ctrl.Result{}, err
+		}
 
+		if controllerutil.ContainsFinalizer(nimCache, NIMCacheFinalizer) {
 			// Remove finalizer to allow for deletion
 			controllerutil.RemoveFinalizer(nimCache, NIMCacheFinalizer)
 			if err := r.Update(ctx, nimCache); err != nil {
 				return ctrl.Result{}, err
 			}
-			return ctrl.Result{}, nil
 		}
+		// return as the cr is being deleted and GC will cleanup owned objects
+		return ctrl.Result{}, nil
 	}
 
 	// Fetch container orchestrator type

--- a/internal/controller/nimpipeline_controller.go
+++ b/internal/controller/nimpipeline_controller.go
@@ -89,19 +89,20 @@ func (r *NIMPipelineReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		}
 	} else {
 		// The instance is being deleted
-		if controllerutil.ContainsFinalizer(nimPipeline, NIMPipelineFinalizer) {
-			// Perform cleanup of resources
-			if err := r.cleanupNIMPipeline(ctx, nimPipeline); err != nil {
-				return ctrl.Result{}, err
-			}
+		// Perform cleanup of resources
+		if err := r.cleanupNIMPipeline(ctx, nimPipeline); err != nil {
+			return ctrl.Result{}, err
+		}
 
+		if controllerutil.ContainsFinalizer(nimPipeline, NIMPipelineFinalizer) {
 			// Remove finalizer to allow for deletion
 			controllerutil.RemoveFinalizer(nimPipeline, NIMPipelineFinalizer)
 			if err := r.Update(ctx, nimPipeline); err != nil {
 				return ctrl.Result{}, err
 			}
-			return ctrl.Result{}, nil
 		}
+		// return as the cr is being deleted and GC will cleanup owned objects
+		return ctrl.Result{}, nil
 	}
 
 	// Handle nim-cache reconciliation

--- a/internal/controller/nimservice_controller.go
+++ b/internal/controller/nimservice_controller.go
@@ -144,14 +144,14 @@ func (r *NIMServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		}
 	} else {
 		// The instance is being deleted
-		if controllerutil.ContainsFinalizer(nimService, NIMServiceFinalizer) {
-			// Perform platform specific cleanup of resources
-			if err := r.Platform.Delete(ctx, r, nimService); err != nil {
-				r.GetEventRecorder().Eventf(nimService, corev1.EventTypeNormal, "Delete",
-					"NIMService %s in deleted", nimService.Name)
-				return ctrl.Result{}, err
-			}
+		// Perform platform specific cleanup of resources
+		if err := r.Platform.Delete(ctx, r, nimService); err != nil {
+			r.GetEventRecorder().Eventf(nimService, corev1.EventTypeNormal, "Delete",
+				"NIMService %s is being deleted", nimService.Name)
+			return ctrl.Result{}, err
+		}
 
+		if controllerutil.ContainsFinalizer(nimService, NIMServiceFinalizer) {
 			// Remove finalizer to allow for deletion
 			controllerutil.RemoveFinalizer(nimService, NIMServiceFinalizer)
 			if err := r.Update(ctx, nimService); err != nil {
@@ -159,8 +159,9 @@ func (r *NIMServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 					"NIMService %s finalizer removed", nimService.Name)
 				return ctrl.Result{}, err
 			}
-			return ctrl.Result{}, nil
 		}
+		// return as the cr is being deleted and GC will cleanup owned objects
+		return ctrl.Result{}, nil
 	}
 
 	// Fetch container orchestrator type


### PR DESCRIPTION
* Handle custom cleanup irrespective of finalizer is set or not
* Remove custom finalizer if present
* Avoid further reconciliation when the object is being deleted