### PR TITLE
Configuring OLM Deployment for Validating Admission Webhooks (for NIMService and NIMCache) + bundle.Dockerfile version bug fix

### DIFF
--- a/bundle/manifests/k8s-nim-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/k8s-nim-operator.clusterserviceversion.yaml
@@ -1381,14 +1381,7 @@ spec:
                       - '--leader-elect'
                     command:
                       - /manager
-                    env:
-                      - name: WATCH_NAMESPACE
-                      - name: OPERATOR_NAMESPACE
-                        valueFrom:
-                          fieldRef:
-                            apiVersion: v1
-                            fieldPath: metadata.namespace
-                    image: 'ghcr.io/nvidia/k8s-nim-operator:main'
+clear                    image: 'ghcr.io/nvidia/k8s-nim-operator:main'
                     imagePullPolicy: Always
                     livenessProbe:
                       failureThreshold: 3
@@ -1445,3 +1438,45 @@ spec:
       supported: false
     - type: AllNamespaces
       supported: true
+  webhookdefinitions:
+  - type: ValidatingAdmissionWebhook
+    admissionReviewVersions:
+      - v1
+    containerPort: 9443
+    targetPort: 9443          
+    deploymentName: k8s-nim-operator
+    failurePolicy: Fail
+    generateName: vnimcache-v1alpha1.kb.io
+    rules:
+      - apiGroups:
+          - apps.nvidia.com
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - nimcaches
+    sideEffects: None
+    webhookPath: /validate-apps-nvidia-com-v1alpha1-nimcache
+  - type: ValidatingAdmissionWebhook
+    admissionReviewVersions:
+      - v1
+    containerPort: 9443  
+    targetPort: 9443 
+    deploymentName: k8s-nim-operator
+    failurePolicy: Fail
+    generateName: vnimservice-v1alpha1.kb.io
+    rules:
+      - apiGroups:
+          - apps.nvidia.com
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - nimservices
+    sideEffects: None
+    webhookPath: /validate-apps-nvidia-com-v1alpha1-nimservice
+

--- a/deployments/container/bundle.Dockerfile
+++ b/deployments/container/bundle.Dockerfile
@@ -22,6 +22,6 @@ LABEL com.redhat.delivery.operator.bundle=true
 LABEL com.redhat.delivery.backport=false
 LABEL vsc-ref=${GIT_COMMIT}
 
-COPY bundle/${VERSION}/manifests /manifests/
-COPY bundle/${VERSION}/metadata /metadata/
+COPY bundle/manifests            /manifests/
+COPY bundle/metadata             /metadata/
 COPY bundle/tests/scorecard /tests/scorecard/


### PR DESCRIPTION
### **Summary**

Updates `bundle/manifests/k8s-nim-operator.clusterserviceversion.yaml` with `webhookdefinitions` and adds `ENABLE_WEBHOOKS` as a secret in the CSV's env. 

Updates `deployments/container/bundle.Dockerfile` to remove version number to fix building bundle errors.

```
COPY bundle/manifests            /manifests/
COPY bundle/metadata             /metadata/
```

### **Verification**

Verified that webhook secret exists: 
```
> kubectl -n nim-operator get secrets

NAME                            TYPE                DATA   AGE
k8s-nim-operator-service-cert   kubernetes.io/tls   3      8m18s 

> kubectl -n nim-operator get secret k8s-nim-operator-service-cert -o yaml | \
yq '{
  "name": .metadata.name,
  "tlsKey": (.data."tls.key" != null),
  "tlsCrt": (.data."tls.crt" != null)
}'

name: k8s-nim-operator-service-cert
tlsKey: true
tlsCrt: true
```
And that the secret is mounted in the operator at: 
```
> kubectl -n nim-operator describe pod k8s-nim-operator-589b95d5c5-bwgzc

Containers:
  <other content> 
  manager
    Mounts:
      /apiserver.local.config/certificates from apiservice-cert (rw)
      /tmp/k8s-webhook-server/serving-certs from webhook-cert (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-hkrks (ro)
Volumes:
  apiservice-cert:
    Type:        Secret (a volume populated by a Secret)
    SecretName:  k8s-nim-operator-service-cert
    Optional:    false
  webhook-cert:
    Type:        Secret (a volume populated by a Secret)
    SecretName:  k8s-nim-operator-service-cert
    Optional:    false
```


Updated specs document: https://docs.google.com/document/d/11pir7oqXmDNUB_BrfCnbj7wa8VNbsos43a-jif01C98/edit?tab=t.tl2rv9t8yoz1#heading=h.7f4p8ydi9p3v