### PR TITLE
Require a single NemoGuardrail config store source

### DIFF
--- a/api/apps/v1alpha1/nemo_guardrails_types.go
+++ b/api/apps/v1alpha1/nemo_guardrails_types.go
@@ -118,7 +118,7 @@ type NIMEndpoint struct {
 
 // GuardrailConfig defines the source where the service config is made available.
 //
-// +kubebuilder:validation:XValidation:rule="!(has(self.configMap) && has(self.pvc))", message="Cannot set both ConfigMap and PVC in ConfigStore"
+// +kubebuilder:validation:XValidation:rule="has(self.configMap) != has(self.pvc)", message="Exactly one of configMap or pvc must be set in ConfigStore"
 type GuardrailConfig struct {
 	ConfigMap *ConfigMapRef          `json:"configMap,omitempty"`
 	PVC       *PersistentVolumeClaim `json:"pvc,omitempty"`
@@ -163,6 +163,18 @@ func (n *NemoGuardrail) GetPVCName(pvc PersistentVolumeClaim) string {
 		pvcName = pvc.Name
 	}
 	return pvcName
+}
+
+// ValidateConfigStore verifies that NemoGuardrail has exactly one config source.
+func (n *NemoGuardrail) ValidateConfigStore() error {
+	hasConfigMap := n.Spec.ConfigStore.ConfigMap != nil
+	hasPVC := n.Spec.ConfigStore.PVC != nil
+
+	if hasConfigMap == hasPVC {
+		return fmt.Errorf("exactly one of spec.configStore.configMap or spec.configStore.pvc must be set")
+	}
+
+	return nil
 }
 
 // GetStandardSelectorLabels returns the standard selector labels for the NemoGuardrail deployment.
@@ -529,33 +541,43 @@ func (n *NemoGuardrail) GetStartupProbe() *corev1.Probe {
 
 // GetVolumes returns volumes for the NemoGuardrail container.
 func (n *NemoGuardrail) GetVolumes() []corev1.Volume {
-	volumes := []corev1.Volume{}
+	if n.ValidateConfigStore() != nil {
+		return []corev1.Volume{}
+	}
+
 	if n.Spec.ConfigStore.ConfigMap != nil {
-		volumes = append(volumes, corev1.Volume{
-			Name: "config-store",
-			VolumeSource: corev1.VolumeSource{
-				ConfigMap: &corev1.ConfigMapVolumeSource{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: n.Spec.ConfigStore.ConfigMap.Name,
+		return []corev1.Volume{
+			{
+				Name: "config-store",
+				VolumeSource: corev1.VolumeSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: n.Spec.ConfigStore.ConfigMap.Name,
+						},
 					},
 				},
 			},
-		})
-	} else {
-		volumes = append(volumes, corev1.Volume{
+		}
+	}
+
+	return []corev1.Volume{
+		{
 			Name: "config-store",
 			VolumeSource: corev1.VolumeSource{
 				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
 					ClaimName: n.Spec.ConfigStore.PVC.Name,
 				},
 			},
-		})
+		},
 	}
-	return volumes
 }
 
 // GetVolumeMounts returns volumes for the NemoGuardrail container.
 func (n *NemoGuardrail) GetVolumeMounts() []corev1.VolumeMount {
+	if n.ValidateConfigStore() != nil {
+		return []corev1.VolumeMount{}
+	}
+
 	volumeMount := corev1.VolumeMount{
 		Name:      "config-store",
 		MountPath: "/config-store",

--- a/api/apps/v1alpha1/nemo_guardrails_types_test.go
+++ b/api/apps/v1alpha1/nemo_guardrails_types_test.go
@@ -1,0 +1,212 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestNemoGuardrailValidateConfigStore(t *testing.T) {
+	tests := []struct {
+		name          string
+		nemoGuardrail *NemoGuardrail
+		wantErr       bool
+	}{
+		{
+			name: "should accept config map if it is the only config source",
+			nemoGuardrail: &NemoGuardrail{
+				Spec: NemoGuardrailSpec{
+					ConfigStore: GuardrailConfig{
+						ConfigMap: &ConfigMapRef{Name: "guardrail-config"},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "should accept pvc if it is the only config source",
+			nemoGuardrail: &NemoGuardrail{
+				Spec: NemoGuardrailSpec{
+					ConfigStore: GuardrailConfig{
+						PVC: &PersistentVolumeClaim{Name: "guardrail-pvc"},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "should reject config store if both config map and pvc are set",
+			nemoGuardrail: &NemoGuardrail{
+				Spec: NemoGuardrailSpec{
+					ConfigStore: GuardrailConfig{
+						ConfigMap: &ConfigMapRef{Name: "guardrail-config"},
+						PVC:       &PersistentVolumeClaim{Name: "guardrail-pvc"},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "should reject config store if both config map and pvc are omitted",
+			nemoGuardrail: &NemoGuardrail{
+				Spec: NemoGuardrailSpec{
+					ConfigStore: GuardrailConfig{},
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.nemoGuardrail.ValidateConfigStore()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateConfigStore() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestNemoGuardrailGetVolumes(t *testing.T) {
+	tests := []struct {
+		name          string
+		nemoGuardrail *NemoGuardrail
+		want          []corev1.Volume
+	}{
+		{
+			name: "should return config map volume if config map is set",
+			nemoGuardrail: &NemoGuardrail{
+				Spec: NemoGuardrailSpec{
+					ConfigStore: GuardrailConfig{
+						ConfigMap: &ConfigMapRef{Name: "guardrail-config"},
+					},
+				},
+			},
+			want: []corev1.Volume{
+				{
+					Name: "config-store",
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "guardrail-config"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "should return pvc volume if pvc is set",
+			nemoGuardrail: &NemoGuardrail{
+				Spec: NemoGuardrailSpec{
+					ConfigStore: GuardrailConfig{
+						PVC: &PersistentVolumeClaim{Name: "guardrail-pvc"},
+					},
+				},
+			},
+			want: []corev1.Volume{
+				{
+					Name: "config-store",
+					VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+							ClaimName: "guardrail-pvc",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "should return no volumes if config store is invalid",
+			nemoGuardrail: &NemoGuardrail{
+				Spec: NemoGuardrailSpec{
+					ConfigStore: GuardrailConfig{},
+				},
+			},
+			want: []corev1.Volume{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.nemoGuardrail.GetVolumes()
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetVolumes() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNemoGuardrailGetVolumeMounts(t *testing.T) {
+	tests := []struct {
+		name          string
+		nemoGuardrail *NemoGuardrail
+		want          []corev1.VolumeMount
+	}{
+		{
+			name: "should return config map mount if config map is set",
+			nemoGuardrail: &NemoGuardrail{
+				Spec: NemoGuardrailSpec{
+					ConfigStore: GuardrailConfig{
+						ConfigMap: &ConfigMapRef{Name: "guardrail-config"},
+					},
+				},
+			},
+			want: []corev1.VolumeMount{
+				{
+					Name:      "config-store",
+					MountPath: "/config-store",
+				},
+			},
+		},
+		{
+			name: "should return pvc mount with default subpath if pvc is set",
+			nemoGuardrail: &NemoGuardrail{
+				Spec: NemoGuardrailSpec{
+					ConfigStore: GuardrailConfig{
+						PVC: &PersistentVolumeClaim{Name: "guardrail-pvc"},
+					},
+				},
+			},
+			want: []corev1.VolumeMount{
+				{
+					Name:      "config-store",
+					MountPath: "/config-store",
+					SubPath:   "guardrails-config-store",
+				},
+			},
+		},
+		{
+			name: "should return no mounts if config store is invalid",
+			nemoGuardrail: &NemoGuardrail{
+				Spec: NemoGuardrailSpec{
+					ConfigStore: GuardrailConfig{},
+				},
+			},
+			want: []corev1.VolumeMount{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.nemoGuardrail.GetVolumeMounts()
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetVolumeMounts() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/config/crd/bases/apps.nvidia.com_nemoguardrails.yaml
+++ b/config/crd/bases/apps.nvidia.com_nemoguardrails.yaml
@@ -1020,8 +1020,8 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-validations:
-                - message: Cannot set both ConfigMap and PVC in ConfigStore
-                  rule: '!(has(self.configMap) && has(self.pvc))'
+                - message: Exactly one of configMap or pvc must be set in ConfigStore
+                  rule: has(self.configMap) != has(self.pvc)
               databaseConfig:
                 description: DatabaseConfig stores the metadata for the guardrail
                   service.

--- a/internal/controller/nemo_guardrail_controller.go
+++ b/internal/controller/nemo_guardrail_controller.go
@@ -310,6 +310,10 @@ func (r *NemoGuardrailReconciler) reconcileNemoGuardrail(ctx context.Context, ne
 
 	renderer := r.GetRenderer()
 
+	if err = nemoGuardrail.ValidateConfigStore(); err != nil {
+		return ctrl.Result{}, err
+	}
+
 	// Sync serviceaccount
 	err = r.renderAndSyncResource(ctx, nemoGuardrail, &renderer, &corev1.ServiceAccount{}, func() (client.Object, error) {
 		return renderer.ServiceAccount(nemoGuardrail.GetServiceAccountParams())

--- a/internal/controller/nemo_guardrail_controller_unit_test.go
+++ b/internal/controller/nemo_guardrail_controller_unit_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	appsv1alpha1 "github.com/NVIDIA/k8s-nim-operator/api/apps/v1alpha1"
+)
+
+func TestReconcileNemoGuardrailRejectsInvalidConfigStore(t *testing.T) {
+	tests := []struct {
+		name          string
+		configStore   appsv1alpha1.GuardrailConfig
+		expectedError string
+	}{
+		{
+			name:          "should reject config store if config sources are omitted",
+			configStore:   appsv1alpha1.GuardrailConfig{},
+			expectedError: "exactly one of spec.configStore.configMap or spec.configStore.pvc must be set",
+		},
+		{
+			name: "should reject config store if both config sources are set",
+			configStore: appsv1alpha1.GuardrailConfig{
+				ConfigMap: &appsv1alpha1.ConfigMapRef{Name: "guardrail-config"},
+				PVC:       &appsv1alpha1.PersistentVolumeClaim{Name: "guardrail-pvc"},
+			},
+			expectedError: "exactly one of spec.configStore.configMap or spec.configStore.pvc must be set",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			if err := appsv1alpha1.AddToScheme(scheme); err != nil {
+				t.Fatalf("AddToScheme() error = %v", err)
+			}
+
+			reconciler := &NemoGuardrailReconciler{
+				Client:   fake.NewClientBuilder().WithScheme(scheme).Build(),
+				scheme:   scheme,
+				recorder: record.NewFakeRecorder(10),
+			}
+
+			nemoGuardrail := &appsv1alpha1.NemoGuardrail{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-nemoguardrail",
+					Namespace: "default",
+				},
+				Spec: appsv1alpha1.NemoGuardrailSpec{
+					ConfigStore: tt.configStore,
+				},
+			}
+
+			_, err := reconciler.reconcileNemoGuardrail(context.Background(), nemoGuardrail)
+			if err == nil {
+				t.Fatal("reconcileNemoGuardrail() error = nil, want non-nil")
+			}
+			if err.Error() != tt.expectedError {
+				t.Fatalf("reconcileNemoGuardrail() error = %q, want %q", err.Error(), tt.expectedError)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- require exactly one `spec.configStore.configMap` or `spec.configStore.pvc` for `NemoGuardrail`
- validate the config store at reconcile time so invalid objects fail cleanly instead of panicking
- harden the volume helpers and add focused Guardrail API/controller tests for the invalid config-store cases

## Why
`NemoGuardrail` only rejected the case where both config sources were set. If neither was set, the API accepted the object and `GetVolumes()` fell through to the PVC path and dereferenced `n.Spec.ConfigStore.PVC.Name` while `PVC` was nil.

This change closes the contract gap in two places: the CRD now requires exactly one config source, and the controller still returns a clear error if it encounters an invalid object from a stale CRD or another programmatic caller.

## Validation
- `go test ./api/apps/v1alpha1 -run 'TestNemoGuardrail' -count=1`
- `go test -ldflags "-X github.com/NVIDIA/k8s-dra-driver-gpu/internal/info.version=v25.12.0" ./internal/controller -run 'TestReconcileNemoGuardrailRejectsInvalidConfigStore' -count=1`
