### PR TITLE
Bump nvidia/distroless/go in /deployments/container (#847)

### DIFF
--- a/deployments/container/Dockerfile
+++ b/deployments/container/Dockerfile
@@ -44,7 +44,7 @@ RUN git checkout c80af13d73e36e0eedbe9b712efa85cccb64213a
 RUN go build -o crd-apply-tool cmd/apply-crds/main.go
 
 # Use distroless as minimal base image to package the manager binary
-FROM nvcr.io/nvidia/distroless/go:v4.0.4
+FROM nvcr.io/nvidia/distroless/go:v4.0.5
 
 ARG VERSION="unknown"
 


### PR DESCRIPTION
Bumps nvidia/distroless/go from v4.0.4 to v4.0.5.

---
updated-dependencies:
- dependency-name: nvidia/distroless/go dependency-version: v4.0.5 dependency-type: direct:production ...