### PR TITLE
Update NIM Operator for Retriever 2.0 Changes

### DIFF
--- a/api/apps/v1alpha1/nimcache_types.go
+++ b/api/apps/v1alpha1/nimcache_types.go
@@ -219,6 +219,15 @@ const (
 	NimCacheStatusPending = "Pending"
 	// NimCacheStatusFailed indicates that caching is failed.
 	NimCacheStatusFailed = "Failed"
+
+	// NIMCacheModelTypeModelFree indicates a NIM whose image ships without a
+	// model_manifest.yaml and downloads its model via the legacy HuggingFace flow.
+	NIMCacheModelTypeModelFree = "model-free"
+	// NIMCacheModelTypeNative indicates a NIM built on the native (NIMCraft)
+	// single-model runtime (e.g. Retriever 2.0 Rust/CUDA). Such NIMs have no
+	// model_manifest.yaml, no download-to-cache/list-model-profiles commands,
+	// and download their single model on start when NGC_API_KEY/HF_TOKEN is set.
+	NIMCacheModelTypeNative = "native"
 )
 
 // EnvFromSecrets return the list of secrets that should be mounted as env vars.
@@ -346,6 +355,14 @@ func (n *NIMCache) IsOptimizedNIM() bool {
 		return true
 	}
 	return false
+}
+
+// IsNativeModelDownload returns true if the NIMCache targets a NIM built on the
+// native (NIMCraft) single-model runtime. This is determined pre-start by
+// inspecting the image's model-download-protocol OCI label and is persisted on
+// the status so subsequent reconciles do not need to re-inspect the registry.
+func (n *NIMCache) IsNativeModelDownload() bool {
+	return n.Status.Type == NIMCacheModelTypeNative
 }
 
 // GetModelSpec returns the model spec for the NIMCache.

--- a/api/apps/v1alpha1/nimservice_types.go
+++ b/api/apps/v1alpha1/nimservice_types.go
@@ -941,6 +941,73 @@ func (n *NIMService) GetInitContainerVolumeMounts(modelPVC *PersistentVolumeClai
 	return volumeMounts
 }
 
+// GetNativeVolumeMounts returns the container volume mounts for a native
+// (NIMCraft) single-model NIM. The model store PVC is mounted at /model (weights)
+// and /opt/cache (compiled CUDA kernels) so both survive pod restarts.
+func (n *NIMService) GetNativeVolumeMounts(modelPVC *PersistentVolumeClaim) []corev1.VolumeMount {
+	subPath := ""
+	if modelPVC != nil {
+		subPath = modelPVC.SubPath
+	}
+	volumeMounts := []corev1.VolumeMount{
+		{
+			Name:      "model-store",
+			MountPath: utils.NativeModelBasePath,
+			SubPath:   subPath,
+		},
+		{
+			Name:      "model-store",
+			MountPath: utils.NativeKernelCachePath,
+			SubPath:   subPath,
+		},
+		{
+			Name:      "dshm",
+			MountPath: "/dev/shm",
+		},
+	}
+	if n.scratchNeeded() {
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      "scratch",
+			MountPath: "/scratch",
+		})
+	}
+	if n.GetProxyCertConfigMap() != "" {
+		volumeMounts = append(volumeMounts, k8sutil.GetVolumesMountsForUpdatingCaCert()...)
+	}
+	return volumeMounts
+}
+
+// GetNativeInitContainerVolumeMounts returns init-container volume mounts for a
+// native NIM, mounting the model store PVC at /model and /opt/cache.
+func (n *NIMService) GetNativeInitContainerVolumeMounts(modelPVC *PersistentVolumeClaim) []corev1.VolumeMount {
+	subPath := ""
+	if modelPVC != nil {
+		subPath = modelPVC.SubPath
+	}
+	volumeMounts := []corev1.VolumeMount{
+		{
+			Name:      "model-store",
+			MountPath: utils.NativeModelBasePath,
+			SubPath:   subPath,
+		},
+		{
+			Name:      "model-store",
+			MountPath: utils.NativeKernelCachePath,
+			SubPath:   subPath,
+		},
+	}
+	if n.scratchNeeded() {
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      "scratch",
+			MountPath: "/scratch",
+		})
+	}
+	if n.GetProxyCertConfigMap() != "" {
+		volumeMounts = append(volumeMounts, k8sutil.GetUpdateCaCertInitContainerVolumeMounts()...)
+	}
+	return volumeMounts
+}
+
 func (n *NIMService) GetWorkerVolumeMounts(modelPVC *PersistentVolumeClaim) []corev1.VolumeMount {
 	volumeMounts := n.GetVolumeMounts(modelPVC)
 

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/mittwald/go-helm-client v0.12.19
 	github.com/onsi/ginkgo/v2 v2.32.0
 	github.com/onsi/gomega v1.42.1
+	github.com/opencontainers/image-spec v1.1.1
 	github.com/openshift/api v0.0.0-20240708071937-c9a91940bf0f
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.86.2
 	github.com/prometheus/client_golang v1.23.2
@@ -26,6 +27,7 @@ require (
 	k8s.io/dynamic-resource-allocation v0.36.0-rc.0
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2
 	knative.dev/pkg v0.0.0-20260120122510-4a022ed9999a
+	oras.land/oras-go/v2 v2.6.0
 	sigs.k8s.io/controller-runtime v0.22.4
 	sigs.k8s.io/dra-driver-nvidia-gpu v0.4.1
 	sigs.k8s.io/gateway-api v1.5.1
@@ -161,7 +163,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
-	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pjbgf/sha1cd v0.6.0 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
@@ -232,7 +233,6 @@ require (
 	k8s.io/kubectl v0.35.1 // indirect
 	knative.dev/networking v0.0.0-20260120131110-a7cdca238a0d // indirect
 	knative.dev/serving v0.48.1 // indirect
-	oras.land/oras-go/v2 v2.6.0 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/kustomize/api v0.21.1 // indirect

--- a/internal/controller/nimcache_controller.go
+++ b/internal/controller/nimcache_controller.go
@@ -83,12 +83,13 @@ const (
 // NIMCacheReconciler reconciles a NIMCache object.
 type NIMCacheReconciler struct {
 	client.Client
-	scheme           *runtime.Scheme
-	log              logr.Logger
-	orchestratorType k8sutil.OrchestratorType
-	updater          conditions.Updater
-	recorder         record.EventRecorder
-	apiReader        client.Reader
+	scheme                *runtime.Scheme
+	log                   logr.Logger
+	orchestratorType      k8sutil.OrchestratorType
+	updater               conditions.Updater
+	recorder              record.EventRecorder
+	apiReader             client.Reader
+	imageProtocolResolver nimsource.ProtocolResolver
 }
 
 // Ensure NIMCacheReconciler implements the Reconciler interface.
@@ -97,9 +98,10 @@ var _ shared.Reconciler = &NIMCacheReconciler{}
 // NewNIMCacheReconciler creates a new reconciler for NIMCache with the given platform.
 func NewNIMCacheReconciler(client client.Client, scheme *runtime.Scheme, log logr.Logger) *NIMCacheReconciler {
 	return &NIMCacheReconciler{
-		Client: client,
-		scheme: scheme,
-		log:    log,
+		Client:                client,
+		scheme:                scheme,
+		log:                   log,
+		imageProtocolResolver: nimsource.NewProtocolResolver(client),
 	}
 }
 
@@ -110,6 +112,7 @@ func NewNIMCacheReconciler(client client.Client, scheme *runtime.Scheme, log log
 // +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;create;delete
 // +kubebuilder:rbac:groups="",resources=pods/log,verbs=get
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;create;delete
 // +kubebuilder:rbac:groups=storage.k8s.io,resources=storageclasses,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;update;patch
@@ -258,6 +261,7 @@ func (r *NIMCacheReconciler) GetOrchestratorType(ctx context.Context) (k8sutil.O
 func (r *NIMCacheReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	r.recorder = mgr.GetEventRecorderFor("nimcache-controller")
 	r.apiReader = mgr.GetAPIReader()
+	r.imageProtocolResolver = nimsource.NewProtocolResolver(r.apiReader)
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&appsv1alpha1.NIMCache{}).
 		Owns(&batchv1.Job{}).
@@ -612,10 +616,12 @@ func (r *NIMCacheReconciler) reconcileModelManifest(ctx context.Context, nimCach
 		return false, nil
 	}
 
-	// No manifest extraction needed: a previous reconcile already determined this NIM has no manifest
-	if nimCache.Status.Type == "model-free" {
+	// No manifest extraction needed: a previous reconcile already determined this
+	// NIM has no manifest (legacy model-free HF flow).
+	if nimCache.Status.Type == appsv1alpha1.NIMCacheModelTypeModelFree {
 		return false, nil
 	}
+
 	// Create a configmap by extracting the model manifest
 	// Create a temporary pod for parsing model manifest
 	pod := constructPodSpec(nimCache, r.orchestratorType)
@@ -655,7 +661,7 @@ func (r *NIMCacheReconciler) reconcileModelManifest(ctx context.Context, nimCach
 
 	if strings.Contains(output, "model_manifest.yaml not found") {
 		logger.Info("model manifest file not found", "output", output)
-		nimCache.Status.Type = "model-free"
+		nimCache.Status.Type = appsv1alpha1.NIMCacheModelTypeModelFree
 	} else {
 		parser := nimparserutils.GetNIMParser([]byte(output))
 		manifest, err := parser.ParseModelManifestFromRawOutput([]byte(output))
@@ -780,6 +786,11 @@ func (r *NIMCacheReconciler) reconcileJobStatus(ctx context.Context, nimCache *a
 		nimCache.Status.State = appsv1alpha1.NimCacheStatusReady
 		nimCache.Status.PVC = shared.GetPVCName(nimCache, nimCache.Spec.Storage.PVC)
 
+		if nimCache.IsNativeModelDownload() {
+			nimCache.Status.Profiles = []appsv1alpha1.NIMProfile{}
+			return nil
+		}
+
 		selectedProfiles, err := getSelectedProfiles(nimCache)
 		if err != nil {
 			return fmt.Errorf("failed to get selected profiles: %w", err)
@@ -873,22 +884,32 @@ func (r *NIMCacheReconciler) reconcileNIMCache(ctx context.Context, nimCache *ap
 		return ctrl.Result{}, err
 	}
 
-	requeue, err := r.reconcileModelManifest(ctx, nimCache)
-	if err != nil {
-		logger.Error(err, "reconciliation to extract model manifest failed", "pod", getPodName(nimCache))
-		return ctrl.Result{}, err
-	}
+	protocol := r.resolveImageProtocol(ctx, nimCache)
+	if protocol.IsNative() {
+		logger.Info("detected native model download protocol, skipping manifest probe and profile selection", "nimcache", nimCache.Name)
+		nimCache.Status.Type = appsv1alpha1.NIMCacheModelTypeNative
+	} else {
+		// Clear a stale native type if the image no longer advertises native-v1.
+		if nimCache.Status.Type == appsv1alpha1.NIMCacheModelTypeNative {
+			nimCache.Status.Type = ""
+		}
+		requeue, err := r.reconcileModelManifest(ctx, nimCache)
+		if err != nil {
+			logger.Error(err, "reconciliation to extract model manifest failed", "pod", getPodName(nimCache))
+			return ctrl.Result{}, err
+		}
 
-	if requeue {
-		logger.V(2).Info("requeueing for reconciliation for model selection", "pod", getPodName(nimCache))
-		return ctrl.Result{RequeueAfter: time.Second * 30}, err
-	}
+		if requeue {
+			logger.V(2).Info("requeueing for reconciliation for model selection", "pod", getPodName(nimCache))
+			return ctrl.Result{RequeueAfter: time.Second * 30}, err
+		}
 
-	// Reconcile NIM model selection
-	err = r.reconcileModelSelection(ctx, nimCache)
-	if err != nil {
-		logger.Error(err, "reconciliation of model selection failed")
-		return ctrl.Result{}, err
+		// Reconcile NIM model selection
+		err = r.reconcileModelSelection(ctx, nimCache)
+		if err != nil {
+			logger.Error(err, "reconciliation of model selection failed")
+			return ctrl.Result{}, err
+		}
 	}
 
 	// Reconcile caching Job
@@ -906,6 +927,24 @@ func (r *NIMCacheReconciler) reconcileNIMCache(ctx context.Context, nimCache *ap
 		return ctrl.Result{}, err
 	}
 	return ctrl.Result{}, nil
+}
+
+func (r *NIMCacheReconciler) resolveImageProtocol(ctx context.Context, nimCache *appsv1alpha1.NIMCache) nimsource.Protocol {
+	// Only NGC optimized NIMs (no ModelEndpoint) need pre-start protocol detection.
+	// HF/DataStore and universal ModelEndpoint flows keep the legacy behavior.
+	if nimCache.Spec.Source.NGC == nil || nimCache.Spec.Source.NGC.ModelEndpoint != nil {
+		return nimsource.Legacy
+	}
+	resolver := r.imageProtocolResolver
+	if resolver == nil {
+		resolver = nimsource.NewProtocolResolver(r.Client)
+	}
+	pullSecrets := []string{}
+	if nimCache.Spec.Source.NGC.PullSecret != "" {
+		pullSecrets = append(pullSecrets, nimCache.Spec.Source.NGC.PullSecret)
+	}
+
+	return nimsource.ResolveProtocolOrLegacy(ctx, resolver, nimCache.Spec.Source.NGC.ModelPuller, nimCache.Namespace, pullSecrets)
 }
 
 func (r *NIMCacheReconciler) updateNIMCacheStatus(ctx context.Context, nimCache *appsv1alpha1.NIMCache) error {
@@ -1108,6 +1147,71 @@ func (r *NIMCacheReconciler) constructJob(ctx context.Context, nimCache *appsv1a
 	}
 
 	switch {
+	case nimCache.IsNativeModelDownload():
+		// Native (NIMCraft) single-model runtime: there is no download-to-cache
+		// command. Instead, run the NIM image itself with the auth key injected
+		// and NIM_ENGINE_MODEL_DOWNLOAD_ONLY=1 so it downloads its single model to
+		// the PVC mounted at /model (and optionally warms /opt/cache), then exits.
+		job.Spec.Template.Spec.Containers = []corev1.Container{
+			{
+				Name:    NIMCacheContainerName,
+				Image:   nimCache.GetModelPuller(),
+				EnvFrom: nimCache.Spec.Source.EnvFromSecrets(),
+				Env: []corev1.EnvVar{
+					{
+						Name:  "NIM_ENGINE_MODEL_DOWNLOAD_ONLY",
+						Value: "1",
+					},
+					{
+						Name:  "NIM_ENGINE_MODEL_PATH",
+						Value: utils.NativeModelPath(nimCache.Name),
+					},
+				},
+				VolumeMounts: []corev1.VolumeMount{
+					{
+						Name:      "nim-cache-volume",
+						MountPath: utils.NativeModelBasePath,
+						SubPath:   nimCache.Spec.Storage.PVC.SubPath,
+					},
+					{
+						Name:      "nim-cache-volume",
+						MountPath: utils.NativeKernelCachePath,
+						SubPath:   nimCache.Spec.Storage.PVC.SubPath,
+					},
+					{
+						Name:      "scratch",
+						MountPath: "/scratch",
+					},
+				},
+				Resources: corev1.ResourceRequirements{
+					Limits: map[corev1.ResourceName]apiResource.Quantity{
+						"cpu":    nimCache.Spec.Resources.CPU,
+						"memory": nimCache.Spec.Resources.Memory,
+					},
+					Requests: map[corev1.ResourceName]apiResource.Quantity{
+						"cpu":    nimCache.Spec.Resources.CPU,
+						"memory": nimCache.Spec.Resources.Memory,
+					},
+				},
+				TerminationMessagePath:   "/dev/termination-log",
+				TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+				SecurityContext: &corev1.SecurityContext{
+					AllowPrivilegeEscalation: ptr.To[bool](false),
+					Capabilities: &corev1.Capabilities{
+						Drop: []corev1.Capability{"ALL"},
+					},
+					RunAsNonRoot: ptr.To[bool](true),
+					RunAsGroup:   nimCache.GetGroupID(),
+					RunAsUser:    nimCache.GetUserID(),
+				},
+			},
+		}
+		job.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{
+			{
+				Name: nimCache.GetPullSecret(),
+			},
+		}
+
 	case nimCache.Spec.Source.DataStore != nil || nimCache.Spec.Source.HF != nil:
 		var hfDataSource nimsource.HFInterface
 		if nimCache.Spec.Source.DataStore != nil {
@@ -1116,7 +1220,7 @@ func (r *NIMCacheReconciler) constructJob(ctx context.Context, nimCache *appsv1a
 			hfDataSource = nimCache.Spec.Source.HF
 		}
 		var command []string
-		if nimCache.Status.Type == "model-free" {
+		if nimCache.Status.Type == appsv1alpha1.NIMCacheModelTypeModelFree {
 			hfUri := nimCache.GetHFUri()
 			command = []string{"download-to-cache", "--model-uri", hfUri, "--manifest-file", utils.DefaultModelStorePath + "/model_manifest.json"}
 		} else {
@@ -1313,6 +1417,26 @@ func (r *NIMCacheReconciler) constructJob(ctx context.Context, nimCache *appsv1a
 	}
 	// Merge env with the user provided values
 	job.Spec.Template.Spec.Containers[0].Env = utils.MergeEnvVars(job.Spec.Template.Spec.Containers[0].Env, nimCache.Spec.Env)
+
+	// Native caching is driven entirely by operator-owned env: the download-only
+	// flag and the per-instance model path are tied to the mounted volume layout.
+	// Re-assert them after merging user env (which wins in MergeEnvVars) so a
+	// user-provided value cannot silently break the caching job.
+	if nimCache.IsNativeModelDownload() {
+		job.Spec.Template.Spec.Containers[0].Env = utils.MergeEnvVars(
+			job.Spec.Template.Spec.Containers[0].Env,
+			[]corev1.EnvVar{
+				{
+					Name:  "NIM_ENGINE_MODEL_DOWNLOAD_ONLY",
+					Value: "1",
+				},
+				{
+					Name:  "NIM_ENGINE_MODEL_PATH",
+					Value: utils.NativeModelPath(nimCache.Name),
+				},
+			},
+		)
+	}
 
 	// Inject custom CA certificates when running in a proxy envronment
 	if nimCache.Spec.CertConfig != nil { //nolint:staticcheck // checking for deprecated field

--- a/internal/controller/nimcache_controller_test.go
+++ b/internal/controller/nimcache_controller_test.go
@@ -42,8 +42,15 @@ import (
 	appsv1alpha1 "github.com/NVIDIA/k8s-nim-operator/api/apps/v1alpha1"
 	"github.com/NVIDIA/k8s-nim-operator/internal/k8sutil"
 	nimparserv1 "github.com/NVIDIA/k8s-nim-operator/internal/nimparser/v1"
+	"github.com/NVIDIA/k8s-nim-operator/internal/nimsource"
 	"github.com/NVIDIA/k8s-nim-operator/internal/shared"
 )
+
+type legacyProtocolResolver struct{}
+
+func (legacyProtocolResolver) Resolve(context.Context, string, string, []string) (nimsource.Protocol, error) {
+	return nimsource.Legacy, nil
+}
 
 var _ = Describe("NIMCache Controller", func() {
 	var (
@@ -64,9 +71,10 @@ var _ = Describe("NIMCache Controller", func() {
 			WithStatusSubresource(&corev1.ConfigMap{}).
 			Build()
 		reconciler = &NIMCacheReconciler{
-			Client:   cli,
-			scheme:   scheme,
-			recorder: record.NewFakeRecorder(1000),
+			Client:                cli,
+			scheme:                scheme,
+			recorder:              record.NewFakeRecorder(1000),
+			imageProtocolResolver: &legacyProtocolResolver{},
 		}
 
 		nimCache := &appsv1alpha1.NIMCache{

--- a/internal/controller/platform/kserve/nimservice.go
+++ b/internal/controller/platform/kserve/nimservice.go
@@ -50,6 +50,7 @@ import (
 	"github.com/NVIDIA/k8s-nim-operator/internal/conditions"
 	"github.com/NVIDIA/k8s-nim-operator/internal/k8sutil"
 	"github.com/NVIDIA/k8s-nim-operator/internal/nimmodels"
+	"github.com/NVIDIA/k8s-nim-operator/internal/nimsource"
 	"github.com/NVIDIA/k8s-nim-operator/internal/render"
 	rendertypes "github.com/NVIDIA/k8s-nim-operator/internal/render/types"
 	"github.com/NVIDIA/k8s-nim-operator/internal/shared"
@@ -64,31 +65,36 @@ const (
 // NIMServiceReconciler represents the NIMService reconciler instance for KServe platform.
 type NIMServiceReconciler struct {
 	client.Client
-	scheme          *runtime.Scheme
-	log             logr.Logger
-	discoveryClient discovery.DiscoveryInterface
-
-	updater          conditions.Updater
-	renderer         render.Renderer
-	recorder         record.EventRecorder
-	apiReader        client.Reader
-	orchestratorType k8sutil.OrchestratorType
+	scheme                *runtime.Scheme
+	log                   logr.Logger
+	discoveryClient       discovery.DiscoveryInterface
+	updater               conditions.Updater
+	renderer              render.Renderer
+	recorder              record.EventRecorder
+	apiReader             client.Reader
+	orchestratorType      k8sutil.OrchestratorType
+	imageProtocolResolver nimsource.ProtocolResolver
 }
 
 // NewNIMServiceReconciler returns NIMServiceReconciler for KServe platform.
 func NewNIMServiceReconciler(ctx context.Context, r shared.Reconciler) *NIMServiceReconciler {
 	orchestratorType, _ := r.GetOrchestratorType(ctx)
+	registryReader := r.GetAPIReader()
+	if registryReader == nil {
+		registryReader = r.GetClient()
+	}
 
 	return &NIMServiceReconciler{
-		Client:           r.GetClient(),
-		scheme:           r.GetScheme(),
-		log:              r.GetLogger(),
-		discoveryClient:  r.GetDiscoveryClient(),
-		updater:          r.GetUpdater(),
-		renderer:         render.NewRenderer(ManifestsDir),
-		recorder:         r.GetEventRecorder(),
-		apiReader:        r.GetAPIReader(),
-		orchestratorType: orchestratorType,
+		Client:                r.GetClient(),
+		scheme:                r.GetScheme(),
+		log:                   r.GetLogger(),
+		discoveryClient:       r.GetDiscoveryClient(),
+		updater:               r.GetUpdater(),
+		renderer:              render.NewRenderer(ManifestsDir),
+		recorder:              r.GetEventRecorder(),
+		apiReader:             registryReader,
+		orchestratorType:      orchestratorType,
+		imageProtocolResolver: nimsource.NewProtocolResolver(registryReader),
 	}
 }
 
@@ -501,7 +507,13 @@ func (r *NIMServiceReconciler) renderAndSyncInferenceService(ctx context.Context
 	isvcParams.OrchestratorType = string(r.orchestratorType)
 
 	isvcParams.PodResourceClaims = namedDraResources.GetPodResourceClaims()
-	if nimCache.IsUniversalNIM() {
+
+	modelLayout, err := nimsource.ResolveModelLayout(ctx, r.imageProtocolResolver, nimService, nimCache)
+	if err != nil {
+		return err
+	}
+
+	if nimCache.IsUniversalNIM() && !modelLayout.Protocol.IsNative() {
 		hfUri := nimCache.GetHFUri()
 		isvcParams.Env = utils.MergeEnvVars([]corev1.EnvVar{
 			{
@@ -515,6 +527,50 @@ func (r *NIMServiceReconciler) renderAndSyncInferenceService(ctx context.Context
 				Value: hfUri,
 			},
 		}, isvcParams.Env)
+	}
+
+	// Native (NIMCraft) single-model NIMs read their weights from a per-instance
+	// directory under /model so multiple NIMs can share one PVC. This must match
+	// NIM_ENGINE_MODEL_PATH used by the NIMCache caching job. It is operator-owned
+	// (merged as the winning side) since it is tied to the mounted volume layout.
+	if modelLayout.Protocol.IsNative() {
+		isvcParams.Env = utils.MergeEnvVars(isvcParams.Env, []corev1.EnvVar{{
+			Name:  "NIM_ENGINE_MODEL_PATH",
+			Value: nimsource.NativeModelPathForCache(nimCache),
+		}})
+
+		// Native (NIMCraft) single-model NIMs resolve their model source at
+		// runtime and authenticate with either NGC_API_KEY or HF_TOKEN. The
+		// standard env requires NGC_API_KEY, which breaks auth secrets that only
+		// carry an HF token. Make NGC_API_KEY optional and surface HF_TOKEN (also
+		// optional) so either credential works.
+		isvcParams.Env = utils.RemoveEnvVar(isvcParams.Env, appsv1alpha1.NGCAPIKey)
+		isvcParams.Env = utils.MergeEnvVars(isvcParams.Env, []corev1.EnvVar{
+			{
+				Name: appsv1alpha1.NGCAPIKey,
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: nimService.Spec.AuthSecret,
+						},
+						Key:      appsv1alpha1.NGCAPIKey,
+						Optional: &[]bool{true}[0],
+					},
+				},
+			},
+			{
+				Name: appsv1alpha1.HFToken,
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: nimService.Spec.AuthSecret,
+						},
+						Key:      appsv1alpha1.HFToken,
+						Optional: &[]bool{true}[0],
+					},
+				},
+			},
+		})
 	}
 	// If NIMCache or NIMService is a Hugging Face Multi-LLM NIM, add the HF_TOKEN to the environment variables and make NGC_API_KEY optional
 	// For custom models stored in Datastore, the NIM Container needs to access NGC to download base model. However, NGC_API_KEY is not required for Hugging Face models.
@@ -547,9 +603,15 @@ func (r *NIMServiceReconciler) renderAndSyncInferenceService(ctx context.Context
 		})
 	}
 
-	// Setup volume mounts with model store
+	// Setup volume mounts with model store. Native (NIMCraft) single-model NIMs
+	// mount the model store PVC at /model and /opt/cache instead of /model-store,
+	// so weights and compiled CUDA kernels persist across restarts.
 	isvcParams.Volumes = nimService.GetVolumes(modelPVC)
-	isvcParams.VolumeMounts = nimService.GetVolumeMounts(modelPVC)
+	if modelLayout.Protocol.IsNative() {
+		isvcParams.VolumeMounts = nimService.GetNativeVolumeMounts(modelPVC)
+	} else {
+		isvcParams.VolumeMounts = nimService.GetVolumeMounts(modelPVC)
+	}
 	if profileEnv != nil {
 		isvcParams.Env = utils.MergeEnvVars(*profileEnv, isvcParams.Env)
 	}
@@ -557,7 +619,12 @@ func (r *NIMServiceReconciler) renderAndSyncInferenceService(ctx context.Context
 	if gpuResources != nil {
 		isvcParams.Resources = gpuResources
 	}
-	initContainerVolumeMounts := nimService.GetInitContainerVolumeMounts(modelPVC)
+	var initContainerVolumeMounts []corev1.VolumeMount
+	if modelLayout.Protocol.IsNative() {
+		initContainerVolumeMounts = nimService.GetNativeInitContainerVolumeMounts(modelPVC)
+	} else {
+		initContainerVolumeMounts = nimService.GetInitContainerVolumeMounts(modelPVC)
+	}
 	for idx := range isvcParams.InitContainers {
 		isvcParams.InitContainers[idx].VolumeMounts = initContainerVolumeMounts
 	}

--- a/internal/controller/platform/standalone/nimservice.go
+++ b/internal/controller/platform/standalone/nimservice.go
@@ -54,6 +54,7 @@ import (
 	"github.com/NVIDIA/k8s-nim-operator/internal/conditions"
 	"github.com/NVIDIA/k8s-nim-operator/internal/k8sutil"
 	"github.com/NVIDIA/k8s-nim-operator/internal/nimmodels"
+	"github.com/NVIDIA/k8s-nim-operator/internal/nimsource"
 	"github.com/NVIDIA/k8s-nim-operator/internal/render"
 	rendertypes "github.com/NVIDIA/k8s-nim-operator/internal/render/types"
 	"github.com/NVIDIA/k8s-nim-operator/internal/shared"
@@ -538,7 +539,13 @@ func (r *NIMServiceReconciler) reconcileNIMService(ctx context.Context, nimServi
 		deploymentParams := nimService.GetDeploymentParams()
 		deploymentParams.OrchestratorType = string(r.GetOrchestratorType())
 		deploymentParams.PodResourceClaims = namedDraResources.GetPodResourceClaims()
-		if nimCache.IsUniversalNIM() {
+
+		modelLayout, err := nimsource.ResolveModelLayout(ctx, r.imageProtocolResolver, nimService, &nimCache)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+
+		if nimCache.IsUniversalNIM() && !modelLayout.Protocol.IsNative() {
 			hfUri := nimCache.GetHFUri()
 			deploymentParams.Env = utils.MergeEnvVars([]corev1.EnvVar{{
 				Name:  "NIM_MODEL_NAME",
@@ -550,6 +557,51 @@ func (r *NIMServiceReconciler) reconcileNIMService(ctx context.Context, nimServi
 				Name:  "NIM_MODEL_PATH",
 				Value: hfUri,
 			}}, deploymentParams.Env)
+		}
+
+		// Native (NIMCraft) single-model NIMs read their weights from a
+		// per-instance directory under /model so multiple NIMs can share one PVC.
+		// This must match NIM_ENGINE_MODEL_PATH used by the NIMCache caching job.
+		// It is operator-owned (merged as the winning side) since it is tied to
+		// the mounted volume layout.
+		if modelLayout.Protocol.IsNative() {
+			deploymentParams.Env = utils.MergeEnvVars(deploymentParams.Env, []corev1.EnvVar{{
+				Name:  "NIM_ENGINE_MODEL_PATH",
+				Value: nimsource.NativeModelPathForCache(&nimCache),
+			}})
+
+			// Native (NIMCraft) single-model NIMs resolve their model source at
+			// runtime and authenticate with either NGC_API_KEY or HF_TOKEN. The
+			// standard env requires NGC_API_KEY, which breaks auth secrets that
+			// only carry an HF token. Make NGC_API_KEY optional and surface
+			// HF_TOKEN (also optional) so either credential works.
+			deploymentParams.Env = utils.RemoveEnvVar(deploymentParams.Env, appsv1alpha1.NGCAPIKey)
+			deploymentParams.Env = utils.MergeEnvVars(deploymentParams.Env, []corev1.EnvVar{
+				{
+					Name: appsv1alpha1.NGCAPIKey,
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: nimService.Spec.AuthSecret,
+							},
+							Key:      appsv1alpha1.NGCAPIKey,
+							Optional: &[]bool{true}[0],
+						},
+					},
+				},
+				{
+					Name: appsv1alpha1.HFToken,
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: nimService.Spec.AuthSecret,
+							},
+							Key:      appsv1alpha1.HFToken,
+							Optional: &[]bool{true}[0],
+						},
+					},
+				},
+			})
 		}
 
 		// If NIMCache or NIMService is a Hugging Face Multi-LLM NIM, add the HF_TOKEN to the environment variables and make NGC_API_KEY optional
@@ -583,9 +635,15 @@ func (r *NIMServiceReconciler) reconcileNIMService(ctx context.Context, nimServi
 			})
 		}
 
-		// Setup volume mounts with model store
+		// Setup volume mounts with model store. Native (NIMCraft) single-model
+		// NIMs mount the model store PVC at /model and /opt/cache instead of
+		// /model-store, so weights and compiled CUDA kernels persist across restarts.
 		deploymentParams.Volumes = nimService.GetVolumes(modelPVC)
-		deploymentParams.VolumeMounts = nimService.GetVolumeMounts(modelPVC)
+		if modelLayout.Protocol.IsNative() {
+			deploymentParams.VolumeMounts = nimService.GetNativeVolumeMounts(modelPVC)
+		} else {
+			deploymentParams.VolumeMounts = nimService.GetVolumeMounts(modelPVC)
+		}
 		if profileEnv != nil {
 			deploymentParams.Env = utils.MergeEnvVars(*profileEnv, deploymentParams.Env)
 		}
@@ -593,7 +651,12 @@ func (r *NIMServiceReconciler) reconcileNIMService(ctx context.Context, nimServi
 		if gpuResources != nil {
 			deploymentParams.Resources = gpuResources
 		}
-		initContainerVolumeMounts := nimService.GetInitContainerVolumeMounts(modelPVC)
+		var initContainerVolumeMounts []corev1.VolumeMount
+		if modelLayout.Protocol.IsNative() {
+			initContainerVolumeMounts = nimService.GetNativeInitContainerVolumeMounts(modelPVC)
+		} else {
+			initContainerVolumeMounts = nimService.GetInitContainerVolumeMounts(modelPVC)
+		}
 		for idx := range deploymentParams.InitContainers {
 			deploymentParams.InitContainers[idx].VolumeMounts = initContainerVolumeMounts
 		}

--- a/internal/controller/platform/standalone/standalone.go
+++ b/internal/controller/platform/standalone/standalone.go
@@ -31,6 +31,7 @@ import (
 	appsv1alpha1 "github.com/NVIDIA/k8s-nim-operator/api/apps/v1alpha1"
 	"github.com/NVIDIA/k8s-nim-operator/internal/conditions"
 	"github.com/NVIDIA/k8s-nim-operator/internal/k8sutil"
+	"github.com/NVIDIA/k8s-nim-operator/internal/nimsource"
 	"github.com/NVIDIA/k8s-nim-operator/internal/render"
 	"github.com/NVIDIA/k8s-nim-operator/internal/shared"
 )
@@ -57,13 +58,14 @@ type NIMCacheReconciler struct {
 // NIMServiceReconciler represents the NIMService reconciler instance for standalone mode.
 type NIMServiceReconciler struct {
 	client.Client
-	scheme           *runtime.Scheme
-	log              logr.Logger
-	updater          conditions.Updater
-	discoveryClient  discovery.DiscoveryInterface
-	renderer         render.Renderer
-	recorder         record.EventRecorder
-	orchestratorType k8sutil.OrchestratorType
+	scheme                *runtime.Scheme
+	log                   logr.Logger
+	updater               conditions.Updater
+	discoveryClient       discovery.DiscoveryInterface
+	renderer              render.Renderer
+	recorder              record.EventRecorder
+	orchestratorType      k8sutil.OrchestratorType
+	imageProtocolResolver nimsource.ProtocolResolver
 }
 
 // NewNIMCacheReconciler returns NIMCacheReconciler for standalone mode.
@@ -80,15 +82,20 @@ func NewNIMCacheReconciler(r shared.Reconciler) *NIMCacheReconciler {
 // NewNIMServiceReconciler returns NIMServiceReconciler for standalone mode.
 func NewNIMServiceReconciler(ctx context.Context, r shared.Reconciler) *NIMServiceReconciler {
 	orchestratorType, _ := r.GetOrchestratorType(ctx)
+	registryReader := r.GetAPIReader()
+	if registryReader == nil {
+		registryReader = r.GetClient()
+	}
 
 	return &NIMServiceReconciler{
-		Client:           r.GetClient(),
-		scheme:           r.GetScheme(),
-		log:              r.GetLogger(),
-		updater:          r.GetUpdater(),
-		discoveryClient:  r.GetDiscoveryClient(),
-		recorder:         r.GetEventRecorder(),
-		orchestratorType: orchestratorType,
+		Client:                r.GetClient(),
+		scheme:                r.GetScheme(),
+		log:                   r.GetLogger(),
+		updater:               r.GetUpdater(),
+		discoveryClient:       r.GetDiscoveryClient(),
+		recorder:              r.GetEventRecorder(),
+		orchestratorType:      orchestratorType,
+		imageProtocolResolver: nimsource.NewProtocolResolver(registryReader),
 	}
 }
 

--- a/internal/nimsource/imageinspect.go
+++ b/internal/nimsource/imageinspect.go
@@ -1,0 +1,406 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nimsource
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"oras.land/oras-go/v2/content"
+	"oras.land/oras-go/v2/registry"
+	"oras.land/oras-go/v2/registry/remote"
+	"oras.land/oras-go/v2/registry/remote/auth"
+	"oras.land/oras-go/v2/registry/remote/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	appsv1alpha1 "github.com/NVIDIA/k8s-nim-operator/api/apps/v1alpha1"
+	"github.com/NVIDIA/k8s-nim-operator/internal/utils"
+)
+
+// ModelDownloadProtocolLabel is the OCI image config label that advertises how a
+// NIM downloads its model(s). The operator reads this label from the registry
+// before starting any container.
+const ModelDownloadProtocolLabel = "com.nvidia.nim.model_download_protocol"
+
+// Protocol is the model-download contract advertised by a NIM image.
+type Protocol string
+
+const (
+	// Legacy is the default Python/nim-sdk contract (model_manifest.yaml,
+	// list-model-profiles, download-to-cache, /model-store).
+	Legacy Protocol = ""
+	// NativeV1 is the NIMCraft single-model runtime that downloads on start
+	// (no download-to-cache) and persists weights under /model.
+	NativeV1 Protocol = "native-v1"
+)
+
+// IsNative reports whether the protocol uses the native download/serve layout.
+func (p Protocol) IsNative() bool {
+	return p == NativeV1
+}
+
+// ProtocolResolver determines a NIM image's model-download protocol without
+// starting the container.
+type ProtocolResolver interface {
+	Resolve(ctx context.Context, image, namespace string, pullSecrets []string) (Protocol, error)
+}
+
+// ModelLayout describes the volume layout for a serving workload.
+type ModelLayout struct {
+	Protocol Protocol
+}
+
+// ResolveModelLayout determines the model volume layout used by a serving
+// workload.
+//
+// When the workload is backed by a NIMCache, the NIMCache controller has already
+// resolved the model download protocol from the image's OCI label and persisted
+// it on the NIMCache status. A NIMService only renders its workload after its
+// NIMCache reports Ready, so that status is an authoritative, already-computed
+// source of truth. Trusting it avoids a registry round-trip on every NIMService
+// reconcile (and the accompanying failure surface) for the common cached path.
+//
+// For a direct NIMService with no NIMCache, the serving image is inspected via
+// ResolveProtocolOrLegacy, which falls back to legacy if the image cannot be
+// inspected (or no resolver is configured), keeping the feature zero-impact for
+// legacy NIMs.
+func ResolveModelLayout(ctx context.Context, resolver ProtocolResolver, nimService *appsv1alpha1.NIMService, nimCache *appsv1alpha1.NIMCache) (ModelLayout, error) {
+	if nimService == nil {
+		return ModelLayout{}, fmt.Errorf("nil NIMService")
+	}
+
+	if nimCache != nil && nimCache.Name != "" {
+		if nimCache.IsNativeModelDownload() {
+			return ModelLayout{Protocol: NativeV1}, nil
+		}
+		return ModelLayout{Protocol: Legacy}, nil
+	}
+
+	protocol := ResolveProtocolOrLegacy(ctx, resolver, nimService.GetImage(), nimService.Namespace, nimService.GetImagePullSecrets())
+	return ModelLayout{Protocol: protocol}, nil
+}
+
+// ResolveProtocolOrLegacy resolves an image's model download protocol and defaults to Legacy.
+// This keeps pre-start protocol detection zero-impact for legacy NIMs: only a successful inspection that positively
+// reports native-v1 diverts to the native path.
+func ResolveProtocolOrLegacy(ctx context.Context, resolver ProtocolResolver, image, namespace string, pullSecrets []string) Protocol {
+	if resolver == nil {
+		return Legacy
+	}
+	protocol, err := resolver.Resolve(ctx, image, namespace, pullSecrets)
+	if err != nil {
+		log.FromContext(ctx).Info("could not inspect image for model download protocol; assuming legacy",
+			"image", image, "error", err.Error())
+		return Legacy
+	}
+	return protocol
+}
+
+// NativeModelPathForCache returns the operator-owned model path for a native
+// NIMCache instance.
+func NativeModelPathForCache(nimCache *appsv1alpha1.NIMCache) string {
+	if nimCache == nil || nimCache.Name == "" {
+		return utils.NativeModelBasePath
+	}
+	return utils.NativeModelPath(nimCache.Name)
+}
+
+const mediaTypeDockerManifestList = "application/vnd.docker.distribution.manifest.list.v2+json"
+
+const (
+	dockerReferenceTypeAnnotation = "vnd.docker.reference.type"
+	attestationManifestType       = "attestation-manifest"
+)
+
+// labelSource fetches OCI config labels for an image. Tests inject fakes.
+type labelSource interface {
+	Labels(ctx context.Context, image, username, password string) ([]map[string]string, error)
+}
+
+type registryResolver struct {
+	secrets client.Reader
+	images  labelSource
+}
+
+// NewProtocolResolver returns a ProtocolResolver that inspects image config
+// labels via ORAS using Kubernetes image pull secrets for authentication.
+func NewProtocolResolver(secrets client.Reader) ProtocolResolver {
+	return newRegistryResolver(secrets, orasLabelSource{})
+}
+
+func newRegistryResolver(secrets client.Reader, images labelSource) ProtocolResolver {
+	return &registryResolver{secrets: secrets, images: images}
+}
+
+// Resolve inspects every runnable platform configuration for image and returns
+// NativeV1 only when every platform advertises that exact label value. An
+// absent/unknown label selects Legacy. Registry, authentication, and
+// inconsistent-platform errors fail reconciliation.
+func (r *registryResolver) Resolve(ctx context.Context, image, namespace string, pullSecrets []string) (Protocol, error) {
+	if image == "" {
+		return Legacy, fmt.Errorf("empty image reference")
+	}
+
+	username, password, err := r.credentials(ctx, namespace, image, pullSecrets)
+	if err != nil {
+		return Legacy, err
+	}
+
+	platformLabels, err := r.images.Labels(ctx, image, username, password)
+	if err != nil {
+		return Legacy, fmt.Errorf("inspect image %q: %w", image, err)
+	}
+	if len(platformLabels) == 0 {
+		return Legacy, fmt.Errorf("inspect image %q: no image configurations found", image)
+	}
+
+	labelValue := platformLabels[0][ModelDownloadProtocolLabel]
+	for _, labels := range platformLabels[1:] {
+		if current := labels[ModelDownloadProtocolLabel]; current != labelValue {
+			return Legacy, fmt.Errorf("inspect image %q: inconsistent model download protocols across platforms (%q and %q)", image, labelValue, current)
+		}
+	}
+	return protocolFromLabelValue(labelValue), nil
+}
+
+func protocolFromLabelValue(value string) Protocol {
+	if value == string(NativeV1) {
+		return NativeV1
+	}
+	return Legacy
+}
+
+type orasLabelSource struct{}
+
+func (orasLabelSource) Labels(ctx context.Context, image, username, password string) ([]map[string]string, error) {
+	ref, err := registry.ParseReference(image)
+	if err != nil {
+		return nil, fmt.Errorf("parse image reference: %w", err)
+	}
+
+	repo, err := remote.NewRepository(image)
+	if err != nil {
+		return nil, fmt.Errorf("create repository client: %w", err)
+	}
+
+	authClient := &auth.Client{
+		Client: retry.DefaultClient,
+		Cache:  auth.NewCache(),
+	}
+	authClient.SetUserAgent("k8s-nim-operator")
+	if username != "" || password != "" {
+		authClient.Credential = auth.StaticCredential(ref.Registry, auth.Credential{
+			Username: username,
+			Password: password,
+		})
+	}
+	repo.Client = authClient
+
+	desc, rc, err := repo.FetchReference(ctx, ref.Reference)
+	if err != nil {
+		return nil, fmt.Errorf("resolve reference: %w", err)
+	}
+	manifestBytes, err := readAllAndClose(rc)
+	if err != nil {
+		return nil, fmt.Errorf("read manifest: %w", err)
+	}
+
+	if desc.MediaType == ocispec.MediaTypeImageIndex || desc.MediaType == mediaTypeDockerManifestList {
+		var index ocispec.Index
+		if err := json.Unmarshal(manifestBytes, &index); err != nil {
+			return nil, fmt.Errorf("unmarshal image index: %w", err)
+		}
+		var labels []map[string]string
+		for _, child := range index.Manifests {
+			if !isPlatformImageDescriptor(child) {
+				continue
+			}
+			prc, err := repo.Manifests().Fetch(ctx, child)
+			if err != nil {
+				return nil, fmt.Errorf("fetch platform manifest %s: %w", child.Digest, err)
+			}
+			childBytes, err := readAllAndClose(prc)
+			if err != nil {
+				return nil, fmt.Errorf("read platform manifest %s: %w", child.Digest, err)
+			}
+			cfgLabels, err := labelsFromManifestBytes(ctx, repo, childBytes)
+			if err != nil {
+				return nil, fmt.Errorf("read platform config %s: %w", child.Digest, err)
+			}
+			labels = append(labels, cfgLabels)
+		}
+		return labels, nil
+	}
+
+	cfgLabels, err := labelsFromManifestBytes(ctx, repo, manifestBytes)
+	if err != nil {
+		return nil, err
+	}
+	return []map[string]string{cfgLabels}, nil
+}
+
+func labelsFromManifestBytes(ctx context.Context, repo *remote.Repository, manifestBytes []byte) (map[string]string, error) {
+	var manifest ocispec.Manifest
+	if err := json.Unmarshal(manifestBytes, &manifest); err != nil {
+		return nil, fmt.Errorf("unmarshal manifest: %w", err)
+	}
+	configBytes, err := content.FetchAll(ctx, repo.Blobs(), manifest.Config)
+	if err != nil {
+		return nil, fmt.Errorf("fetch image config: %w", err)
+	}
+	var image ocispec.Image
+	if err := json.Unmarshal(configBytes, &image); err != nil {
+		return nil, fmt.Errorf("unmarshal image config: %w", err)
+	}
+	if image.Config.Labels == nil {
+		return map[string]string{}, nil
+	}
+	return image.Config.Labels, nil
+}
+
+func isPlatformImageDescriptor(d ocispec.Descriptor) bool {
+	if d.Annotations[dockerReferenceTypeAnnotation] == attestationManifestType {
+		return false
+	}
+	if d.Platform != nil && (d.Platform.OS == "unknown" || d.Platform.Architecture == "unknown") {
+		return false
+	}
+	return true
+}
+
+func readAllAndClose(rc io.ReadCloser) ([]byte, error) {
+	defer rc.Close()
+	return io.ReadAll(rc)
+}
+
+type dockerConfigJSON struct {
+	Auths map[string]dockerAuthEntry `json:"auths"`
+}
+
+type dockerAuthEntry struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+	Auth     string `json:"auth"`
+}
+
+func (r *registryResolver) credentials(ctx context.Context, namespace, image string, pullSecrets []string) (string, string, error) {
+	if len(pullSecrets) == 0 {
+		return "", "", nil
+	}
+	ref, err := registry.ParseReference(image)
+	if err != nil {
+		return "", "", fmt.Errorf("parse image reference %q: %w", image, err)
+	}
+	targetHost := normalizeRegistryHost(ref.Registry)
+
+	for _, secretName := range pullSecrets {
+		if secretName == "" {
+			continue
+		}
+		secret := &corev1.Secret{}
+		if err := r.secrets.Get(ctx, types.NamespacedName{Name: secretName, Namespace: namespace}, secret); err != nil {
+			return "", "", fmt.Errorf("get image pull secret %q in namespace %q: %w", secretName, namespace, err)
+		}
+		data, ok := secret.Data[corev1.DockerConfigJsonKey]
+		if !ok {
+			return "", "", fmt.Errorf("pull secret %q in namespace %q does not contain %s", secretName, namespace, corev1.DockerConfigJsonKey)
+		}
+		username, password, found, err := credentialsForHost(targetHost, data)
+		if err != nil {
+			return "", "", fmt.Errorf("parse image pull secret %q in namespace %q: %w", secretName, namespace, err)
+		}
+		if found {
+			return username, password, nil
+		}
+	}
+	// No matching registry entry: anonymous access. Do not fall back to an
+	// unrelated single auth entry — that can send the wrong credentials.
+	return "", "", nil
+}
+
+// credentialsForHost extracts credentials for targetHost from a dockerconfigjson
+// payload. Matching is host-scoped (and Docker Hub alias aware). Returns
+// found=false when no matching entry exists.
+func credentialsForHost(targetHost string, configJSON []byte) (string, string, bool, error) {
+	var cfg dockerConfigJSON
+	if err := json.Unmarshal(configJSON, &cfg); err != nil {
+		return "", "", false, fmt.Errorf("unmarshal dockerconfigjson: %w", err)
+	}
+
+	aliases := registryAliases(targetHost)
+	var entry dockerAuthEntry
+	var matched bool
+	for host, e := range cfg.Auths {
+		normalized := normalizeRegistryHost(host)
+		for _, alias := range aliases {
+			if normalized == alias {
+				entry = e
+				matched = true
+				break
+			}
+		}
+		if matched {
+			break
+		}
+	}
+	if !matched {
+		return "", "", false, nil
+	}
+
+	if entry.Username != "" || entry.Password != "" {
+		return entry.Username, entry.Password, true, nil
+	}
+	if entry.Auth != "" {
+		decoded, err := base64.StdEncoding.DecodeString(entry.Auth)
+		if err != nil {
+			return "", "", false, fmt.Errorf("decode auth for registry %q: %w", targetHost, err)
+		}
+		user, pass, found := strings.Cut(string(decoded), ":")
+		if !found {
+			return "", "", false, fmt.Errorf("malformed auth entry for registry %q", targetHost)
+		}
+		return user, pass, true, nil
+	}
+	return "", "", true, nil
+}
+
+func registryAliases(host string) []string {
+	host = normalizeRegistryHost(host)
+	switch host {
+	case "", "docker.io", "index.docker.io", "registry-1.docker.io":
+		return []string{"docker.io", "index.docker.io", "registry-1.docker.io"}
+	default:
+		return []string{host}
+	}
+}
+
+func normalizeRegistryHost(host string) string {
+	host = strings.TrimPrefix(host, "https://")
+	host = strings.TrimPrefix(host, "http://")
+	if idx := strings.IndexByte(host, '/'); idx != -1 {
+		host = host[:idx]
+	}
+	return host
+}

--- a/internal/nimsource/imageinspect_test.go
+++ b/internal/nimsource/imageinspect_test.go
@@ -1,0 +1,274 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nimsource
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	appsv1alpha1 "github.com/NVIDIA/k8s-nim-operator/api/apps/v1alpha1"
+)
+
+const testImage = "registry.example.com/team/retriever:2.0"
+
+type fakeLabelSource struct {
+	labels []map[string]string
+	err    error
+}
+
+func (f *fakeLabelSource) Labels(_ context.Context, _ string, _, _ string) ([]map[string]string, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.labels, nil
+}
+
+func TestResolve(t *testing.T) {
+	tests := []struct {
+		name    string
+		labels  []map[string]string
+		err     error
+		want    Protocol
+		wantErr string
+	}{
+		{
+			name: "native-v1 on single platform",
+			labels: []map[string]string{
+				{ModelDownloadProtocolLabel: string(NativeV1)},
+			},
+			want: NativeV1,
+		},
+		{
+			name: "native-v1 on all platforms",
+			labels: []map[string]string{
+				{ModelDownloadProtocolLabel: string(NativeV1)},
+				{ModelDownloadProtocolLabel: string(NativeV1)},
+			},
+			want: NativeV1,
+		},
+		{
+			name: "absent label is legacy",
+			labels: []map[string]string{
+				{},
+			},
+			want: Legacy,
+		},
+		{
+			name: "unknown label is legacy",
+			labels: []map[string]string{
+				{ModelDownloadProtocolLabel: "future-v2"},
+			},
+			want: Legacy,
+		},
+		{
+			name: "mixed platform protocols fail",
+			labels: []map[string]string{
+				{ModelDownloadProtocolLabel: string(NativeV1)},
+				{},
+			},
+			wantErr: "inconsistent model download protocols",
+		},
+		{
+			name:    "inspect error fails",
+			err:     context.DeadlineExceeded,
+			wantErr: "inspect image",
+		},
+		{
+			name:    "no platforms fail",
+			labels:  []map[string]string{},
+			wantErr: "no image configurations found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolver := newRegistryResolver(fake.NewClientBuilder().Build(), &fakeLabelSource{labels: tt.labels, err: tt.err})
+			got, err := resolver.Resolve(context.Background(), testImage, "default", nil)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("Resolve() error = %v, want containing %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Resolve() unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("Resolve() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCredentialsForHost(t *testing.T) {
+	auth := base64.StdEncoding.EncodeToString([]byte("user:pass"))
+	cfg := []byte(`{"auths":{"https://nvcr.io/v2/":{"auth":"` + auth + `"}}}`)
+	user, pass, found, err := credentialsForHost("nvcr.io", cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found || user != "user" || pass != "pass" {
+		t.Fatalf("credentials = (%q,%q,%v), want (user,pass,true)", user, pass, found)
+	}
+
+	_, _, found, err = credentialsForHost("registry.example.com", cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if found {
+		t.Fatal("expected no credentials for unmatched host")
+	}
+}
+
+func TestResolveUsesMatchingPullSecret(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	auth := base64.StdEncoding.EncodeToString([]byte("ngc:token"))
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "ngc-secret", Namespace: "default"},
+		Type:       corev1.SecretTypeDockerConfigJson,
+		Data: map[string][]byte{
+			corev1.DockerConfigJsonKey: []byte(`{"auths":{"nvcr.io":{"auth":"` + auth + `"}}}`),
+		},
+	}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
+
+	source := &recordingLabelSource{labels: []map[string]string{{ModelDownloadProtocolLabel: string(NativeV1)}}}
+	resolver := newRegistryResolver(cli, source)
+	got, err := resolver.Resolve(context.Background(), "nvcr.io/nim/retriever:2.0.0", "default", []string{"ngc-secret"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != NativeV1 {
+		t.Fatalf("got %q, want native-v1", got)
+	}
+	if source.username != "ngc" || source.password != "token" {
+		t.Fatalf("credentials = (%q,%q), want (ngc,token)", source.username, source.password)
+	}
+}
+
+type recordingLabelSource struct {
+	labels             []map[string]string
+	username, password string
+}
+
+func (r *recordingLabelSource) Labels(_ context.Context, _ string, username, password string) ([]map[string]string, error) {
+	r.username, r.password = username, password
+	return r.labels, nil
+}
+
+// failingResolver fails if Resolve is ever called. Used to prove that a
+// NIMCache-backed layout is derived from the persisted NIMCache status without
+// any registry inspection.
+type failingResolver struct{}
+
+func (failingResolver) Resolve(context.Context, string, string, []string) (Protocol, error) {
+	return Legacy, fmt.Errorf("resolver should not be called")
+}
+
+// fixedResolver returns a fixed protocol for the direct (no NIMCache) path.
+type fixedResolver struct{ protocol Protocol }
+
+func (f fixedResolver) Resolve(context.Context, string, string, []string) (Protocol, error) {
+	return f.protocol, nil
+}
+
+func TestResolveProtocolOrLegacy(t *testing.T) {
+	if got := ResolveProtocolOrLegacy(context.Background(), nil, "img", "ns", nil); got != Legacy {
+		t.Fatalf("nil resolver: got %q, want legacy", got)
+	}
+	if got := ResolveProtocolOrLegacy(context.Background(), failingResolver{}, "img", "ns", nil); got != Legacy {
+		t.Fatalf("inspection error: got %q, want legacy", got)
+	}
+	if got := ResolveProtocolOrLegacy(context.Background(), fixedResolver{protocol: NativeV1}, "img", "ns", nil); got != NativeV1 {
+		t.Fatalf("native: got %q, want native-v1", got)
+	}
+}
+
+func TestResolveModelLayout(t *testing.T) {
+	service := &appsv1alpha1.NIMService{
+		ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "default"},
+		Spec: appsv1alpha1.NIMServiceSpec{
+			Image: appsv1alpha1.Image{Repository: "nvcr.io/nim/retriever", Tag: "2.0.0"},
+		},
+	}
+
+	t.Run("native NIMCache yields native layout without inspection", func(t *testing.T) {
+		cache := &appsv1alpha1.NIMCache{
+			ObjectMeta: metav1.ObjectMeta{Name: "cache", Namespace: "default"},
+			Status:     appsv1alpha1.NIMCacheStatus{Type: appsv1alpha1.NIMCacheModelTypeNative},
+		}
+		layout, err := ResolveModelLayout(context.Background(), failingResolver{}, service, cache)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !layout.Protocol.IsNative() {
+			t.Fatalf("protocol = %q, want native", layout.Protocol)
+		}
+	})
+
+	t.Run("non-native NIMCache yields legacy layout without inspection", func(t *testing.T) {
+		cache := &appsv1alpha1.NIMCache{
+			ObjectMeta: metav1.ObjectMeta{Name: "cache", Namespace: "default"},
+		}
+		layout, err := ResolveModelLayout(context.Background(), failingResolver{}, service, cache)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if layout.Protocol != Legacy {
+			t.Fatalf("protocol = %q, want legacy", layout.Protocol)
+		}
+	})
+
+	t.Run("direct NIMService inspects serving image", func(t *testing.T) {
+		layout, err := ResolveModelLayout(context.Background(), fixedResolver{protocol: NativeV1}, service, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !layout.Protocol.IsNative() {
+			t.Fatalf("protocol = %q, want native", layout.Protocol)
+		}
+	})
+
+	t.Run("direct NIMService with nil resolver defaults to legacy", func(t *testing.T) {
+		layout, err := ResolveModelLayout(context.Background(), nil, service, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if layout.Protocol != Legacy {
+			t.Fatalf("protocol = %q, want legacy", layout.Protocol)
+		}
+	})
+
+	t.Run("direct NIMService inspection error falls back to legacy without failing", func(t *testing.T) {
+		layout, err := ResolveModelLayout(context.Background(), failingResolver{}, service, nil)
+		if err != nil {
+			t.Fatalf("inspection error must not fail reconciliation: %v", err)
+		}
+		if layout.Protocol != Legacy {
+			t.Fatalf("protocol = %q, want legacy", layout.Protocol)
+		}
+	})
+}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"os"
+	"path"
 	"path/filepath"
 	"reflect"
 	"sort"
@@ -55,7 +56,24 @@ const (
 
 	// DefaultModelStorePath is the default path for model store.
 	DefaultModelStorePath = "/model-store"
+
+	// NativeModelBasePath is the base path where the native (NIMCraft) runtime
+	// downloads and expects the single model's weights (e.g. Retriever 2.0
+	// Rust/CUDA runtime). Per-instance model directories live under this path.
+	NativeModelBasePath = "/model"
+
+	// NativeKernelCachePath is the path where the native runtime persists
+	// compiled CUDA kernels (e.g. cudnn-sdpa-plan) across restarts.
+	NativeKernelCachePath = "/opt/cache"
 )
+
+// NativeModelPath returns the per-instance model directory for a native NIM,
+// i.e. NativeModelBasePath/<name>. Both the caching job and the serving workload
+// point NIM_ENGINE_MODEL_PATH at this path so a single PVC can hold the weights
+// of multiple native NIMs without collision.
+func NativeModelPath(name string) string {
+	return path.Join(NativeModelBasePath, name)
+}
 
 const (
 	// MinSupportedClusterVersionForDRA is the minimum supported cluster version for integration with DRA resources.


### PR DESCRIPTION
This PR will Update NIM Operator for Retriever 2.0 Changes:

**api/apps/v1alpha1/nimcache_types.go** - created two named constants with _NIMCacheModelTypeModelFree_ representing the pre-existing model-free path with _download-to-cache_ and _NIMCacheModelTypeNative_ representing the new pathway with _native-v1_ along with _IsNativeModelDownload()_ helper.
```
NIMCacheModelTypeModelFree = "model-free"
NIMCacheModelTypeNative = "native"
```


**internal/controller/nimcache_controller.go** - Added imageProtocolResolver nimsource.ProtocolResolver to the NIMCache reconciler struct. Created a helper function _resolveImageProtocol()_ which reads the OCI label from the registry.
...in _reconcileNIMCache()_, before we extract the manifest, we add a step to determine whether this is a Native download protocol. If it is Native, we can skip the manifest probe and profile selection; else, we will run _reconcileModelManifest_ and _reconcileModelSelection_. The reasoning for this is that model-free is only assigned inside _reconcileModelMainfest_ after the probe pod runs and doesn't find the model_manifest.yaml. Retriever images are slimmed down and ship without sh, so this would not work. Since, Retriever 2.0 has no engine profiles to select we can also skip _reconcileModelSelection_.
```
if protocol.IsNative() {
	logger.Info("detected native model download protocol, skipping manifest probe and profile selection", "nimcache", nimCache.Name)
	nimCache.Status.Type = appsv1alpha1.NIMCacheModelTypeNative
} else {
	if nimCache.Status.Type == appsv1alpha1.NIMCacheModelTypeNative {
		nimCache.Status.Type = ""   // clear stale native if image changed
	}
	requeue, err := r.reconcileModelManifest(ctx, nimCache)   // legacy probe
	...
	err = r.reconcileModelSelection(ctx, nimCache)            // legacy profiles
	...
}
```
...in _constructJob()_ a new case _nimCache.IsNativeModelDownload()_ is added that builds the single container that the native (Retriever 2.0 / NIMCraft) caching Job runs. Unlike the legacy branches, there's no download-to-cache command. The nimCache.IsNativeModelDownload() now holds the full container literal inline (image, NIM_ENGINE_MODEL_DOWNLOAD_ONLY=1 + NIM_ENGINE_MODEL_PATH=/model/'name', /model + /opt/cache + /scratch mounts.


**api/apps/v1alpha1/nimservice_types.go** - Two new methods define the native layout: _GetNativeVolumeMounts()_ and _GetNativeInitContainerVolumeMounts()_ . The PVC mounts at both /model and /opt/cache, so weights and compiled kernels both persist.

**internal/controller/platform/kserve/nimservice.go** - Added a guard against using Native, as the env vars assume the legacy /model-store layout, so native NIMs must not get them.
`if nimCache.IsUniversalNIM() && !modelLayout.Protocol.IsNative() {...}`
...inject the native model path env: it sets the same NIM_ENGINE_MODEL_PATH = /model/<name> that the caching Job used, so serving reads exactly where caching wrote. NativeModelPathForCache returns /model/<name> when a cache is referenced.
```
if modelLayout.Protocol.IsNative() {
    <params>.Env = utils.MergeEnvVars(<params>.Env, []corev1.EnvVar{{
        Name:  "NIM_ENGINE_MODEL_PATH",                 // (was utils.NativeModelPathEnv; we inlined it)
        Value: nimsource.NativeModelPathForCache(&nimCache),  // /model/<name>
    }})
}
```
Additionally, Native (NIMCraft) NIMs can auth with either NGC or Hugging Face, but the operator’s default env only wired up a required NGC_API_KEY. For modelLayout.Protocol.IsNative() we remove the required NGC_API_KEY from standard env, re-add NGC_API_KEY with Optional: true, and add HF_TOKEN with Optional: true. So a secret with only NGC, only HF, or both can start the pod.

```
isvcParams.Env = utils.RemoveEnvVar(isvcParams.Env, appsv1alpha1.NGCAPIKey)
isvcParams.Env = utils.MergeEnvVars(isvcParams.Env, []corev1.EnvVar{
			{
				Name: appsv1alpha1.NGCAPIKey,
				ValueFrom: &corev1.EnvVarSource{
					SecretKeyRef: &corev1.SecretKeySelector{
						LocalObjectReference: corev1.LocalObjectReference{
							Name: nimService.Spec.AuthSecret,
						},
						Key:      appsv1alpha1.NGCAPIKey,
						Optional: &[]bool{true}[0],
```
**internal/nimsource/imageinspect.go** - determines whether the NIM image uses the legacy download-to-cache contract or the native (Retriever 2.0) single-model runtime. The operator needs to know the NIM's model-download protocol before it creates any Job or Deployment. This file reads the image's config label com.nvidia.nim.model_download_protocol from the registry over the wire (via ORAS), authenticating with the relevant Kubernetes image pull secret, and maps it to a Protocol (native-v1 or legacy).

TESTING:
Verified the setup with the new Retriever images
```
local-agadiyar@ipp1-1210:~/k8s-nim-operator$ kubectl get nimcache,nimservice,pvc -n nim-test
NAME                                     STATUS   PVC                 AGE
nimcache.apps.nvidia.com/retriever-ocr   Ready    retriever-ocr-pvc   5m48s
nimcache.apps.nvidia.com/retriever-od    Ready    retriever-od-pvc    5m48s

NAME                                      STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   VOLUMEATTRIBUTESCLASS   AGE
persistentvolumeclaim/retriever-ocr-pvc   Bound    pvc-035f8a81-582a-4e9c-bb42-784f186c0738   50Gi       RWO            local-path     <unset>                 5m48s
persistentvolumeclaim/retriever-od-pvc    Bound    pvc-80878e8b-7571-4557-8cc2-8986bb896695   50Gi       RWO            local-path     <unset>                 5m47s
```
```
local-agadiyar@ipp1-1210:~/k8s-nim-operator$ kubectl get pod -n nim-test retriever-ocr-job-pqwv6 -o jsonpath='{range .spec.containers[*]}{.name}:{"\n"}{range .volumeMounts[*]}  {.mountPath} (subPath={.subPath}){"\n"}{end}{end}'
nim-cache-ctr:
  /model (subPath=)
  /opt/cache (subPath=)
  /scratch (subPath=)
  /var/run/secrets/kubernetes.io/serviceaccount (subPath=)
local-agadiyar@ipp1-1210:~/k8s-nim-operator$ kubectl get pod -n nim-test retriever-od-job-f5gm4 -o jsonpath='{range .spec.containers[*]}{.name}:{"\n"}{range .volumeMounts[*]}  {.mountPath} (subPath={.subPath}){"\n"}{end}{end}'
nim-cache-ctr:
  /model (subPath=)
  /opt/cache (subPath=)
  /scratch (subPath=)
  /var/run/secrets/kubernetes.io/serviceaccount (subPath=)
```