### PR TITLE
Tidied up redundant code in nimservice_webhook.go and nimcache_webhook.go

### DIFF
--- a/internal/webhook/apps/v1alpha1/nimcache_webhook.go
+++ b/internal/webhook/apps/v1alpha1/nimcache_webhook.go
@@ -82,17 +82,6 @@ func (v *NIMCacheCustomValidator) ValidateCreate(_ context.Context, obj runtime.
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type NIMCache.
 // Check immutable fields haven't changed, validate transitions between states, ensure updates don't break existing functionality.
 func (v *NIMCacheCustomValidator) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
-	nimcache, ok := newObj.(*appsv1alpha1.NIMCache)
-	if !ok {
-		return nil, fmt.Errorf("expected a NIMCache object for the newObj but got %T", newObj)
-	}
-	nimcachelog.V(4).Info("Validation for NIMCache upon update", "name", nimcache.GetName())
-
-	fldPath := field.NewPath("nimcache").Child("spec")
-
-	// Begin by validating the new spec structurally.
-	warningList, errList := validateNIMCacheSpec(&nimcache.Spec, fldPath)
-
 	oldNIMCache, ok := oldObj.(*appsv1alpha1.NIMCache)
 	if !ok {
 		return nil, fmt.Errorf("expected a NIMCache object for oldObj but got %T", oldObj)
@@ -101,6 +90,12 @@ func (v *NIMCacheCustomValidator) ValidateUpdate(_ context.Context, oldObj, newO
 	if !ok {
 		return nil, fmt.Errorf("expected a NIMCache object for newObj but got %T", newObj)
 	}
+	nimcachelog.V(4).Info("Validation for NIMCache upon update", "name", newNIMCache.GetName())
+
+	fldPath := field.NewPath("nimcache").Child("spec")
+
+	// Begin by validating the new spec structurally.
+	warningList, errList := validateNIMCacheSpec(&newNIMCache.Spec, fldPath)
 
 	// Append immutability errors after structural checks.
 	wList, eList := validateImmutableNIMCacheSpec(oldNIMCache, newNIMCache, field.NewPath("nimcache"))

--- a/internal/webhook/apps/v1alpha1/nimservice_webhook.go
+++ b/internal/webhook/apps/v1alpha1/nimservice_webhook.go
@@ -106,19 +106,6 @@ func (v *NIMServiceCustomValidator) ValidateCreate(_ context.Context, obj runtim
 
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type NIMService.
 func (v *NIMServiceCustomValidator) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
-	nimservice, ok := newObj.(*appsv1alpha1.NIMService)
-	if !ok {
-		return nil, fmt.Errorf("expected a NIMService object for the newObj but got %T", newObj)
-	}
-	nimservicelog.V(4).Info("Validation for NIMService upon update", "name", nimservice.GetName())
-
-	fldPath := field.NewPath("nimservice").Child("spec")
-	// Start with structural validation to ensure the updated object is well formed.
-	warningList, errList := validateNIMServiceSpec(&nimservice.Spec, fldPath, v.k8sVersion)
-
-	// All fields of NIMService.Spec are mutable, except for:
-	// - Spec.MultiNode
-	// - If PVC has been created with PVC.Create = true, reject any updates to any fields of PVC object
 	oldNIMService, ok := oldObj.(*appsv1alpha1.NIMService)
 	if !ok {
 		return nil, fmt.Errorf("expected a NIMService object for oldObj but got %T", oldObj)
@@ -127,6 +114,11 @@ func (v *NIMServiceCustomValidator) ValidateUpdate(_ context.Context, oldObj, ne
 	if !ok {
 		return nil, fmt.Errorf("expected a NIMService object for newObj but got %T", newObj)
 	}
+	nimservicelog.V(4).Info("Validation for NIMService upon update", "name", newNIMService.GetName())
+
+	fldPath := field.NewPath("nimservice").Child("spec")
+	// Start with structural validation to ensure the updated object is well formed.
+	warningList, errList := validateNIMServiceSpec(&newNIMService.Spec, fldPath, v.k8sVersion)
 
 	wList, eList := validateMultiNodeImmutability(oldNIMService, newNIMService, field.NewPath("spec").Child("multiNode"))
 	warningList = append(warningList, wList...)


### PR DESCRIPTION
Cleaned up duplicate creation and assignment of `newObj.(*appsv1alpha1.NIMService)` and `newObj.(*appsv1alpha1.NIMCache)` in `nimservice_webhook.go` and `nimcache_webhook.go`. 