### PR TITLE
fix: make certConfigMap non-mandatory for proxy in NIMCache

### DIFF
--- a/api/apps/v1alpha1/nimcache_types.go
+++ b/api/apps/v1alpha1/nimcache_types.go
@@ -417,7 +417,7 @@ func (n *NIMCache) GetInitContainers() []corev1.Container {
 
 	var initContainers []corev1.Container
 
-	if n.Spec.Proxy != nil {
+	if n.GetProxyCertConfigMap() != "" {
 		var image string
 		if n.Spec.Source.NGC != nil { // nolint:gocritic
 			image = n.Spec.Source.NGC.ModelPuller


### PR DESCRIPTION
NIMCache.GetInitContainers() was checking `n.Spec.Proxy != nil` before creating the update-ca-certificates init container, but the volumes for custom-ca are only created when `GetProxyCertConfigMap() != ""`. This caused validation errors when proxy was configured without certConfigMap:

  "spec.template.spec.volumes[3].configMap.name: Required value,
  spec.template.spec.initContainers[0].volumeMounts[1].name: Not found: 'custom-ca'"

This is a regression of the fix in PR #714 which was applied to NIMService but the same check was not updated in NIMCache.

Changed the guard condition to match NIMService.GetInitContainers() which correctly uses `n.GetProxyCertConfigMap() != ""`.

Fixes: #700