### PR TITLE
Updating tag for k8s-operator-libs for crd-apply-tool

### DIFF
--- a/deployments/container/Dockerfile
+++ b/deployments/container/Dockerfile
@@ -34,7 +34,7 @@ RUN git clone https://github.com/NVIDIA/k8s-operator-libs.git
 WORKDIR /utils/k8s-operator-libs
 
 #Checkout the version of the k8s-operator-libs repo that is compatible with the current version of the NIM Operator
-RUN git checkout 7d667fbaa7ac8fb02196987eb65296856e2dd564
+RUN git checkout c80af13d73e36e0eedbe9b712efa85cccb64213a
 
 #Build the crd-apply-tool
 RUN go build -o crd-apply-tool cmd/apply-crds/main.go


### PR DESCRIPTION
- Fix for vulernability https://pkg.go.dev/vuln/GO-2025-3488

- Updating tag for k8s-operator-libs updates golang.org/x/oauth2 to 0.27.0

Pulse scanner output
```
✔️	Vulnerability report received:
		 0 Critical
		 0 High
		 0 Medium
		 0 Low
		 8 Negligible
		 0 Unknown
✔️	License report

Global Content Checks. Policy is applied to all scans as part of Product Security Guidance
✔️	Policy evaluation passed

    0 go
    0 stop
    0 warn
    +------------+------+---------+-----------------+--------------+---------------------+
    | GateAction | Gate | Trigger | Additional Info | Check Output | Inherited from Base |
    +------------+------+---------+-----------------+--------------+---------------------+
    +------------+------+---------+-----------------+--------------+---------------------+

Scan completed!
Generating reports took: 125 seconds
✔️	successfully created report components for image.
```