### PR TITLE
Fix KServe namespace discovery 

### DIFF
--- a/internal/controller/platform/kserve/nimservice_test.go
+++ b/internal/controller/platform/kserve/nimservice_test.go
@@ -410,10 +410,10 @@ var _ = Describe("NIMServiceReconciler for a KServe platform", func() {
 
 		kserveDeployment := &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      utils.KServeControllerName,
+				Name:      "kserve-controller-manager",
 				Namespace: "default",
 				Labels: map[string]string{
-					"app.kubernetes.io/name": utils.KServeControllerName,
+					"control-plane": "kserve-controller-manager",
 				},
 			},
 			Spec: appsv1.DeploymentSpec{
@@ -507,7 +507,7 @@ var _ = Describe("NIMServiceReconciler for a KServe platform", func() {
 		By("delete the KServe Deployment")
 		kserveDeployment := &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      utils.KServeControllerName,
+				Name:      "kserve-controller-manager",
 				Namespace: "default",
 			},
 		}

--- a/internal/utils/kserve.go
+++ b/internal/utils/kserve.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 
 	kservev1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 	kserveconstants "github.com/kserve/kserve/pkg/constants"
@@ -35,7 +36,9 @@ import (
 )
 
 const (
-	KServeControllerName = "kserve-controller-manager"
+	KServeNamespaceEnvVar      = "KSERVE_NAMESPACE"
+	KServeControllerLabel      = "control-plane"
+	KServeControllerLabelValue = "kserve-controller-manager"
 )
 
 func IsKServeStandardDeploymentMode(deploymentMode kserveconstants.DeploymentModeType) bool {
@@ -215,37 +218,87 @@ func newDeployConfig(isvcConfigMap *corev1.ConfigMap) (*kservev1beta1.DeployConf
 	return deployConfig, nil
 }
 
-func getISVCConfigMap(ctx context.Context, k8sReader client.Reader, k8sClient client.Client) (*corev1.ConfigMap, error) {
-	var namespace string
-	// Find the namespace of the KServe controller
+// discoverKServeNamespace finds the KServe controller namespace by listing Deployments across all namespaces
+// with label control-plane=kserve-controller-manager. Returns the namespace of the matched Deployment.
+// Errors if zero or more than one matching Deployments are found.
+func discoverKServeNamespace(ctx context.Context, k8sReader client.Reader) (string, error) {
 	deploymentList := &appsv1.DeploymentList{}
-	if err := k8sReader.List(ctx, deploymentList, client.MatchingLabels{"app.kubernetes.io/name": KServeControllerName}); err != nil {
+	if err := k8sReader.List(ctx, deploymentList, client.MatchingLabels{
+		KServeControllerLabel: KServeControllerLabelValue,
+	}); err != nil {
+		return "", fmt.Errorf("failed to list KServe controller deployments: %w", err)
+	}
+
+	switch len(deploymentList.Items) {
+	case 0:
+		return "", fmt.Errorf("no KServe controller deployment found with label %s=%s; "+
+			"set the %s env var to specify the target KServe namespace explicitly",
+			KServeControllerLabel, KServeControllerLabelValue, KServeNamespaceEnvVar)
+	case 1:
+		return deploymentList.Items[0].Namespace, nil
+	default:
+		return "", fmt.Errorf("expected exactly one KServe controller deployment with label %s=%s, found %d; "+
+			"set the %s env var to specify the target KServe namespace explicitly",
+			KServeControllerLabel, KServeControllerLabelValue, len(deploymentList.Items), KServeNamespaceEnvVar)
+	}
+}
+
+// getISVCConfigMap fetches the inferenceservice-config ConfigMap from the KServe controller namespace using a
+// two-tier strategy:
+//   - Primary: if the KSERVE_NAMESPACE env var is set, fetches the ConfigMap from that namespace directly.
+//     Returns nil if the ConfigMap does not exist there.
+//   - Fallback: if KSERVE_NAMESPACE is unset, discovers the namespace dynamically via discoverKServeNamespace
+//     and fetches the ConfigMap from there. Returns nil if the ConfigMap does not exist in the discovered namespace.
+func getISVCConfigMap(ctx context.Context, k8sReader client.Reader, k8sClient client.Client) (*corev1.ConfigMap, error) {
+	logger := log.FromContext(ctx).WithName("KServe")
+
+	isvcConfigMap := &corev1.ConfigMap{}
+
+	namespace := os.Getenv(KServeNamespaceEnvVar)
+	if namespace != "" {
+		err := k8sClient.Get(ctx, types.NamespacedName{
+			Name:      kserveconstants.InferenceServiceConfigMapName,
+			Namespace: namespace,
+		}, isvcConfigMap)
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				logger.Info("ConfigMap not found in namespace from env var",
+					"configMap", kserveconstants.InferenceServiceConfigMapName, "namespace", namespace)
+				return nil, nil
+			}
+			return nil, fmt.Errorf("failed to get ConfigMap %s from namespace %s: %w", kserveconstants.InferenceServiceConfigMapName, namespace, err)
+		}
+
+		logger.Info("Using KServe namespace from env var",
+			"namespace", namespace)
+		return isvcConfigMap, nil
+	}
+
+	logger.Info("Env var not set, discovering KServe namespace from controller deployment",
+		"envVar", KServeNamespaceEnvVar)
+
+	namespace, err := discoverKServeNamespace(ctx, k8sReader)
+	if err != nil {
 		return nil, err
 	}
-	for _, deployment := range deploymentList.Items {
-		if deployment.GetName() == KServeControllerName {
-			namespace = deployment.Namespace
-			break
-		}
-	}
 
-	if namespace == "" {
-		return nil, fmt.Errorf("failed to find the namespace of KServe Deployment")
-	}
+	logger.Info("Discovered KServe namespace",
+		"namespace", namespace)
 
-	// Get the inferenceservice-config ConfigMap in the namespace
-	isvcConfigMap := &corev1.ConfigMap{}
-	err := k8sClient.Get(ctx,
-		types.NamespacedName{
-			Name:      kserveconstants.InferenceServiceConfigMapName,
-			Namespace: namespace},
-		isvcConfigMap)
+	err = k8sClient.Get(ctx, types.NamespacedName{
+		Name:      kserveconstants.InferenceServiceConfigMapName,
+		Namespace: namespace,
+	}, isvcConfigMap)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
+			logger.Info("ConfigMap not found in discovered namespace",
+				"configMap", kserveconstants.InferenceServiceConfigMapName, "namespace", namespace)
 			return nil, nil
 		}
-		return nil, err
+		return nil, fmt.Errorf("failed to get ConfigMap %s from namespace %s: %w", kserveconstants.InferenceServiceConfigMapName, namespace, err)
 	}
 
+	logger.Info("Using KServe namespace from controller deployment discovery",
+		"namespace", namespace)
 	return isvcConfigMap, nil
 }

--- a/internal/utils/kserve_test.go
+++ b/internal/utils/kserve_test.go
@@ -19,6 +19,7 @@ package utils
 import (
 	"context"
 	"fmt"
+	"os"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -38,6 +39,172 @@ import (
 )
 
 var _ = Describe("KServe Utilities", func() {
+	Describe("getISVCConfigMap namespace discovery", func() {
+		var (
+			client k8sclient.Client
+			scheme *runtime.Scheme
+		)
+
+		BeforeEach(func() {
+			scheme = runtime.NewScheme()
+			Expect(appsv1.AddToScheme(scheme)).To(Succeed())
+			Expect(corev1.AddToScheme(scheme)).To(Succeed())
+
+			os.Unsetenv(KServeNamespaceEnvVar)
+		})
+
+		AfterEach(func() {
+			os.Unsetenv(KServeNamespaceEnvVar)
+		})
+
+		It("should fetch ConfigMap from env var namespace directly", func() {
+			os.Setenv(KServeNamespaceEnvVar, "custom-ns")
+
+			configMap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      kserveconstants.InferenceServiceConfigMapName,
+					Namespace: "custom-ns",
+				},
+				Data: map[string]string{"deploy": `{"defaultDeploymentMode": "Standard"}`},
+			}
+			client = fake.NewClientBuilder().WithScheme(scheme).WithObjects(configMap).Build()
+
+			cm, err := getISVCConfigMap(context.Background(), client, client)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cm).NotTo(BeNil())
+			Expect(cm.Namespace).To(Equal("custom-ns"))
+		})
+
+		It("should discover namespace via deployment when env var is unset", func() {
+			deployment := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kserve-controller-manager",
+					Namespace: "kserve",
+					Labels:    map[string]string{KServeControllerLabel: KServeControllerLabelValue},
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: ptr.To[int32](1),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "kserve"},
+					},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "kserve"}},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{Name: "manager", Image: "kserve:latest"}},
+						},
+					},
+				},
+			}
+			configMap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      kserveconstants.InferenceServiceConfigMapName,
+					Namespace: "kserve",
+				},
+				Data: map[string]string{"deploy": `{"defaultDeploymentMode": "Standard"}`},
+			}
+			client = fake.NewClientBuilder().WithScheme(scheme).WithObjects(deployment, configMap).Build()
+
+			cm, err := getISVCConfigMap(context.Background(), client, client)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cm).NotTo(BeNil())
+			Expect(cm.Namespace).To(Equal("kserve"))
+		})
+
+		It("should return nil when env var is set but ConfigMap not found in that namespace", func() {
+			os.Setenv(KServeNamespaceEnvVar, "wrong-ns")
+
+			client = fake.NewClientBuilder().WithScheme(scheme).Build()
+
+			cm, err := getISVCConfigMap(context.Background(), client, client)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cm).To(BeNil())
+		})
+
+		It("should return nil when ConfigMap not found in discovered namespace", func() {
+			deployment := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kserve-controller-manager",
+					Namespace: "kserve-system",
+					Labels:    map[string]string{KServeControllerLabel: KServeControllerLabelValue},
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: ptr.To[int32](1),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "kserve"},
+					},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "kserve"}},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{Name: "manager", Image: "kserve:latest"}},
+						},
+					},
+				},
+			}
+			client = fake.NewClientBuilder().WithScheme(scheme).WithObjects(deployment).Build()
+
+			cm, err := getISVCConfigMap(context.Background(), client, client)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cm).To(BeNil())
+		})
+
+		It("should return error when no deployment found in fallback", func() {
+			client = fake.NewClientBuilder().WithScheme(scheme).Build()
+
+			_, err := getISVCConfigMap(context.Background(), client, client)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("no KServe controller deployment found"))
+			Expect(err.Error()).To(ContainSubstring(KServeNamespaceEnvVar))
+		})
+
+		It("should return error when multiple deployments found in fallback", func() {
+			dep1 := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kserve-controller-1",
+					Namespace: "ns1",
+					Labels:    map[string]string{KServeControllerLabel: KServeControllerLabelValue},
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: ptr.To[int32](1),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "kserve-1"},
+					},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "kserve-1"}},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{Name: "manager", Image: "kserve:latest"}},
+						},
+					},
+				},
+			}
+			dep2 := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kserve-controller-2",
+					Namespace: "ns2",
+					Labels:    map[string]string{KServeControllerLabel: KServeControllerLabelValue},
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: ptr.To[int32](1),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "kserve-2"},
+					},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "kserve-2"}},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{Name: "manager", Image: "kserve:latest"}},
+						},
+					},
+				},
+			}
+			client = fake.NewClientBuilder().WithScheme(scheme).WithObjects(dep1, dep2).Build()
+
+			_, err := getISVCConfigMap(context.Background(), client, client)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("expected exactly one"))
+			Expect(err.Error()).To(ContainSubstring("found 2"))
+			Expect(err.Error()).To(ContainSubstring(KServeNamespaceEnvVar))
+		})
+	})
+
 	Describe("Get Deployment Mode", func() {
 		var (
 			client k8sclient.Client
@@ -46,19 +213,17 @@ var _ = Describe("KServe Utilities", func() {
 
 		namespace := "default"
 
-		var kserveDeployment *appsv1.Deployment
 		var isvcConfig *corev1.ConfigMap
 
 		isvcName := "test-isvc"
 
-		// Helper function to create a fresh KServe deployment for isolated tests
 		createKServeDeployment := func() *appsv1.Deployment {
 			return &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      KServeControllerName,
+					Name:      "kserve-controller-manager",
 					Namespace: namespace,
 					Labels: map[string]string{
-						"app.kubernetes.io/name": KServeControllerName,
+						KServeControllerLabel: KServeControllerLabelValue,
 					},
 				},
 				Spec: appsv1.DeploymentSpec{
@@ -98,45 +263,11 @@ var _ = Describe("KServe Utilities", func() {
 			Expect(corev1.AddToScheme(scheme)).To(Succeed())
 			Expect(kservev1beta1.AddToScheme(scheme)).To(Succeed())
 
+			os.Setenv(KServeNamespaceEnvVar, namespace)
+
 			client = fake.NewClientBuilder().WithScheme(scheme).Build()
 
-			kserveDeployment = &appsv1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      KServeControllerName,
-					Namespace: namespace,
-					Labels: map[string]string{
-						"app.kubernetes.io/name": KServeControllerName,
-					},
-				},
-				Spec: appsv1.DeploymentSpec{
-					Replicas: ptr.To[int32](1),
-					Selector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{
-							"app": "nim-test-kserve",
-						},
-					},
-					Template: corev1.PodTemplateSpec{
-						ObjectMeta: metav1.ObjectMeta{
-							Labels: map[string]string{
-								"app": "nim-test-kserve",
-							},
-						},
-						Spec: corev1.PodSpec{
-							Containers: []corev1.Container{
-								{
-									Name:  "nim-test-kserve-container",
-									Image: "nim-test-kserve-image",
-									Ports: []corev1.ContainerPort{
-										{
-											ContainerPort: 80,
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			}
+			kserveDeployment := createKServeDeployment()
 			Expect(client.Create(context.Background(), kserveDeployment)).To(Succeed())
 
 			isvcConfig = &corev1.ConfigMap{
@@ -152,6 +283,8 @@ var _ = Describe("KServe Utilities", func() {
 		})
 
 		AfterEach(func() {
+			os.Unsetenv(KServeNamespaceEnvVar)
+
 			By("delete the KServe Deployment")
 			Expect(client.DeleteAllOf(context.Background(), &appsv1.Deployment{})).To(Succeed())
 
@@ -364,19 +497,19 @@ var _ = Describe("KServe Utilities", func() {
 				Expect(err.Error()).To(ContainSubstring("invalid deployment mode"))
 			})
 
-			It("should return error when KServe deployment not found", func() {
+			It("should return error when KServe namespace cannot be discovered", func() {
+				os.Unsetenv(KServeNamespaceEnvVar)
 				isolatedClient := fake.NewClientBuilder().WithScheme(scheme).Build()
-				// Don't create KServe deployment
 
 				_, err := GetKServeDeploymentMode(context.Background(), isolatedClient, isolatedClient, nil, nil)
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("failed to find the namespace of KServe Deployment"))
+				Expect(err.Error()).To(ContainSubstring("no KServe controller deployment found"))
+				Expect(err.Error()).To(ContainSubstring(KServeNamespaceEnvVar))
 			})
 
 			It("should use annotation when ConfigMap doesn't exist", func() {
 				isolatedClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 				Expect(isolatedClient.Create(context.Background(), createKServeDeployment())).To(Succeed())
-				// Don't create ConfigMap
 
 				mode, err := GetKServeDeploymentMode(context.Background(), isolatedClient, isolatedClient,
 					map[string]string{kserveconstants.DeploymentMode: string(kserveconstants.Knative)}, nil)
@@ -585,6 +718,18 @@ var _ = Describe("KServe Utilities", func() {
 				// Status = Knative, filtered annotation = LegacyServerless, config = Standard
 				// Result should be Knative (status wins)
 				Expect(mode).To(Equal(kserveconstants.Knative))
+			})
+		})
+
+		Describe("Env var set but ConfigMap missing", func() {
+			It("should use default deployment mode when env var namespace has no ConfigMap", func() {
+				os.Setenv(KServeNamespaceEnvVar, "wrong-ns")
+
+				isolatedClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+				mode, err := GetKServeDeploymentMode(context.Background(), isolatedClient, isolatedClient, nil, nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(mode).To(Equal(kserveconstants.DefaultDeployment))
 			})
 		})
 	})


### PR DESCRIPTION
Fixes an issue where creating a NIMService fails with:                                                                                                                                                   
 ```
admission webhook "vnimservice-v1alpha1.kb.io" denied the request:
  nimservice.spec: Internal error: failed to determine KServe deployment mode:                                                                                                                             
  failed to find the namespace of KServe Deployment  
```
The operator was looking for KServe's controller Deployment using label `app.kubernetes.io/name=kserve-controller-manager`, then using the namespace of the Deployment to retrieve the ConfigMap `inferenceservice-config`. But, the label was recently modified to `app.kubernetes.io/name=kserve` instead, causing the lookup to fail.


This PR:
  - Switch to the `control-plane=kserve-controller-manager` label, which is part of KServe Controller Deployment's `spec.selector.matchLabels` and is not supposed to be changed or overridden by kustomize.                           
  - Implement a two-tier strategy for locating the `inferenceservice-config` ConfigMap:
    - Primary: if the `KSERVE_NAMESPACE` env var is set, fetch the ConfigMap from that namespace directly. Return nil gracefully if not found.                                                               
    - Fallback: if `KSERVE_NAMESPACE` is unset, discover the namespace dynamically by listing Deployments with label `control-plane=kserve-controller-manager`. Expects exactly one match; errors with guidance to set `KSERVE_NAMESPACE` if multiple are found.                                                                                                                                                          

 Tests:       
  - Verify ConfigMap is fetched from `KSERVE_NAMESPACE` when set and ConfigMap exists                                                                                                                        
  - Verify nil is returned when `KSERVE_NAMESPACE` is set but ConfigMap does not exist                                                                                                                       
  - Verify dynamic discovery via `control-plane=kserve-controller-manager` label works when `KSERVE_NAMESPACE` is unset                                                                                        
  - Verify ConfigMap is fetched from the discovered namespace                                                                                                                                              
  - Verify nil is returned when ConfigMap does not exist in the discovered namespace                                                                                                                       
  - Verify error with `KSERVE_NAMESPACE` hint when no KServe controller deployment is found                                                                                                                  
  - Verify error with `KSERVE_NAMESPACE` hint when multiple KServe controller deployments are found                                                                                                          
  - Verify existing deployment mode detection tests pass with updated label  