### PR TITLE
Require DRA attribute selector values

### DIFF
--- a/api/apps/v1alpha1/dra_types.go
+++ b/api/apps/v1alpha1/dra_types.go
@@ -87,6 +87,10 @@ type DRADeviceAttributeSelectorValue struct {
 }
 
 func (d *DRADeviceAttributeSelectorValue) GetValue() any {
+	if d == nil {
+		return nil
+	}
+
 	switch {
 	case d.BoolValue != nil:
 		return *d.BoolValue
@@ -101,6 +105,10 @@ func (d *DRADeviceAttributeSelectorValue) GetValue() any {
 }
 
 func (d *DRADeviceAttributeSelectorValue) GetValueType() k8sutilcel.ValueType {
+	if d == nil {
+		return k8sutilcel.TypeUnknown
+	}
+
 	switch {
 	case d.BoolValue != nil:
 		return k8sutilcel.TypeBool
@@ -166,10 +174,15 @@ type DRADeviceAttributeSelector struct {
 	// +kubebuilder:default=Equal
 	Op DRADeviceAttributeSelectorOp `json:"op"`
 	// Value is the value to compare against the device attribute.
+	// +kubebuilder:validation:Required
 	Value *DRADeviceAttributeSelectorValue `json:"value,omitempty"`
 }
 
 func (d *DRADeviceAttributeSelector) GetCELExpression(driverName string) (string, error) {
+	if d == nil || d.Value == nil {
+		return "", fmt.Errorf("attribute selector value is required")
+	}
+
 	domain, name := k8sutil.SplitQualifiedName(d.Key, driverName)
 	attrKey := fmt.Sprintf("device.attributes[%q].%s", domain, name)
 	return k8sutilcel.BuildExpr(attrKey, d.Op.GetCELOperator(), d.Value.GetValue(), d.Value.GetValueType())

--- a/api/apps/v1alpha1/dra_types_test.go
+++ b/api/apps/v1alpha1/dra_types_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"testing"
+
+	"k8s.io/utils/ptr"
+)
+
+func TestDRADeviceAttributeSelectorGetCELExpression(t *testing.T) {
+	tests := []struct {
+		name       string
+		selector   *DRADeviceAttributeSelector
+		driverName string
+		wantExpr   string
+		wantErr    string
+	}{
+		{
+			name: "should return cel expression if selector value is set",
+			selector: &DRADeviceAttributeSelector{
+				Key: "memory",
+				Op:  DRADeviceAttributeSelectorOpGreaterThanOrEqual,
+				Value: &DRADeviceAttributeSelectorValue{
+					IntValue: ptr.To(int32(8)),
+				},
+			},
+			driverName: "gpu.nvidia.com",
+			wantExpr:   `device.attributes["gpu.nvidia.com"].memory >= 8`,
+		},
+		{
+			name: "should return error if selector value is missing",
+			selector: &DRADeviceAttributeSelector{
+				Key:   "memory",
+				Op:    DRADeviceAttributeSelectorOpEqual,
+				Value: nil,
+			},
+			driverName: "gpu.nvidia.com",
+			wantErr:    "attribute selector value is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotExpr, err := tt.selector.GetCELExpression(tt.driverName)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("GetCELExpression() error = nil, want %q", tt.wantErr)
+				}
+				if err.Error() != tt.wantErr {
+					t.Fatalf("GetCELExpression() error = %q, want %q", err.Error(), tt.wantErr)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("GetCELExpression() error = %v", err)
+			}
+			if gotExpr != tt.wantExpr {
+				t.Fatalf("GetCELExpression() = %q, want %q", gotExpr, tt.wantExpr)
+			}
+		})
+	}
+}

--- a/config/crd/bases/apps.nvidia.com_nimpipelines.yaml
+++ b/config/crd/bases/apps.nvidia.com_nimpipelines.yaml
@@ -1108,6 +1108,7 @@ spec:
                                             required:
                                             - key
                                             - op
+                                            - value
                                             type: object
                                           type: array
                                         capacitySelectors:

--- a/config/crd/bases/apps.nvidia.com_nimpipelines.yaml
+++ b/config/crd/bases/apps.nvidia.com_nimpipelines.yaml
@@ -1109,6 +1109,7 @@ spec:
                                             required:
                                             - key
                                             - op
+                                            - value
                                             type: object
                                           type: array
                                         capacitySelectors:

--- a/config/crd/bases/apps.nvidia.com_nimservices.yaml
+++ b/config/crd/bases/apps.nvidia.com_nimservices.yaml
@@ -1051,6 +1051,7 @@ spec:
                                   required:
                                   - key
                                   - op
+                                  - value
                                   type: object
                                 type: array
                               capacitySelectors:

--- a/config/crd/bases/apps.nvidia.com_nimservices.yaml
+++ b/config/crd/bases/apps.nvidia.com_nimservices.yaml
@@ -1053,6 +1053,7 @@ spec:
                                   required:
                                   - key
                                   - op
+                                  - value
                                   type: object
                                 type: array
                               capacitySelectors:

--- a/internal/controller/platform/standalone/nimservice.go
+++ b/internal/controller/platform/standalone/nimservice.go
@@ -157,6 +157,11 @@ func (r *NIMServiceReconciler) validateDRAResources(ctx context.Context, nimServ
 		}
 		for deviceIdx, device := range resource.ClaimCreationSpec.Devices {
 			for attributeIdx, attribute := range device.AttributeSelectors {
+				if attribute.Value == nil {
+					msg := fmt.Sprintf("spec.draResources[%d].claimCreationSpec.devices[%d].attributeSelectors[%d].value: value is required", idx, deviceIdx, attributeIdx)
+					logger.Error(errors.New(msg), msg, "nimService", nimService.Name)
+					return false, msg, nil
+				}
 				if attribute.Value.VersionValue == nil {
 					continue
 				}

--- a/internal/controller/platform/standalone/nimservice.go
+++ b/internal/controller/platform/standalone/nimservice.go
@@ -147,6 +147,11 @@ func (r *NIMServiceReconciler) validateDRAResources(ctx context.Context, nimServ
 		}
 		for deviceIdx, device := range resource.ClaimCreationSpec.Devices {
 			for attributeIdx, attribute := range device.AttributeSelectors {
+				if attribute.Value == nil {
+					msg := fmt.Sprintf("spec.draResources[%d].claimCreationSpec.devices[%d].attributeSelectors[%d].value: value is required", idx, deviceIdx, attributeIdx)
+					logger.Error(errors.New(msg), msg, "nimService", nimService.Name)
+					return false, msg, nil
+				}
 				if attribute.Value.VersionValue == nil {
 					continue
 				}

--- a/internal/controller/platform/standalone/nimservice_test.go
+++ b/internal/controller/platform/standalone/nimservice_test.go
@@ -785,6 +785,46 @@ var _ = Describe("NIMServiceReconciler for a standalone platform", func() {
 				Expect(failedCondition.Message).To(ContainSubstring("spec.draResources[0].claimCreationSpec.devices[0].attributeSelectors[0].value.versionValue.version: invalid version \"550.127.08\":"))
 			})
 
+			It("should mark NIMService as failed when ClaimCreationSpec.Devices[].AttributeSelectors value is omitted", func() {
+				nimService.Spec.DRAResources = []appsv1alpha1.DRAResource{
+					{
+						ClaimCreationSpec: &appsv1alpha1.DRAClaimCreationSpec{
+							Devices: []appsv1alpha1.DRADeviceSpec{
+								{
+									Name:            "test-device",
+									Count:           1,
+									DriverName:      "gpu.nvidia.com",
+									DeviceClassName: "gpu.nvidia.com",
+									AttributeSelectors: []appsv1alpha1.DRADeviceAttributeSelector{
+										{
+											Key:   "testKey",
+											Op:    "GreaterThan",
+											Value: nil,
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+				nimServiceKey := types.NamespacedName{Name: nimService.Name, Namespace: nimService.Namespace}
+				err := client.Create(context.TODO(), nimService)
+				Expect(err).NotTo(HaveOccurred())
+
+				_, err = reconciler.reconcileNIMService(context.TODO(), nimService)
+				Expect(err).NotTo(HaveOccurred())
+
+				obj := &appsv1alpha1.NIMService{}
+				err = client.Get(context.TODO(), nimServiceKey, obj)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(obj.Status.State).To(Equal(appsv1alpha1.NIMServiceStatusFailed))
+				failedCondition := getCondition(obj, conditions.Failed)
+				Expect(failedCondition).NotTo(BeNil())
+				Expect(failedCondition.Status).To(Equal(metav1.ConditionTrue))
+				Expect(failedCondition.Reason).To(Equal(conditions.ReasonDRAResourcesUnsupported))
+				Expect(failedCondition.Message).To(Equal("spec.draResources[0].claimCreationSpec.devices[0].attributeSelectors[0].value: value is required"))
+			})
+
 			It("should succeed with valid ClaimCreationSpec", func() {
 				nimService.Spec.DRAResources = []appsv1alpha1.DRAResource{
 					{

--- a/internal/webhook/apps/v1alpha1/nimservice_webhook_validation_helper.go
+++ b/internal/webhook/apps/v1alpha1/nimservice_webhook_validation_helper.go
@@ -389,6 +389,11 @@ func validateDRADeviceAttributeSelectorOp(op appsv1alpha1.DRADeviceAttributeSele
 
 func validateDRADeviceAttributeSelectorValue(attribute *appsv1alpha1.DRADeviceAttributeSelectorValue, fldPath *field.Path) field.ErrorList {
 	errList := field.ErrorList{}
+	if attribute == nil {
+		errList = append(errList, field.Required(fldPath, "is required"))
+		return errList
+	}
+
 	var fieldCount int
 	if attribute.BoolValue != nil {
 		fieldCount++

--- a/internal/webhook/apps/v1alpha1/nimservice_webhook_validation_helper.go
+++ b/internal/webhook/apps/v1alpha1/nimservice_webhook_validation_helper.go
@@ -385,6 +385,11 @@ func validateDRADeviceAttributeSelectorOp(op appsv1alpha1.DRADeviceAttributeSele
 
 func validateDRADeviceAttributeSelectorValue(attribute *appsv1alpha1.DRADeviceAttributeSelectorValue, fldPath *field.Path) field.ErrorList {
 	errList := field.ErrorList{}
+	if attribute == nil {
+		errList = append(errList, field.Required(fldPath, "is required"))
+		return errList
+	}
+
 	var fieldCount int
 	if attribute.BoolValue != nil {
 		fieldCount++

--- a/internal/webhook/apps/v1alpha1/nimservice_webhook_validation_helper_test.go
+++ b/internal/webhook/apps/v1alpha1/nimservice_webhook_validation_helper_test.go
@@ -581,6 +581,33 @@ func TestValidateDRAResourcesConfiguration(t *testing.T) {
 			wantWarnings:    0,
 		},
 		{
+			name: "claimCreationSpec with invalid attribute selector - nil value",
+			modify: func(ns *appsv1alpha1.NIMService) {
+				ns.Spec.DRAResources = []appsv1alpha1.DRAResource{{
+					ClaimCreationSpec: &appsv1alpha1.DRAClaimCreationSpec{
+						Devices: []appsv1alpha1.DRADeviceSpec{{
+							Name:            "gpu",
+							Count:           1,
+							DeviceClassName: "gpu.nvidia.com",
+							DriverName:      "gpu.nvidia.com",
+							AttributeSelectors: []appsv1alpha1.DRADeviceAttributeSelector{
+								{
+									Key:   "memory",
+									Op:    appsv1alpha1.DRADeviceAttributeSelectorOpEqual,
+									Value: nil,
+								},
+							},
+						}},
+					},
+				}}
+			},
+			k8sVersion:      "v1.34.0",
+			wantErrs:        1,
+			wantErrMsgs:     []string{"spec.draResources[0].claimCreationSpec.devices[0].attributeSelectors[0].value: Required value: is required"},
+			wantWarningMsgs: nil,
+			wantWarnings:    0,
+		},
+		{
 			name: "claimCreationSpec with invalid attribute selector - no value",
 			modify: func(ns *appsv1alpha1.NIMService) {
 				ns.Spec.DRAResources = []appsv1alpha1.DRAResource{{


### PR DESCRIPTION
## Summary
- require `attributeSelectors[].value` for shared DRA selector types used by NIMService and NIMPipeline CRDs
- harden DRA selector evaluation and validation paths so missing values return clear errors instead of dereferencing nil
- add focused API, webhook, and standalone controller regressions for omitted attribute selector values

## Why
`DRADeviceAttributeSelector.Value` was optional in the generated schema, but multiple code paths treated it as mandatory:
- `GetCELExpression()` dereferenced `d.Value`
- standalone DRA validation dereferenced `attribute.Value.VersionValue`
- webhook validation assumed the pointer itself was non-nil

That let invalid objects through the schema and turned them into panics or nil-pointer crashes during validation or reconciliation.

## Validation
- `go test ./api/apps/v1alpha1 -run TestDRADeviceAttributeSelectorGetCELExpression -count=1`
- `go test ./internal/webhook/apps/v1alpha1 -run TestValidateDRAResourcesConfiguration -count=1`
- `go test -ldflags "-X github.com/NVIDIA/k8s-dra-driver-gpu/internal/info.version=v25.12.0" ./internal/controller/platform/standalone -run TestControllers -ginkgo.focus='AttributeSelectors value is omitted' -count=1`
