### PR TITLE
Avoid overriding KServe network visibility configuration if it is explicitly set

### DIFF
--- a/config/samples/nim/serving/kserve/standard/llm.yaml
+++ b/config/samples/nim/serving/kserve/standard/llm.yaml
@@ -32,6 +32,8 @@ spec:
   inferencePlatform: kserve
   annotations:
     serving.kserve.io/deploymentMode: 'Standard'
+  labels:
+    networking.kserve.io/visibility: "exposed"
   scale:
     enabled: true
     hpa:

--- a/config/samples/nim/serving/kserve/standard/multi-llm.yaml
+++ b/config/samples/nim/serving/kserve/standard/multi-llm.yaml
@@ -32,6 +32,8 @@ spec:
   inferencePlatform: kserve
   annotations:
     serving.kserve.io/deploymentMode: 'Standard'
+  labels:
+    networking.kserve.io/visibility: "exposed"
   image:
     repository: nvcr.io/nim/nvidia/llm-nim
     tag: "1.12"

--- a/internal/controller/platform/kserve/nimservice.go
+++ b/internal/controller/platform/kserve/nimservice.go
@@ -473,8 +473,12 @@ func (r *NIMServiceReconciler) renderAndSyncInferenceService(ctx context.Context
 	}
 
 	// Sync ingress
-	if !nimService.IsIngressEnabled() {
-		isvcParams.Labels[kserveconstants.NetworkVisibility] = kserveconstants.ClusterLocalVisibility
+	// Only if network visibility is not explicitly configured
+	if _, hasVisibility := isvcParams.Labels[kserveconstants.NetworkVisibility]; !hasVisibility {
+		// User has not explicitly set visibility
+		if !nimService.IsIngressEnabled() {
+			isvcParams.Labels[kserveconstants.NetworkVisibility] = kserveconstants.ClusterLocalVisibility
+		}
 	}
 
 	isvcParams.OrchestratorType = string(r.orchestratorType)


### PR DESCRIPTION
If the label `networking.kserve.io/visibility` is present in the spec of a NIMService for KServe deployment, skip the ingress check and keep the label as is for InferenceService creation.

This allows the user to configure if the service is exposed without setting the unnecessary ingress configurations for KServe deployment.