### PR TITLE
fix nimservice sync issues with deployment status

### DIFF
--- a/internal/controller/platform/standalone/nimservice_test.go
+++ b/internal/controller/platform/standalone/nimservice_test.go
@@ -976,12 +976,35 @@ var _ = Describe("NIMServiceReconciler for a standalone platform", func() {
 			}
 			_ = client.Delete(context.TODO(), deployment)
 		})
+
+		It("Deployment is scaled down", func() {
+			nimServiceKey := types.NamespacedName{Name: nimService.Name, Namespace: nimService.Namespace}
+			deployment := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-nimservice",
+					Namespace: "default",
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: &[]int32{0}[0],
+				},
+			}
+			err := client.Create(context.TODO(), deployment)
+			Expect(err).NotTo(HaveOccurred())
+			msg, ready, err := reconciler.isDeploymentReady(context.TODO(), &nimServiceKey)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ready).To(BeFalse())
+			Expect(msg).To(Equal(fmt.Sprintf("deployment %q is scaled down", deployment.Name)))
+		})
+
 		It("Deployment exceeded in its progress", func() {
 			nimServiceKey := types.NamespacedName{Name: nimService.Name, Namespace: nimService.Namespace}
 			deployment := &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-nimservice",
 					Namespace: "default",
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: &[]int32{1}[0],
 				},
 				Status: appsv1.DeploymentStatus{
 					Conditions: []appsv1.DeploymentCondition{
@@ -996,7 +1019,7 @@ var _ = Describe("NIMServiceReconciler for a standalone platform", func() {
 			Expect(err).NotTo(HaveOccurred())
 			msg, ready, err := reconciler.isDeploymentReady(context.TODO(), &nimServiceKey)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(ready).To(Equal(false))
+			Expect(ready).To(BeFalse())
 			Expect(msg).To(Equal(fmt.Sprintf("deployment %q exceeded its progress deadline", deployment.Name)))
 		})
 
@@ -1018,28 +1041,8 @@ var _ = Describe("NIMServiceReconciler for a standalone platform", func() {
 			Expect(err).NotTo(HaveOccurred())
 			msg, ready, err := reconciler.isDeploymentReady(context.TODO(), &nimServiceKey)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(ready).To(Equal(false))
+			Expect(ready).To(BeFalse())
 			Expect(msg).To(Equal(fmt.Sprintf("Waiting for deployment %q rollout to finish: %d out of %d new replicas have been updated...\n", deployment.Name, deployment.Status.UpdatedReplicas, *deployment.Spec.Replicas)))
-		})
-
-		It("Waiting for deployment rollout to finish: old replicas are pending termination", func() {
-			nimServiceKey := types.NamespacedName{Name: nimService.Name, Namespace: nimService.Namespace}
-			deployment := &appsv1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-nimservice",
-					Namespace: "default",
-				},
-				Status: appsv1.DeploymentStatus{
-					UpdatedReplicas: 1,
-					Replicas:        4,
-				},
-			}
-			err := client.Create(context.TODO(), deployment)
-			Expect(err).NotTo(HaveOccurred())
-			msg, ready, err := reconciler.isDeploymentReady(context.TODO(), &nimServiceKey)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(ready).To(Equal(false))
-			Expect(msg).To(Equal(fmt.Sprintf("Waiting for deployment %q rollout to finish: %d old replicas are pending termination...\n", deployment.Name, deployment.Status.Replicas-deployment.Status.UpdatedReplicas)))
 		})
 
 		It("Waiting for deployment rollout to finish:", func() {
@@ -1048,6 +1051,9 @@ var _ = Describe("NIMServiceReconciler for a standalone platform", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-nimservice",
 					Namespace: "default",
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: &[]int32{4}[0],
 				},
 				Status: appsv1.DeploymentStatus{
 					UpdatedReplicas:   4,
@@ -1058,7 +1064,7 @@ var _ = Describe("NIMServiceReconciler for a standalone platform", func() {
 			Expect(err).NotTo(HaveOccurred())
 			msg, ready, err := reconciler.isDeploymentReady(context.TODO(), &nimServiceKey)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(ready).To(Equal(false))
+			Expect(ready).To(BeFalse())
 			Expect(msg).To(Equal(fmt.Sprintf("Waiting for deployment %q rollout to finish: %d of %d updated replicas are available...\n", deployment.Name, deployment.Status.AvailableReplicas, deployment.Status.UpdatedReplicas)))
 		})
 
@@ -1069,6 +1075,9 @@ var _ = Describe("NIMServiceReconciler for a standalone platform", func() {
 					Name:      "test-nimservice",
 					Namespace: "default",
 				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: &[]int32{4}[0],
+				},
 				Status: appsv1.DeploymentStatus{
 					UpdatedReplicas:   4,
 					AvailableReplicas: 4,
@@ -1078,7 +1087,7 @@ var _ = Describe("NIMServiceReconciler for a standalone platform", func() {
 			Expect(err).NotTo(HaveOccurred())
 			msg, ready, err := reconciler.isDeploymentReady(context.TODO(), &nimServiceKey)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(ready).To(Equal(true))
+			Expect(ready).To(BeTrue())
 			Expect(msg).To(Equal(fmt.Sprintf("deployment %q successfully rolled out\n", deployment.Name)))
 		})
 	})


### PR DESCRIPTION
Fixes log spew from https://github.com/NVIDIA/k8s-nim-operator/issues/710

* When NIMService deployment is scaled down to 0, this change marks the NIMService status as NotReady
* Increased log verbosity for warning messages