### PR TITLE
Add priorityClass to NIMService

### DIFF
--- a/api/apps/v1alpha1/nimservice_types.go
+++ b/api/apps/v1alpha1/nimservice_types.go
@@ -125,12 +125,15 @@ type NIMServiceSpec struct {
 	SchedulerName  string        `json:"schedulerName,omitempty"`
 	Metrics        Metrics       `json:"metrics,omitempty"`
 	// +kubebuilder:validation:Minimum=0
-	Replicas         *int32                     `json:"replicas,omitempty"`
-	UserID           *int64                     `json:"userID,omitempty"`
-	GroupID          *int64                     `json:"groupID,omitempty"`
-	RuntimeClassName string                     `json:"runtimeClassName,omitempty"`
-	Proxy            *ProxySpec                 `json:"proxy,omitempty"`
-	MultiNode        *NimServiceMultiNodeConfig `json:"multiNode,omitempty"`
+	Replicas         *int32 `json:"replicas,omitempty"`
+	UserID           *int64 `json:"userID,omitempty"`
+	GroupID          *int64 `json:"groupID,omitempty"`
+	RuntimeClassName string `json:"runtimeClassName,omitempty"`
+	// PriorityClassName is the name of the PriorityClass to assign to pods created by this NIMService.
+	// If set, the Kubernetes scheduler uses the priority for preemption decisions.
+	PriorityClassName string                     `json:"priorityClassName,omitempty"`
+	Proxy             *ProxySpec                 `json:"proxy,omitempty"`
+	MultiNode         *NimServiceMultiNodeConfig `json:"multiNode,omitempty"`
 	// InferencePlatform specifies the inference platform to use for this NIMService.
 	// Valid values are "standalone" (default) and "kserve".
 	// +kubebuilder:validation:Enum=standalone;kserve
@@ -1249,6 +1252,9 @@ func (n *NIMService) GetDeploymentParams() *rendertypes.DeploymentParams {
 	// Set scheduler
 	params.SchedulerName = n.GetSchedulerName()
 
+	// Set priority class
+	params.PriorityClassName = n.GetPriorityClassName()
+
 	// Setup container ports for nimservice
 	params.Ports = []corev1.ContainerPort{
 		{
@@ -1333,6 +1339,7 @@ func (n *NIMService) GetLWSParams() *rendertypes.LeaderWorkerSetParams {
 	params.ServiceAccountName = n.GetServiceAccountName()
 	params.SchedulerName = n.GetSchedulerName()
 	params.RuntimeClassName = n.GetRuntimeClassName()
+	params.PriorityClassName = n.GetPriorityClassName()
 
 	params.InitContainers = n.GetInitContainers()
 	for idx := range params.InitContainers {
@@ -1348,6 +1355,11 @@ func (n *NIMService) GetLWSParams() *rendertypes.LeaderWorkerSetParams {
 // GetSchedulerName returns the scheduler name for the NIMService deployment.
 func (n *NIMService) GetSchedulerName() string {
 	return n.Spec.SchedulerName
+}
+
+// GetPriorityClassName returns the priority class for the NIMService deployment.
+func (n *NIMService) GetPriorityClassName() string {
+	return n.Spec.PriorityClassName
 }
 
 // GetStatefulSetParams returns params to render StatefulSet from templates.
@@ -1393,6 +1405,9 @@ func (n *NIMService) GetStatefulSetParams() *rendertypes.StatefulSetParams {
 
 	// Set runtime class
 	params.RuntimeClassName = n.GetRuntimeClassName()
+
+	// Set priority class
+	params.PriorityClassName = n.GetPriorityClassName()
 	return params
 }
 
@@ -1845,6 +1860,9 @@ func (n *NIMService) GetInferenceServiceParams(
 
 	// Set scheduler
 	params.SchedulerName = n.GetSchedulerName()
+
+	// Set priority class
+	params.PriorityClassName = n.GetPriorityClassName()
 
 	params.Ports = n.GetInferenceServicePorts(deploymentMode)
 

--- a/api/apps/v1alpha1/nimservice_types_test.go
+++ b/api/apps/v1alpha1/nimservice_types_test.go
@@ -999,3 +999,35 @@ func TestStandardModeReplicasWithoutAutoscaling(t *testing.T) {
 		t.Errorf("MaxReplicas = %d, want 3", *params.MaxReplicas)
 	}
 }
+
+func TestGetPriorityClassName(t *testing.T) {
+	nimService := &NIMService{
+		Spec: NIMServiceSpec{
+			PriorityClassName: "gpu-critical",
+			Image: Image{
+				Repository: "test-repo",
+				Tag:        "test-tag",
+			},
+			AuthSecret: "test-secret",
+			Expose: Expose{
+				Service: Service{
+					Port: ptr.To[int32](8000),
+				},
+			},
+		},
+	}
+
+	if got := nimService.GetPriorityClassName(); got != "gpu-critical" {
+		t.Errorf("GetPriorityClassName() = %q, want %q", got, "gpu-critical")
+	}
+
+	deploymentParams := nimService.GetDeploymentParams()
+	if deploymentParams.PriorityClassName != "gpu-critical" {
+		t.Errorf("GetDeploymentParams().PriorityClassName = %q, want %q", deploymentParams.PriorityClassName, "gpu-critical")
+	}
+
+	inferenceParams := nimService.GetInferenceServiceParams("Standard")
+	if inferenceParams.PriorityClassName != "gpu-critical" {
+		t.Errorf("GetInferenceServiceParams().PriorityClassName = %q, want %q", inferenceParams.PriorityClassName, "gpu-critical")
+	}
+}

--- a/bundle/manifests/apps.nvidia.com_nimpipelines.yaml
+++ b/bundle/manifests/apps.nvidia.com_nimpipelines.yaml
@@ -3749,6 +3749,11 @@ spec:
                               type: array
                               x-kubernetes-list-type: atomic
                           type: object
+                        priorityClassName:
+                          description: |-
+                            PriorityClassName is the name of the PriorityClass to assign to pods created by this NIMService.
+                            If set, the Kubernetes scheduler uses the priority for preemption decisions.
+                          type: string
                         proxy:
                           description: ProxySpec defines the proxy configuration for
                             NIMService.

--- a/bundle/manifests/apps.nvidia.com_nimservices.yaml
+++ b/bundle/manifests/apps.nvidia.com_nimservices.yaml
@@ -3627,6 +3627,11 @@ spec:
                     type: array
                     x-kubernetes-list-type: atomic
                 type: object
+              priorityClassName:
+                description: |-
+                  PriorityClassName is the name of the PriorityClass to assign to pods created by this NIMService.
+                  If set, the Kubernetes scheduler uses the priority for preemption decisions.
+                type: string
               proxy:
                 description: ProxySpec defines the proxy configuration for NIMService.
                 properties:

--- a/config/crd/bases/apps.nvidia.com_nimpipelines.yaml
+++ b/config/crd/bases/apps.nvidia.com_nimpipelines.yaml
@@ -3749,6 +3749,11 @@ spec:
                               type: array
                               x-kubernetes-list-type: atomic
                           type: object
+                        priorityClassName:
+                          description: |-
+                            PriorityClassName is the name of the PriorityClass to assign to pods created by this NIMService.
+                            If set, the Kubernetes scheduler uses the priority for preemption decisions.
+                          type: string
                         proxy:
                           description: ProxySpec defines the proxy configuration for
                             NIMService.

--- a/config/crd/bases/apps.nvidia.com_nimservices.yaml
+++ b/config/crd/bases/apps.nvidia.com_nimservices.yaml
@@ -3627,6 +3627,11 @@ spec:
                     type: array
                     x-kubernetes-list-type: atomic
                 type: object
+              priorityClassName:
+                description: |-
+                  PriorityClassName is the name of the PriorityClass to assign to pods created by this NIMService.
+                  If set, the Kubernetes scheduler uses the priority for preemption decisions.
+                type: string
               proxy:
                 description: ProxySpec defines the proxy configuration for NIMService.
                 properties:

--- a/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nimpipelines.yaml
+++ b/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nimpipelines.yaml
@@ -3749,6 +3749,11 @@ spec:
                               type: array
                               x-kubernetes-list-type: atomic
                           type: object
+                        priorityClassName:
+                          description: |-
+                            PriorityClassName is the name of the PriorityClass to assign to pods created by this NIMService.
+                            If set, the Kubernetes scheduler uses the priority for preemption decisions.
+                          type: string
                         proxy:
                           description: ProxySpec defines the proxy configuration for
                             NIMService.

--- a/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nimservices.yaml
+++ b/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nimservices.yaml
@@ -3627,6 +3627,11 @@ spec:
                     type: array
                     x-kubernetes-list-type: atomic
                 type: object
+              priorityClassName:
+                description: |-
+                  PriorityClassName is the name of the PriorityClass to assign to pods created by this NIMService.
+                  If set, the Kubernetes scheduler uses the priority for preemption decisions.
+                type: string
               proxy:
                 description: ProxySpec defines the proxy configuration for NIMService.
                 properties:

--- a/internal/render/types/types.go
+++ b/internal/render/types/types.go
@@ -68,6 +68,7 @@ type DeploymentParams struct {
 	ImagePullSecrets   []string
 	ImagePullPolicy    string
 	SchedulerName      string
+	PriorityClassName  string
 	Volumes            []corev1.Volume
 	VolumeMounts       []corev1.VolumeMount
 	Env                []corev1.EnvVar
@@ -109,6 +110,7 @@ type LeaderWorkerSetParams struct {
 	ImagePullSecrets   []string
 	ImagePullPolicy    string
 	SchedulerName      string
+	PriorityClassName  string
 	WorkerVolumes      []corev1.Volume
 	LeaderVolumes      []corev1.Volume
 	WorkerVolumeMounts []corev1.VolumeMount
@@ -164,6 +166,7 @@ type StatefulSetParams struct {
 	NIMCachePVC        string
 	RuntimeClassName   string
 	OrchestratorType   string
+	PriorityClassName  string
 	InitContainers     []corev1.Container
 }
 
@@ -317,6 +320,7 @@ type InferenceServiceParams struct {
 	ImagePullSecrets   []string
 	ImagePullPolicy    string
 	SchedulerName      string
+	PriorityClassName  string
 	Volumes            []corev1.Volume
 	VolumeMounts       []corev1.VolumeMount
 	Env                []corev1.EnvVar

--- a/manifests/deployment.yaml
+++ b/manifests/deployment.yaml
@@ -38,6 +38,9 @@ spec:
       {{- if .SchedulerName }}
       schedulerName: {{ .SchedulerName }}
       {{- end }}
+      {{- if .PriorityClassName }}
+      priorityClassName: {{ .PriorityClassName }}
+      {{- end }}
       {{- if .Affinity }}
       affinity:
         {{ .Affinity | yaml | nindent 8 }}

--- a/manifests/inferenceservice.yaml
+++ b/manifests/inferenceservice.yaml
@@ -46,6 +46,9 @@ spec:
     {{- if .SchedulerName }}
     schedulerName: {{ .SchedulerName }}
     {{- end }}
+    {{- if .PriorityClassName }}
+    priorityClassName: {{ .PriorityClassName }}
+    {{- end }}
     serviceAccountName: {{ .ServiceAccountName }}
     runtimeClassName: {{ .RuntimeClassName }}
     initContainers:

--- a/manifests/lws.yaml
+++ b/manifests/lws.yaml
@@ -47,6 +47,9 @@ spec:
         {{- if .SchedulerName }}
         schedulerName: {{ .SchedulerName }}
         {{- end }}
+        {{- if .PriorityClassName }}
+        priorityClassName: {{ .PriorityClassName }}
+        {{- end }}
         initContainers:
         {{- range .InitContainers }}
         - name: {{ .Name }}
@@ -241,6 +244,9 @@ spec:
           runAsGroup: {{ .GroupID }}
           fsGroup: {{ .GroupID }}
           {{- end }}
+        {{- if .PriorityClassName }}
+        priorityClassName: {{ .PriorityClassName }}
+        {{- end }}
         initContainers:
         {{- range .InitContainers }}
         - name: {{ .Name }}

--- a/manifests/statefulset.yaml
+++ b/manifests/statefulset.yaml
@@ -24,6 +24,9 @@ spec:
         app: {{ .Name }}
     spec:
       runtimeClassName: {{ .RuntimeClassName }}
+      {{- if .PriorityClassName }}
+      priorityClassName: {{ .PriorityClassName }}
+      {{- end }}
       {{- if .Affinity }}
       affinity:
         {{ .Affinity | yaml | nindent 8 }}


### PR DESCRIPTION
This MR is in response to this [issue](https://github.com/NVIDIA/k8s-nim-operator/issues/731). Essentially, we are trying to ensure the NIMService pods have priority for scheduling by using priority classes.

SOLUTION:

The NIMServiceSpec struct was updated to include a PriorityClassName field. This is passed to GetDeploymentParams(), GetLWSParams(), GetStatefulSetParams(), for the default path and GetInferenceServiceParams() for kserve.

type NIMServiceSpec struct {
	...........
	RuntimeClassName string `json:"runtimeClassName,omitempty"`
	// PriorityClassName is the name of the PriorityClass to assign to pods created by this NIMService.
	// If set, the Kubernetes scheduler uses the specified priority for preemption decisions,
	// ensuring pods are scheduled even when resources (e.g. GPUs) are fully utilised by lower-priority workloads.
	// The referenced PriorityClass must exist in the cluster.
	PriorityClassName string                     `json:"priorityClassName,omitempty"`
	Proxy             *ProxySpec                 `json:"proxy,omitempty"`

func (n *NIMService) GetDeploymentParams() *rendertypes.DeploymentParams {
	............
        params.PriorityClassName = n.GetPriorityClassName()
        

TESTING:

TestGetPriorityClassName builds a minimal NIMService with spec.priorityClassName: gpu-critical and checks that the value is read correctly and passed into both GetDeploymentParams() (standalone) and GetInferenceServiceParams() (KServe). This makes sure the CR field exists and is wired through to the templates.