### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/code_scanning.yml
+++ b/.github/workflows/code_scanning.yml
@@ -33,7 +33,7 @@ jobs:
       packages: read
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3
       with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -34,7 +34,7 @@ jobs:
       statuses: write
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         
       - name: Calculate build vars
         id: vars
@@ -52,7 +52,7 @@ jobs:
           holodeck_config: "test/e2e/infra/aws.yml"
 
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GOLANG_VERSION }}
 
@@ -75,7 +75,7 @@ jobs:
 
       - name: Archive test logs
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: e2e-test-logs
           path: ./e2e_logs/
@@ -84,7 +84,7 @@ jobs:
      # This makes the result appear on the merged commit's Checks tab
       - name: Report status on merged commit
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             await github.rest.checks.create({

--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -28,7 +28,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       name: Checkout code
     - name: Get Golang version
       id: vars
@@ -36,7 +36,7 @@ jobs:
         GOLANG_VERSION=$(./hack/golang-version.sh)
         echo "GOLANG_VERSION=${GOLANG_VERSION##GOLANG_VERSION := }" >> $GITHUB_ENV
     - name: Install Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: ${{ env.GOLANG_VERSION }}
     - name: Lint
@@ -66,14 +66,14 @@ jobs:
       id-token: write
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Get Golang version
       id: vars
       run: |
         GOLANG_VERSION=$(./hack/golang-version.sh)
         echo "GOLANG_VERSION=${GOLANG_VERSION##GOLANG_VERSION ?= }" >> $GITHUB_ENV
     - name: Install Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: ${{ env.GOLANG_VERSION }}
     - name: Setup Go Proxy
@@ -92,14 +92,14 @@ jobs:
       id-token: write
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Get Golang version
       id: vars
       run: |
         GOLANG_VERSION=$(./hack/golang-version.sh)
         echo "GOLANG_VERSION=${GOLANG_VERSION##GOLANG_VERSION ?= }" >> $GITHUB_ENV
     - name: Install Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: ${{ env.GOLANG_VERSION }}
     - name: Setup Go Proxy

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -11,7 +11,7 @@ jobs:
   lint-test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       name: Checkout code
     - name: Set up Helm
       uses: azure/setup-helm@v4.2.0

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -30,7 +30,7 @@ jobs:
       id-token: write
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         name: Check out code
       - name: Calculate build vars
         id: vars
@@ -80,7 +80,7 @@ jobs:
       id-token: write
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         name: Check out code
       - name: Calculate build vars
         id: vars
@@ -131,7 +131,7 @@ jobs:
       packages: write
     needs: [build-image-amd64, build-image-arm64]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         name: Check out code
       - name: Calculate build vars
         id: vars
@@ -179,7 +179,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-image-multi-arch
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         name: Check out code
       - name: Calculate build vars
         id: vars


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/checkout` | [`v4`](https://github.com/actions/checkout/releases/tag/v4) | [`v6`](https://github.com/actions/checkout/releases/tag/v6) | [Release](https://github.com/actions/checkout/releases/tag/v6) | code_scanning.yml, e2e.yml, golang.yml, helm.yml, image.yml |
| `actions/github-script` | [`v7`](https://github.com/actions/github-script/releases/tag/v7) | [`v8`](https://github.com/actions/github-script/releases/tag/v8) | [Release](https://github.com/actions/github-script/releases/tag/v8) | e2e.yml |
| `actions/setup-go` | [`v5`](https://github.com/actions/setup-go/releases/tag/v5) | [`v6`](https://github.com/actions/setup-go/releases/tag/v6) | [Release](https://github.com/actions/setup-go/releases/tag/v6) | e2e.yml, golang.yml |
| `actions/upload-artifact` | [`v4`](https://github.com/actions/upload-artifact/releases/tag/v4) | [`v6`](https://github.com/actions/upload-artifact/releases/tag/v6) | [Release](https://github.com/actions/upload-artifact/releases/tag/v6) | e2e.yml |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting March 4th, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: March 4th, 2026
- **Action**: Update to latest action versions that support Node 24

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
