### PR TITLE
Propagate knative annotations in KServe serverless mode

### DIFF
--- a/api/apps/v1alpha1/nimservice_types.go
+++ b/api/apps/v1alpha1/nimservice_types.go
@@ -538,7 +538,26 @@ func (n *NIMService) GetNIMServiceAnnotations() map[string]string {
 	return standardAnnotations
 }
 
-// GetServiceLabels returns merged labels to apply to NIMService-owned resources.
+// GetInferenceServiceAnnotations returns annotations to apply to KServe InferenceService resources.
+func (n *NIMService) GetInferenceServiceAnnotations() map[string]string {
+	annotations := maps.Clone(n.GetNIMServiceAnnotations())
+	for key, value := range n.GetAnnotations() {
+		if shouldPropagateMetadataAnnotationToInferenceService(key) {
+			if _, exists := annotations[key]; !exists {
+				annotations[key] = value
+			}
+		}
+	}
+	return annotations
+}
+
+func shouldPropagateMetadataAnnotationToInferenceService(key string) bool {
+	return strings.HasPrefix(key, "autoscaling.knative.dev/") ||
+		strings.HasPrefix(key, "serving.knative.dev/") ||
+		strings.HasPrefix(key, "queue.sidecar.serving.knative.dev/")
+}
+
+// GetServiceLabels returns merged labels to apply to the NIMService instance.
 func (n *NIMService) GetServiceLabels() map[string]string {
 	standardLabels := n.GetStandardLabels()
 
@@ -1768,8 +1787,8 @@ func (n *NIMService) GetInferenceServiceParams(
 	params.Name = n.GetName()
 	params.Namespace = n.GetNamespace()
 	params.Labels = n.GetServiceLabels()
-	params.Annotations = n.GetNIMServiceAnnotations()
-	params.PodAnnotations = n.GetNIMServiceAnnotations()
+	params.Annotations = n.GetInferenceServiceAnnotations()
+	params.PodAnnotations = n.GetInferenceServiceAnnotations()
 	delete(params.PodAnnotations, utils.NvidiaAnnotationParentSpecHashKey)
 
 	// Set template spec

--- a/api/apps/v1alpha1/nimservice_types_test.go
+++ b/api/apps/v1alpha1/nimservice_types_test.go
@@ -20,9 +20,11 @@ import (
 	"reflect"
 	"testing"
 
+	kserveconstants "github.com/kserve/kserve/pkg/constants"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
@@ -856,6 +858,65 @@ func TestGetInferenceServiceParams(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestGetInferenceServiceParamsPropagatesKnativeMetadataAnnotations(t *testing.T) {
+	nimService := &NIMService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "nim-models",
+			Annotations: map[string]string{
+				"autoscaling.knative.dev/initial-scale":                  "1",
+				"autoscaling.knative.dev/min-scale":                      "1",
+				"autoscaling.knative.dev/max-scale":                      "5",
+				"serving.knative.dev/progress-deadline":                  "3640s",
+				"serving.knative.dev/rollout-duration":                   "90s",
+				"queue.sidecar.serving.knative.dev/cpu-resource-request": "500m",
+				"example.com/ignored":                                    "true",
+			},
+		},
+		Spec: NIMServiceSpec{
+			Image: Image{
+				Repository: "test-repo",
+				Tag:        "test-tag",
+			},
+			AuthSecret: "test-secret",
+			Annotations: map[string]string{
+				"autoscaling.knative.dev/max-scale": "7",
+			},
+			Expose: Expose{
+				Service: Service{
+					Port: ptr.To[int32](8000),
+				},
+			},
+		},
+	}
+
+	params := nimService.GetInferenceServiceParams(kserveconstants.DeploymentModeType("Knative"))
+
+	expected := map[string]string{
+		"autoscaling.knative.dev/initial-scale":                  "1",
+		"autoscaling.knative.dev/min-scale":                      "1",
+		"autoscaling.knative.dev/max-scale":                      "7",
+		"serving.knative.dev/progress-deadline":                  "3640s",
+		"serving.knative.dev/rollout-duration":                   "90s",
+		"queue.sidecar.serving.knative.dev/cpu-resource-request": "500m",
+	}
+	for key, value := range expected {
+		if params.Annotations[key] != value {
+			t.Errorf("params.Annotations[%q] = %q, want %q", key, params.Annotations[key], value)
+		}
+		if params.PodAnnotations[key] != value {
+			t.Errorf("params.PodAnnotations[%q] = %q, want %q", key, params.PodAnnotations[key], value)
+		}
+	}
+
+	if _, ok := params.Annotations["example.com/ignored"]; ok {
+		t.Errorf("unexpected unrelated metadata annotation propagated to InferenceService annotations")
+	}
+	if _, ok := params.PodAnnotations["example.com/ignored"]; ok {
+		t.Errorf("unexpected unrelated metadata annotation propagated to pod annotations")
 	}
 }
 

--- a/internal/controller/nimservice_controller.go
+++ b/internal/controller/nimservice_controller.go
@@ -293,8 +293,9 @@ func (r *NIMServiceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 							return true
 						}
 
-						// Handle only spec updates
-						return !reflect.DeepEqual(oldNIMService.Spec, newNIMService.Spec)
+						// Handle spec updates and metadata annotation updates that may propagate to child resources.
+						return !reflect.DeepEqual(oldNIMService.Spec, newNIMService.Spec) ||
+							!reflect.DeepEqual(oldNIMService.GetAnnotations(), newNIMService.GetAnnotations())
 					}
 				}
 				// For other types we watch, reconcile them


### PR DESCRIPTION
This PR is in response to this [issue](https://github.com/NVIDIA/k8s-nim-operator/issues/829). Essentially, when deployign with KServe's Knative (serverless) deployment mode, Knative-specific annotations placed on NIMService.metadata.annotations are not propagated end-to-end to the underlying Knative Revision.

SOLUTION:
The code change adds GetInferenceServiceAnnotations() in nimservice_types.go. It starts with the existing service annotations, then selectively copies relevant top-level metadata.annotations onto the generated KServe resources. 

This is propagated in GetInferenceServiceParams():
params.Annotations = n.GetInferenceServiceAnnotations()
params.PodAnnotations = n.GetInferenceServiceAnnotations()

The controller update in nimservice_controller.go was also updated to reconcile for metadata.annotations.

TESTING:
Added a regression test in nimservice_types_test.go. It verifies that Knative annotations from metadata.annotations are propagated, unrelated annotations are ignored, and spec.annotations still wins if the same key exists.
