### PR TITLE
fix: compress large model manifests to fit ConfigMap size limit

### DIFF
--- a/internal/controller/nimbuild_controller.go
+++ b/internal/controller/nimbuild_controller.go
@@ -1039,22 +1039,28 @@ func (r *NIMBuildReconciler) updateManifestConfigMap(ctx context.Context, nimCac
 		},
 	}
 
-	// Create the ConfigMap
+	// Create the ConfigMap. Small manifests are stored as plaintext for backward
+	// compatibility; large ones are gzip-compressed into binaryData so the
+	// ConfigMap stays under the 1 MiB limit (mirrors NIMCache manifest storage).
+	var setErr error
 	if err := k8sutil.RetryUpdate(ctx, r.Client, configMap, func(obj client.Object) {
 		cm, ok := obj.(*corev1.ConfigMap)
 		if !ok {
 			return
 		}
-		if cm.Data == nil {
-			cm.Data = make(map[string]string)
+		if _, err := utils.SetManifestConfigMapData(cm, LocalModelManifestKey, prettyManifestBytes); err != nil {
+			setErr = err
+			return
 		}
-		cm.Data["local_model_manifest.yaml"] = string(prettyManifestBytes)
 		if cm.Labels == nil {
 			cm.Labels = make(map[string]string)
 		}
 		cm.Labels["app"] = nimCache.GetName()
 	}); err != nil {
 		return fmt.Errorf("failed to create manifest ConfigMap %s: %w", configMap.Name, err)
+	}
+	if setErr != nil {
+		return fmt.Errorf("failed to set local manifest data for ConfigMap %s: %w", configMap.Name, setErr)
 	}
 	return nil
 }

--- a/internal/controller/nimcache_controller.go
+++ b/internal/controller/nimcache_controller.go
@@ -78,6 +78,15 @@ const (
 
 	// NIMCacheContainerName returns the name of the container used for NIM Cache operations.
 	NIMCacheContainerName = "nim-cache-ctr"
+
+	// ModelManifestKey is the ConfigMap key under which the extracted model
+	// manifest is stored (plaintext in Data, or gzip-compressed in BinaryData
+	// under ModelManifestKey+".gz" for large manifests).
+	ModelManifestKey = "model_manifest.yaml"
+
+	// LocalModelManifestKey is the ConfigMap key under which NIMBuild stores the
+	// locally-built model manifest (same plaintext/gzip handling as above).
+	LocalModelManifestKey = "local_model_manifest.yaml"
 )
 
 // NIMCacheReconciler reconciles a NIMCache object.
@@ -1352,13 +1361,16 @@ func (r *NIMCacheReconciler) extractNIMManifest(ctx context.Context, configName,
 		return nil, fmt.Errorf("unable to get ConfigMap %s: %w", configName, err)
 	}
 
-	data, ok := configMap.Data["model_manifest.yaml"]
+	data, ok, err := utils.GetManifestConfigMapData(configMap, ModelManifestKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read manifest data from ConfigMap %s: %w", configName, err)
+	}
 	if !ok {
 		return nil, fmt.Errorf("model_manifest.yaml not found in ConfigMap")
 	}
 
-	parser := nimparserutils.GetNIMParser([]byte(data))
-	manifest, err := parser.ParseModelManifestFromRawOutput([]byte(data))
+	parser := nimparserutils.GetNIMParser(data)
+	manifest, err := parser.ParseModelManifestFromRawOutput(data)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal manifest data: %w", err)
 	}
@@ -1396,9 +1408,17 @@ func (r *NIMCacheReconciler) createManifestConfigMap(ctx context.Context, nimCac
 		return err
 	}
 
-	// Update the data
-	configMap.Data = map[string]string{
-		"model_manifest.yaml": string(manifestBytes),
+	// Store the manifest. Small manifests are kept as plaintext for backward
+	// compatibility; large manifests (e.g. models with many profiles) are
+	// gzip-compressed into binaryData so they stay under the 1 MiB ConfigMap limit.
+	compressed, err := utils.SetManifestConfigMapData(configMap, ModelManifestKey, manifestBytes)
+	if err != nil {
+		return fmt.Errorf("failed to set manifest data for ConfigMap %s: %w", configMap.Name, err)
+	}
+	if compressed {
+		r.log.Info("Storing gzip-compressed model manifest in ConfigMap binaryData",
+			"configMap", configMap.Name, "rawBytes", len(manifestBytes),
+			"compressedBytes", len(configMap.BinaryData[ModelManifestKey+utils.GzipCompressedKeySuffix]))
 	}
 
 	// Create the ConfigMap

--- a/internal/controller/nimcache_controller_test.go
+++ b/internal/controller/nimcache_controller_test.go
@@ -39,10 +39,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
+	"sigs.k8s.io/yaml"
+
 	appsv1alpha1 "github.com/NVIDIA/k8s-nim-operator/api/apps/v1alpha1"
 	"github.com/NVIDIA/k8s-nim-operator/internal/k8sutil"
 	nimparserv1 "github.com/NVIDIA/k8s-nim-operator/internal/nimparser/v1"
 	"github.com/NVIDIA/k8s-nim-operator/internal/shared"
+	"github.com/NVIDIA/k8s-nim-operator/internal/utils"
 )
 
 var _ = Describe("NIMCache Controller", func() {
@@ -104,6 +107,51 @@ var _ = Describe("NIMCache Controller", func() {
 			},
 		}
 		_ = cli.Delete(context.TODO(), nimCache)
+	})
+
+	Context("When the manifest ConfigMap is gzip-compressed", func() {
+		It("extractNIMManifest transparently decompresses and parses it", func() {
+			nimCache := &appsv1alpha1.NIMCache{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-nimcache-gz",
+					Namespace: "default",
+				},
+				Spec: appsv1alpha1.NIMCacheSpec{
+					Source: appsv1alpha1.NIMSource{NGC: &appsv1alpha1.NGCSource{ModelPuller: "nvcr.io/nim:test", PullSecret: "my-secret"}},
+				},
+			}
+
+			// Parse a real manifest and marshal it back to YAML bytes.
+			filePath := filepath.Join("testdata", "manifest_trtllm.yaml")
+			parser := nimparserv1.NIMParser{}
+			manifestData, err := parser.ParseModelManifest(filePath)
+			Expect(err).NotTo(HaveOccurred())
+			manifestBytes, err := yaml.Marshal(&manifestData)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Store it gzip-compressed in BinaryData, simulating a large manifest
+			// that exceeded the plaintext threshold.
+			gz, err := utils.CompressData(manifestBytes)
+			Expect(err).NotTo(HaveOccurred())
+			cm := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      getManifestConfigName(nimCache),
+					Namespace: nimCache.Namespace,
+				},
+				BinaryData: map[string][]byte{
+					ModelManifestKey + utils.GzipCompressedKeySuffix: gz,
+				},
+			}
+			Expect(cli.Create(context.TODO(), cm)).To(Succeed())
+
+			// extractNIMManifest should transparently decompress + parse.
+			manifest, err := reconciler.extractNIMManifest(context.TODO(), cm.Name, cm.Namespace)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(manifest).NotTo(BeNil())
+			Expect(manifest.GetProfilesList()).To(ConsistOf(manifestData.GetProfilesList()))
+
+			Expect(cli.Delete(context.TODO(), cm)).To(Succeed())
+		})
 	})
 
 	Context("When creating a NIMCache", func() {

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -17,10 +17,13 @@
 package utils
 
 import (
+	"bytes"
+	"compress/gzip"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"hash/fnv"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -523,4 +526,95 @@ func FindEnvByValue(envs []corev1.EnvVar, key string) *corev1.EnvVar {
 		}
 	}
 	return nil
+}
+
+// ManifestConfigMapMaxPlaintextBytes is the size threshold (in bytes) above which
+// manifest content is gzip-compressed into a ConfigMap's binaryData instead of
+// being stored as plaintext in its data. It is kept well under the Kubernetes
+// 1 MiB (1048576 bytes) ConfigMap limit to leave headroom for other keys and
+// object metadata. Payloads at or below this threshold are stored as plaintext
+// so behavior (and downgrade-compatibility) is unchanged for the common case.
+const ManifestConfigMapMaxPlaintextBytes = 900 * 1024
+
+// GzipCompressedKeySuffix is appended to a manifest key when its value is stored
+// gzip-compressed in a ConfigMap's binaryData.
+const GzipCompressedKeySuffix = ".gz"
+
+// CompressData gzip-compresses the given bytes using the best compression level.
+func CompressData(data []byte) ([]byte, error) {
+	var buf bytes.Buffer
+	gw, err := gzip.NewWriterLevel(&buf, gzip.BestCompression)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create gzip writer: %w", err)
+	}
+	if _, err := gw.Write(data); err != nil {
+		_ = gw.Close()
+		return nil, fmt.Errorf("failed to gzip data: %w", err)
+	}
+	if err := gw.Close(); err != nil {
+		return nil, fmt.Errorf("failed to finalize gzip data: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+// DecompressData gzip-decompresses the given bytes.
+func DecompressData(data []byte) ([]byte, error) {
+	gr, err := gzip.NewReader(bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create gzip reader: %w", err)
+	}
+	defer gr.Close()
+	out, err := io.ReadAll(gr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to gunzip data: %w", err)
+	}
+	return out, nil
+}
+
+// SetManifestConfigMapData stores manifest bytes into the ConfigMap under baseKey.
+//
+// Small payloads (<= ManifestConfigMapMaxPlaintextBytes) are stored as plaintext
+// in cm.Data[baseKey] to preserve existing behavior and remain readable by older
+// operator versions. Larger payloads that would otherwise approach the 1 MiB
+// ConfigMap limit are gzip-compressed into cm.BinaryData[baseKey+".gz"] instead.
+// The counterpart representation of the same key is removed so only one form is
+// ever present. It returns true when the compressed form was used.
+func SetManifestConfigMapData(cm *corev1.ConfigMap, baseKey string, raw []byte) (bool, error) {
+	gzKey := baseKey + GzipCompressedKeySuffix
+	if len(raw) <= ManifestConfigMapMaxPlaintextBytes {
+		if cm.Data == nil {
+			cm.Data = map[string]string{}
+		}
+		cm.Data[baseKey] = string(raw)
+		delete(cm.BinaryData, gzKey)
+		return false, nil
+	}
+	compressed, err := CompressData(raw)
+	if err != nil {
+		return false, err
+	}
+	if cm.BinaryData == nil {
+		cm.BinaryData = map[string][]byte{}
+	}
+	cm.BinaryData[gzKey] = compressed
+	delete(cm.Data, baseKey)
+	return true, nil
+}
+
+// GetManifestConfigMapData retrieves manifest bytes stored under baseKey,
+// transparently handling both the gzip-compressed (cm.BinaryData[baseKey+".gz"])
+// and plaintext (cm.Data[baseKey]) representations. The compressed form takes
+// precedence. The second return value reports whether the key was found.
+func GetManifestConfigMapData(cm *corev1.ConfigMap, baseKey string) ([]byte, bool, error) {
+	if gz, ok := cm.BinaryData[baseKey+GzipCompressedKeySuffix]; ok {
+		raw, err := DecompressData(gz)
+		if err != nil {
+			return nil, true, err
+		}
+		return raw, true, nil
+	}
+	if s, ok := cm.Data[baseKey]; ok {
+		return []byte(s), true, nil
+	}
+	return nil, false, nil
 }

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -19,6 +19,7 @@ package utils
 import (
 	"os"
 	"path/filepath"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -330,4 +331,169 @@ var _ = Describe("Utils", func() {
 		Entry("empty version", "", "v1.33.0", false),
 		Entry("empty min version", "v1.33.0", "", false),
 	)
+})
+
+var _ = Describe("Manifest ConfigMap compression helpers", func() {
+	Describe("CompressData/DecompressData", func() {
+		It("round-trips arbitrary content", func() {
+			original := []byte(strings.Repeat("nim-operator manifest content\n", 5000))
+			compressed, err := CompressData(original)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(compressed)).To(BeNumerically("<", len(original)), "gzip should shrink repetitive content")
+
+			decompressed, err := DecompressData(compressed)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(decompressed).To(Equal(original))
+		})
+
+		It("round-trips empty input", func() {
+			compressed, err := CompressData([]byte{})
+			Expect(err).NotTo(HaveOccurred())
+			decompressed, err := DecompressData(compressed)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(decompressed).To(HaveLen(0))
+		})
+
+		It("returns an error for non-gzip input", func() {
+			_, err := DecompressData([]byte("this is not gzip"))
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("SetManifestConfigMapData", func() {
+		const key = "model_manifest.yaml"
+		const gzKey = "model_manifest.yaml" + GzipCompressedKeySuffix
+
+		It("stores small payloads as plaintext in Data", func() {
+			cm := &corev1.ConfigMap{}
+			small := []byte("small manifest")
+
+			compressed, err := SetManifestConfigMapData(cm, key, small)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(compressed).To(BeFalse())
+			Expect(cm.Data).To(HaveKeyWithValue(key, string(small)))
+			Expect(cm.BinaryData).NotTo(HaveKey(gzKey))
+		})
+
+		It("stores payloads exactly at the threshold as plaintext", func() {
+			cm := &corev1.ConfigMap{}
+			atLimit := make([]byte, ManifestConfigMapMaxPlaintextBytes)
+
+			compressed, err := SetManifestConfigMapData(cm, key, atLimit)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(compressed).To(BeFalse())
+			Expect(cm.Data).To(HaveKey(key))
+			Expect(cm.BinaryData).NotTo(HaveKey(gzKey))
+		})
+
+		It("gzip-compresses payloads above the threshold into BinaryData", func() {
+			cm := &corev1.ConfigMap{}
+			// Repetitive content compresses well and exceeds the plaintext threshold.
+			large := []byte(strings.Repeat("a", ManifestConfigMapMaxPlaintextBytes+1))
+
+			compressed, err := SetManifestConfigMapData(cm, key, large)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(compressed).To(BeTrue())
+			Expect(cm.Data).NotTo(HaveKey(key))
+			Expect(cm.BinaryData).To(HaveKey(gzKey))
+			Expect(len(cm.BinaryData[gzKey])).To(BeNumerically("<", len(large)))
+		})
+
+		It("removes a stale plaintext entry when switching to compressed", func() {
+			cm := &corev1.ConfigMap{Data: map[string]string{key: "stale plaintext"}}
+			large := []byte(strings.Repeat("b", ManifestConfigMapMaxPlaintextBytes+1))
+
+			compressed, err := SetManifestConfigMapData(cm, key, large)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(compressed).To(BeTrue())
+			Expect(cm.Data).NotTo(HaveKey(key))
+			Expect(cm.BinaryData).To(HaveKey(gzKey))
+		})
+
+		It("removes a stale compressed entry when switching to plaintext", func() {
+			cm := &corev1.ConfigMap{BinaryData: map[string][]byte{gzKey: []byte("stale gz")}}
+			small := []byte("now small")
+
+			compressed, err := SetManifestConfigMapData(cm, key, small)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(compressed).To(BeFalse())
+			Expect(cm.BinaryData).NotTo(HaveKey(gzKey))
+			Expect(cm.Data).To(HaveKeyWithValue(key, string(small)))
+		})
+	})
+
+	Describe("GetManifestConfigMapData", func() {
+		const key = "model_manifest.yaml"
+		const gzKey = "model_manifest.yaml" + GzipCompressedKeySuffix
+
+		It("reads plaintext content from Data", func() {
+			cm := &corev1.ConfigMap{Data: map[string]string{key: "plain content"}}
+			data, ok, err := GetManifestConfigMapData(cm, key)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeTrue())
+			Expect(data).To(Equal([]byte("plain content")))
+		})
+
+		It("reads and decompresses content from BinaryData", func() {
+			gz, err := CompressData([]byte("compressed content"))
+			Expect(err).NotTo(HaveOccurred())
+			cm := &corev1.ConfigMap{BinaryData: map[string][]byte{gzKey: gz}}
+
+			data, ok, err := GetManifestConfigMapData(cm, key)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeTrue())
+			Expect(data).To(Equal([]byte("compressed content")))
+		})
+
+		It("prefers the compressed entry when both are present", func() {
+			gz, err := CompressData([]byte("compressed wins"))
+			Expect(err).NotTo(HaveOccurred())
+			cm := &corev1.ConfigMap{
+				Data:       map[string]string{key: "plaintext loses"},
+				BinaryData: map[string][]byte{gzKey: gz},
+			}
+
+			data, ok, err := GetManifestConfigMapData(cm, key)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeTrue())
+			Expect(data).To(Equal([]byte("compressed wins")))
+		})
+
+		It("reports not found when neither representation exists", func() {
+			cm := &corev1.ConfigMap{}
+			_, ok, err := GetManifestConfigMapData(cm, key)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeFalse())
+		})
+
+		It("returns an error for corrupt compressed content", func() {
+			cm := &corev1.ConfigMap{BinaryData: map[string][]byte{gzKey: []byte("not gzip")}}
+			_, ok, err := GetManifestConfigMapData(cm, key)
+			Expect(err).To(HaveOccurred())
+			Expect(ok).To(BeTrue())
+		})
+	})
+
+	Describe("Round-trip via Set then Get", func() {
+		const key = "model_manifest.yaml"
+
+		DescribeTable("preserves content across the storage boundary",
+			func(size int) {
+				cm := &corev1.ConfigMap{}
+				original := []byte(strings.Repeat("x", size))
+
+				_, err := SetManifestConfigMapData(cm, key, original)
+				Expect(err).NotTo(HaveOccurred())
+
+				got, ok, err := GetManifestConfigMapData(cm, key)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ok).To(BeTrue())
+				Expect(got).To(Equal(original))
+			},
+			Entry("tiny plaintext", 16),
+			Entry("just below threshold", ManifestConfigMapMaxPlaintextBytes-1),
+			Entry("just above threshold (compressed)", ManifestConfigMapMaxPlaintextBytes+1),
+			Entry("well above threshold (compressed)", 2*ManifestConfigMapMaxPlaintextBytes),
+		)
+	})
 })


### PR DESCRIPTION
## Summary

`NIMCache` (and `NIMBuild`) store the extracted `model_manifest.yaml` — and the
built `local_model_manifest.yaml` — in a `ConfigMap`'s `Data` field. For models
with many profiles the manifest exceeds the hard **1 MiB (1048576 bytes)**
Kubernetes ConfigMap limit, so reconciliation fails and the model can never be
cached.

Example: `nemotron-3-ultra` produces a **~1.63 MiB** manifest, and the operator
fails with:

```
ConfigMap "<name>" is invalid: []: Too long: may not be more than 1048576 bytes
```

This affects large models regardless of GPU type (H100/H200/B200/B300) and
regardless of the profile requested — the operator stores the *full* manifest
before any profile filtering.

## Fix

Introduce a **threshold-hybrid** storage scheme in `internal/utils`:

- `SetManifestConfigMapData(cm, key, raw)`
  - `len(raw) <= 900 KiB` → store as plaintext in `Data[key]` (unchanged behavior)
  - otherwise → gzip-compress into `BinaryData[key + ".gz"]`
  - removes the counterpart representation so only one form is ever present
- `GetManifestConfigMapData(cm, key)`
  - reads transparently, preferring the compressed form, falling back to plaintext

These helpers are wired into:

- `nimcache_controller.go`: `createManifestConfigMap` (write) and `extractNIMManifest` (read)
- `nimbuild_controller.go`: `updateManifestConfigMap` (write of `local_model_manifest.yaml`)

The `nemotron-3-ultra` manifest compresses from **~1.63 MiB → ~0.34 MiB**, well
under the limit (~4.8× ratio).

## Backward compatibility

- Small manifests keep the exact plaintext form, so behavior is unchanged for the common case.
- Readers handle **both** representations, so existing ConfigMaps continue to work with **no migration**.
- The manifest ConfigMap is only read in-process by the operator (never mounted as a volume), so moving large payloads to `BinaryData` has no consumer-side impact.
- Minor downgrade caveat: a manifest written by a new operator in compressed form would not be readable by an *older* operator that only reads `Data[...]`. Small (plaintext) manifests remain fully downgrade-safe.

## Testing

- Unit tests (`internal/utils`): gzip round-trip (incl. empty + corrupt input), plaintext/gzip threshold (below / at / above), stale-entry cleanup on switch, read precedence/fallback/not-found/corrupt, and a `Set`→`Get` round-trip table across sizes.
- Controller test (`internal/controller`): `extractNIMManifest` transparently decompresses and parses a gzip-stored manifest ConfigMap.
- Verified end-to-end against a **real kube-apiserver** (envtest, which enforces the real 1 MiB limit) using the actual 1.63 MiB `nemotron-3-ultra` manifest:
  - plaintext `ConfigMap.Create` → rejected with `Too long` (reproduces the bug)
  - compressed `ConfigMap.Create` → succeeds
  - round-trip read is byte-identical to the original manifest

```
go build ./...                     # ok
go vet ./internal/...              # ok
go test ./internal/utils/...       # ok
go test ./internal/controller/...  # ok
```

## Notes / relationship to #886

This is orthogonal to #886 (native model download protocol). #886 only bypasses
the manifest-ConfigMap path for images labeled
`com.nvidia.nim.model_download_protocol=native-v1`. Standard LLM images that use
the legacy manifest/profile flow (e.g. `nemotron-3-ultra`, which does **not**
carry that label) still hit the 1 MiB limit; this PR fixes that path directly,
and the two changes can coexist.

## How to reproduce (before this fix)

```yaml
apiVersion: apps.nvidia.com/v1alpha1
kind: NIMCache
metadata:
  name: nemotron-3-ultra
spec:
  source:
    ngc:
      modelPuller: nvcr.io/nim/nvidia/nemotron-3-ultra-ga:<tag>
      pullSecret: ngc-secret
  storage:
    pvc:
      create: true
      storageClass: <sc>
      size: "500Gi"
```

The `NIMCache` goes to `Failed` with the `Too long: may not be more than 1048576 bytes` error in the operator logs.