### PR TITLE
Guard omitted NemoCustomizer training config map

### DIFF
--- a/internal/controller/nemocustomizer_controller.go
+++ b/internal/controller/nemocustomizer_controller.go
@@ -663,7 +663,8 @@ func (r *NemoCustomizerReconciler) addTrainingConfig(ctx context.Context, cfg ma
 	}
 
 	trainingCfg := make(map[string]interface{})
-	if cmName := n.Spec.Training.ConfigMap.Name; cmName != "" {
+	if trainingConfigMap := n.Spec.Training.ConfigMap; trainingConfigMap != nil && trainingConfigMap.Name != "" {
+		cmName := trainingConfigMap.Name
 		trainingRaw, err := k8sutil.GetRawYAMLFromConfigMap(ctx, r.GetClient(), n.GetNamespace(), cmName, "training")
 		if err != nil {
 			return fmt.Errorf("loading training config: %w", err)

--- a/internal/controller/nemocustomizer_controller_test.go
+++ b/internal/controller/nemocustomizer_controller_test.go
@@ -648,6 +648,36 @@ var _ = Describe("NemoCustomizer Controller", func() {
 			Expect(parsed).To(HaveKeyWithValue("mlflow_tracking_url", "http://mlflow-tracking.nemo.svc.cluster.local:80"))
 		})
 
+		It("should create customizer config when training config map is omitted", func() {
+			namespacedName := types.NamespacedName{Name: nemoCustomizer.Name, Namespace: "default"}
+			nemoCustomizer.Spec.Training.ConfigMap = nil
+
+			err := client.Create(context.TODO(), nemoCustomizer)
+			Expect(err).NotTo(HaveOccurred())
+			err = client.Create(context.TODO(), secrets)
+			Expect(err).NotTo(HaveOccurred())
+
+			result, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: namespacedName})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(ctrl.Result{}))
+
+			configMap := &corev1.ConfigMap{}
+			err = client.Get(context.TODO(), namespacedName, configMap)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(configMap.Data).To(HaveKey("config.yaml"))
+
+			var parsed map[string]interface{}
+			err = yaml.Unmarshal([]byte(configMap.Data["config.yaml"]), &parsed)
+			Expect(err).NotTo(HaveOccurred())
+
+			training, ok := parsed["training"].(map[string]interface{})
+			Expect(ok).To(BeTrue(), "expected 'training' to be a map")
+			Expect(training).To(HaveKeyWithValue("image", "nvcr.io/nvidia/nemo-microservices/customizer:25.04"))
+			Expect(training).To(HaveKey("pvc"))
+			Expect(training).To(HaveKey("imagePullSecrets"))
+			Expect(training).To(HaveKeyWithValue("workspace_dir", "/pvc/workspace"))
+		})
+
 		It("should delete HPA when NemoCustomizer is updated", func() {
 			namespacedName := types.NamespacedName{Name: nemoCustomizer.Name, Namespace: "default"}
 			err := client.Create(context.TODO(), nemoCustomizer)


### PR DESCRIPTION
## Summary
- guard the optional `trainingConfig.configMap` before reading its name in `addTrainingConfig`
- keep config rendering working when the training ConfigMap is omitted and rely on the generated training settings
- add a controller regression test that reconciles a `NemoCustomizer` with `trainingConfig.configMap` unset

## Why
`TrainingConfig.ConfigMap` is optional in the API, but the controller unconditionally dereferenced `n.Spec.Training.ConfigMap.Name` while rendering the customizer config. A valid CR that omitted the field could panic reconciliation.

## Validation
- `go test -ldflags "-X github.com/NVIDIA/k8s-dra-driver-gpu/internal/info.version=v25.12.0" ./internal/controller -run TestControllers -ginkgo.focus='NemoCustomizer Controller' -count=1`
