### PR TITLE
validate version value for attributeSelectors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ toolchain go1.24.1
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/NVIDIA/k8s-test-infra v0.0.0-20240806103558-2d7411125519
+	github.com/blang/semver/v4 v4.0.0
 	github.com/go-git/go-git/v5 v5.12.0
 	github.com/go-logr/logr v1.4.2
 	github.com/google/cel-go v0.23.2
@@ -60,7 +61,6 @@ require (
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/aws/aws-sdk-go v1.55.6 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/blendle/zapdriver v1.3.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/internal/webhook/apps/v1alpha1/nimservice_webhook_validation_helper.go
+++ b/internal/webhook/apps/v1alpha1/nimservice_webhook_validation_helper.go
@@ -28,7 +28,7 @@ import (
 	apiresource "k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
-	utilversion "k8s.io/apimachinery/pkg/util/version"
+	"github.com/blang/semver/v4"
 
 	appsv1alpha1 "github.com/NVIDIA/k8s-nim-operator/api/apps/v1alpha1"
 	"github.com/NVIDIA/k8s-nim-operator/internal/k8sutil"
@@ -311,9 +311,9 @@ func validateDRADeviceAttributeSelectorValue(attribute *appsv1alpha1.DRADeviceAt
 	}
 
 	if attribute.VersionValue != nil {
-		_, err := utilversion.ParseSemantic(*attribute.VersionValue)
+		_, err := semver.Parse(*attribute.VersionValue)
 		if err != nil {
-			errList = append(errList, field.Invalid(fldPath, attribute.VersionValue, "must be a valid semantic version"))
+			errList = append(errList, field.Invalid(fldPath, attribute.VersionValue, fmt.Sprintf("must be a valid semantic version: %v", err)))
 		}
 	}
 	return errList

--- a/internal/webhook/apps/v1alpha1/nimservice_webhook_validation_helper_test.go
+++ b/internal/webhook/apps/v1alpha1/nimservice_webhook_validation_helper_test.go
@@ -594,7 +594,7 @@ func TestValidateDRAResourcesConfiguration(t *testing.T) {
 									Key: "driver-version",
 									Op:  appsv1alpha1.DRADeviceAttributeSelectorOpEqual,
 									Value: &appsv1alpha1.DRADeviceAttributeSelectorValue{
-										VersionValue: ptr.To("not-a-version"),
+										VersionValue: ptr.To("550.127.08"),
 									},
 								},
 							},
@@ -604,7 +604,7 @@ func TestValidateDRAResourcesConfiguration(t *testing.T) {
 			},
 			k8sVersion:  "v1.34.0",
 			wantErrs:    1,
-			wantErrMsgs: []string{"spec.draResources[0].claimCreationSpec.devices[0].attributeSelectors[0].value: Invalid value: \"not-a-version\": must be a valid semantic version"},
+			wantErrMsgs: []string{"spec.draResources[0].claimCreationSpec.devices[0].attributeSelectors[0].value: Invalid value: \"550.127.08\": must be a valid semantic version: Patch number must not contain leading zeroes \"08\""},
 		},
 		{
 			name: "claimCreationSpec with invalid quantity selector - invalid op",


### PR DESCRIPTION
Sample draResources snippet:
```
  draResources:
  - claimCreationSpec:
      devices:
      - name: gpu
        deviceClassName: gpu.nvidia.com
        driverName: gpu.nvidia.com
        attributeSelectors:
        - key: driverVersion
          op: GreaterThanOrEqual
          value:
            versionValue: "550.127.08"
```
* example error with webhook enabled:
```
Error from server (Forbidden): error when creating "autocreateclaim.yaml": admission webhook "vnimservice-v1alpha1.kb.io" denied the request: nimservice.spec.draResources[0].claimCreationSpec.devices[0].attributeSelectors[1].value: Invalid value: "550.127.08": must be a valid semantic version: Patch number must not contain leading zeroes "08"
```

* example nimservice status with webhook disabled:
```
Status:
  Conditions:
    Last Transition Time:  2025-08-27T18:34:39Z
    Message:               
    Reason:                Failed
    Status:                False
    Type:                  Ready
    Last Transition Time:  2025-08-27T18:34:39Z
    Message:               spec.draResources[0].claimCreationSpec.devices[0].attributeSelectors[1].value.versionValue.version: invalid version "550.127.08": Patch number must not contain leading zeroes "08"
    Reason:                DRAResourcesUnsupported
    Status:                True
    Type:                  Failed
  State:                   Failed
```