### PR TITLE
Update Kserve Serverless Deployment for scale-to-zero

### DIFF
--- a/api/apps/v1alpha1/nimservice_types.go
+++ b/api/apps/v1alpha1/nimservice_types.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"maps"
 	"os"
+	"strconv"
 	"strings"
 
 	kserveconstants "github.com/kserve/kserve/pkg/constants"
@@ -1840,6 +1841,34 @@ func (n *NIMService) GetHostPath() string {
 	return ""
 }
 
+const (
+	// knativeMinScaleAnnotation is the Knative annotation for the minimum number
+	// of pods (autoscaling.knative.dev/min-scale). A value of "0" enables
+	// scale-to-zero.
+	knativeMinScaleAnnotation = "autoscaling.knative.dev/min-scale"
+	// knativeMaxScaleAnnotation is the Knative annotation for the maximum number
+	// of pods (autoscaling.knative.dev/max-scale). A value of "0" means unbounded.
+	knativeMaxScaleAnnotation = "autoscaling.knative.dev/max-scale"
+)
+
+// parseKnativeScaleAnnotation parses a Knative scale annotation (min-scale /
+// max-scale) into an *int32. It returns (nil, nil) when the annotation is absent
+// or empty, and an error when the value is not a valid non-negative int32.
+func parseKnativeScaleAnnotation(annotations map[string]string, key string) (*int32, error) {
+	value, ok := annotations[key]
+	if !ok || value == "" {
+		return nil, nil
+	}
+	parsed, err := strconv.ParseInt(value, 10, 32)
+	if err != nil {
+		return nil, fmt.Errorf("invalid %s annotation %q: %w", key, value, err)
+	}
+	if parsed < 0 {
+		return nil, fmt.Errorf("invalid %s annotation %q: must not be negative", key, value)
+	}
+	return ptr.To(int32(parsed)), nil
+}
+
 // GetInferenceServiceParams returns params to render InferenceService from templates.
 func (n *NIMService) GetInferenceServiceParams(
 	deploymentMode kserveconstants.DeploymentModeType) *rendertypes.InferenceServiceParams {
@@ -1885,6 +1914,24 @@ func (n *NIMService) GetInferenceServiceParams(
 			params.ScaleMetric = ""
 			params.ScaleMetricType = ""
 			params.ScaleTarget = nil
+		}
+	} else if utils.IsKServeKnativeDeploymentMode(deploymentMode) {
+		// In KServe serverless (Knative) mode, scaling is handled by the Knative
+		// KPA. KServe keeps autoscaling.knative.dev/min-scale and max-scale on its
+		// ServiceAnnotationDisallowedList and regenerates them from the typed
+		// predictor.minReplicas/maxReplicas fields (min-scale defaults to 1 when
+		// minReplicas is nil, which makes scale-to-zero impossible). HPA-based
+		// autoscaling (spec.scale.enabled) is rejected by the webhook in this mode,
+		// so users express scale bounds via the Knative annotations. Translate those
+		// annotations into the typed fields here so they survive KServe rendering.
+		// A minReplicas of 0 enables scale-to-zero.
+		if minReplicas, err := parseKnativeScaleAnnotation(params.Annotations, knativeMinScaleAnnotation); err == nil && minReplicas != nil {
+			params.MinReplicas = minReplicas
+		}
+		// max-scale of 0 means "unbounded" in Knative; leave MaxReplicas unset so
+		// KServe omits max-scale rather than pinning it to 0.
+		if maxReplicas, err := parseKnativeScaleAnnotation(params.Annotations, knativeMaxScaleAnnotation); err == nil && maxReplicas != nil && *maxReplicas > 0 {
+			params.MaxReplicas = maxReplicas
 		}
 	}
 

--- a/api/apps/v1alpha1/nimservice_types.go
+++ b/api/apps/v1alpha1/nimservice_types.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"maps"
 	"os"
+	"strconv"
 	"strings"
 
 	kserveconstants "github.com/kserve/kserve/pkg/constants"
@@ -37,6 +38,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	sigsyaml "sigs.k8s.io/yaml"
 
@@ -1847,6 +1849,34 @@ func (n *NIMService) GetHostPath() string {
 	return ""
 }
 
+const (
+	// knativeMinScaleAnnotation is the Knative annotation for the minimum number
+	// of pods (autoscaling.knative.dev/min-scale). A value of "0" enables
+	// scale-to-zero.
+	knativeMinScaleAnnotation = "autoscaling.knative.dev/min-scale"
+	// knativeMaxScaleAnnotation is the Knative annotation for the maximum number
+	// of pods (autoscaling.knative.dev/max-scale). A value of "0" means unbounded.
+	knativeMaxScaleAnnotation = "autoscaling.knative.dev/max-scale"
+)
+
+// parseKnativeScaleAnnotation parses a Knative scale annotation (min-scale /
+// max-scale) into an *int32. It returns (nil, nil) when the annotation is absent
+// or empty, and an error when the value is not a valid non-negative int32.
+func parseKnativeScaleAnnotation(annotations map[string]string, key string) (*int32, error) {
+	value, ok := annotations[key]
+	if !ok || value == "" {
+		return nil, nil
+	}
+	parsed, err := strconv.ParseInt(value, 10, 32)
+	if err != nil {
+		return nil, fmt.Errorf("invalid %s annotation %q: %w", key, value, err)
+	}
+	if parsed < 0 {
+		return nil, fmt.Errorf("invalid %s annotation %q: must not be negative", key, value)
+	}
+	return ptr.To(int32(parsed)), nil
+}
+
 // GetInferenceServiceParams returns params to render InferenceService from templates.
 func (n *NIMService) GetInferenceServiceParams(
 	deploymentMode kserveconstants.DeploymentModeType) *rendertypes.InferenceServiceParams {
@@ -1892,6 +1922,30 @@ func (n *NIMService) GetInferenceServiceParams(
 			params.ScaleMetric = ""
 			params.ScaleMetricType = ""
 			params.ScaleTarget = nil
+		}
+	} else if utils.IsKServeKnativeDeploymentMode(deploymentMode) {
+		// In KServe serverless (Knative) mode, scaling is handled by the Knative
+		// KPA. KServe keeps autoscaling.knative.dev/min-scale and max-scale on its
+		// ServiceAnnotationDisallowedList and regenerates them from the typed
+		// predictor.minReplicas/maxReplicas fields (min-scale defaults to 1 when
+		// minReplicas is nil, which makes scale-to-zero impossible). HPA-based
+		// autoscaling (spec.scale.enabled) is rejected by the webhook in this mode,
+		// so users express scale bounds via the Knative annotations. Translate those
+		// annotations into the typed fields here so they survive KServe rendering.
+		// A minReplicas of 0 enables scale-to-zero.
+		minReplicas, err := parseKnativeScaleAnnotation(params.Annotations, knativeMinScaleAnnotation)
+		if err != nil {
+			log.Log.Error(err, "invalid Knative min-scale annotation; KServe will default minReplicas to 1", "nimservice", n.Name)
+		} else if minReplicas != nil {
+			params.MinReplicas = minReplicas
+		}
+		// max-scale of 0 means "unbounded" in Knative; leave MaxReplicas unset so
+		// KServe omits max-scale rather than pinning it to 0.
+		maxReplicas, err := parseKnativeScaleAnnotation(params.Annotations, knativeMaxScaleAnnotation)
+		if err != nil {
+			log.Log.Error(err, "invalid Knative max-scale annotation; maxReplicas will be left unset (unbounded)", "nimservice", n.Name)
+		} else if maxReplicas != nil && *maxReplicas > 0 {
+			params.MaxReplicas = maxReplicas
 		}
 	}
 

--- a/api/apps/v1alpha1/nimservice_types_test.go
+++ b/api/apps/v1alpha1/nimservice_types_test.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"testing"
 
+	kserveconstants "github.com/kserve/kserve/pkg/constants"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -857,6 +858,123 @@ func TestGetInferenceServiceParams(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestParseKnativeScaleAnnotation covers parsing of the Knative scale annotations.
+func TestParseKnativeScaleAnnotation(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		present bool
+		want    *int32
+		wantErr bool
+	}{
+		{name: "absent", present: false, want: nil},
+		{name: "empty", present: true, value: "", want: nil},
+		{name: "zero (scale-to-zero)", present: true, value: "0", want: ptr.To[int32](0)},
+		{name: "positive", present: true, value: "5", want: ptr.To[int32](5)},
+		{name: "negative", present: true, value: "-1", wantErr: true},
+		{name: "non-numeric", present: true, value: "abc", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			annotations := map[string]string{}
+			if tt.present {
+				annotations[knativeMinScaleAnnotation] = tt.value
+			}
+			got, err := parseKnativeScaleAnnotation(annotations, knativeMinScaleAnnotation)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			switch {
+			case tt.want == nil && got != nil:
+				t.Fatalf("got %d, want nil", *got)
+			case tt.want != nil && got == nil:
+				t.Fatalf("got nil, want %d", *tt.want)
+			case tt.want != nil && got != nil && *got != *tt.want:
+				t.Fatalf("got %d, want %d", *got, *tt.want)
+			}
+		})
+	}
+}
+
+// TestGetInferenceServiceParamsKnativeScale verifies that Knative scale
+// annotations are translated into the typed predictor min/max replica fields in
+// serverless mode, enabling scale-to-zero.
+func TestGetInferenceServiceParamsKnativeScale(t *testing.T) {
+	newSvc := func(annotations map[string]string) *NIMService {
+		return &NIMService{
+			Spec: NIMServiceSpec{
+				Image:       Image{Repository: "test-repo", Tag: "test-tag"},
+				AuthSecret:  "test-secret",
+				Annotations: annotations,
+				Expose:      Expose{Service: Service{Port: ptr.To[int32](8000)}},
+			},
+		}
+	}
+
+	t.Run("scale-to-zero with max bound", func(t *testing.T) {
+		svc := newSvc(map[string]string{
+			knativeMinScaleAnnotation: "0",
+			knativeMaxScaleAnnotation: "2",
+		})
+		params := svc.GetInferenceServiceParams(kserveconstants.Knative)
+		if params.MinReplicas == nil {
+			t.Fatal("expected MinReplicas to be set, got nil")
+		}
+		if *params.MinReplicas != 0 {
+			t.Errorf("MinReplicas = %d, want 0", *params.MinReplicas)
+		}
+		if params.MaxReplicas == nil {
+			t.Fatal("expected MaxReplicas to be set, got nil")
+		}
+		if *params.MaxReplicas != 2 {
+			t.Errorf("MaxReplicas = %d, want 2", *params.MaxReplicas)
+		}
+		// HPA autoscaler class must NOT be applied in serverless mode.
+		if _, ok := params.Annotations[string(kserveconstants.AutoscalerClass)]; ok {
+			t.Errorf("HPA autoscaler class annotation must not be set in Knative mode")
+		}
+	})
+
+	t.Run("max-scale 0 leaves MaxReplicas unset (unbounded)", func(t *testing.T) {
+		svc := newSvc(map[string]string{
+			knativeMinScaleAnnotation: "1",
+			knativeMaxScaleAnnotation: "0",
+		})
+		params := svc.GetInferenceServiceParams(kserveconstants.Knative)
+		if params.MinReplicas == nil || *params.MinReplicas != 1 {
+			t.Errorf("MinReplicas = %v, want 1", params.MinReplicas)
+		}
+		if params.MaxReplicas != nil {
+			t.Errorf("MaxReplicas = %d, want nil (unbounded)", *params.MaxReplicas)
+		}
+	})
+
+	t.Run("no scale annotations leaves bounds unset", func(t *testing.T) {
+		svc := newSvc(nil)
+		params := svc.GetInferenceServiceParams(kserveconstants.Knative)
+		if params.MinReplicas != nil {
+			t.Errorf("MinReplicas = %d, want nil", *params.MinReplicas)
+		}
+		if params.MaxReplicas != nil {
+			t.Errorf("MaxReplicas = %d, want nil", *params.MaxReplicas)
+		}
+	})
+
+	t.Run("malformed annotation is ignored (no bound set)", func(t *testing.T) {
+		svc := newSvc(map[string]string{knativeMinScaleAnnotation: "abc"})
+		params := svc.GetInferenceServiceParams(kserveconstants.Knative)
+		if params.MinReplicas != nil {
+			t.Errorf("MinReplicas = %d, want nil for malformed input", *params.MinReplicas)
+		}
+	})
 }
 
 // TestReplicasMinimumValidation tests that zero replicas are now allowed.

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -703,5 +703,28 @@ var _ = Describe("K8s Resources Rendering", func() {
 			Expect(*inferenceservice.Spec.Predictor.SecurityContext.FSGroup).To(Equal(int64(2000)))
 
 		})
+
+		It("should render minReplicas/maxReplicas in Knative (serverless) mode", func() {
+			params := types.InferenceServiceParams{
+				Name:           "test-inferenceservice",
+				Namespace:      "default",
+				MinReplicas:    ptr.To[int32](0),
+				MaxReplicas:    ptr.To[int32](2),
+				ContainerName:  "test-container",
+				Image:          "nim-llm:latest",
+				DeploymentMode: "Knative",
+			}
+
+			r := render.NewRenderer(templatesDir)
+			inferenceservice, err := r.InferenceService(&params)
+			Expect(err).NotTo(HaveOccurred())
+			// Scale-to-zero: minReplicas must render even when 0.
+			Expect(inferenceservice.Spec.Predictor.MinReplicas).NotTo(BeNil())
+			Expect(*inferenceservice.Spec.Predictor.MinReplicas).To(Equal(int32(0)))
+			// maxReplicas must render in serverless mode (previously gated to raw/standard).
+			Expect(inferenceservice.Spec.Predictor.MaxReplicas).To(Equal(int32(2)))
+			// HPA/raw-only fields must remain unset in serverless mode.
+			Expect(inferenceservice.Spec.Predictor.DeploymentStrategy).To(BeNil())
+		})
 	})
 })

--- a/manifests/inferenceservice.yaml
+++ b/manifests/inferenceservice.yaml
@@ -16,10 +16,10 @@ spec:
     {{- if .MinReplicas }}
     minReplicas: {{ .MinReplicas }}
     {{- end }}
-    {{- if or (eq .DeploymentMode "RawDeployment") (eq .DeploymentMode "Standard") }}
     {{- if .MaxReplicas }}
     maxReplicas: {{ .MaxReplicas }}
     {{- end }}
+    {{- if or (eq .DeploymentMode "RawDeployment") (eq .DeploymentMode "Standard") }}
     {{- if .ScaleMetricType }}
     scaleMetricType: {{ .ScaleMetricType }}
     {{- end }}


### PR DESCRIPTION
This PR is a response to this [issue](https://github.com/NVIDIA/k8s-nim-operator/issues/890), and is aimed at ensuring that in Kserve serverless mode the, the operator can scale replicas to zero.

**api/apps/v1alpha1/nimservice_types.go** - Created a helper function _parseKnativeScaleAnnotation(...)_ to turn a Knative annotation (min-scale/max-scale) into an *int32. It returns (nil, nil) when the annotation is absent or empty, and an error when the value is not a valid non-negative int32.
...In KServe serverless (Knative) deployment mode, autoscaling.knative.dev/min-scale[or max-scale] still never take effect, because KServe strips these two keys and regenerates them from the predictor's typed fields. As such, in serverless deployment mode we will include:
```
if minReplicas, err := parseKnativeScaleAnnotation(params.Annotations, knativeMinScaleAnnotation); err == nil && minReplicas != nil {
			params.MinReplicas = minReplicas
		}
		if maxReplicas, err := parseKnativeScaleAnnotation(params.Annotations, knativeMaxScaleAnnotation); err == nil && maxReplicas != nil && *maxReplicas > 0 {
			params.MaxReplicas = maxReplicas
		}
```

**manifests/inferenceservice.yaml** - Setting params.MaxReplicas in Go isn't enough on its own, because the template only rendered maxReplicas for raw/standard. We moved it out of that gate so it renders in serverless too:
```
{{- if .MinReplicas }}
minReplicas: {{ .MinReplicas }}
{{- end }}
{{- if .MaxReplicas }}
maxReplicas: {{ .MaxReplicas }}
{{- end }}
{{- if or (eq .DeploymentMode "RawDeployment") (eq .DeploymentMode "Standard") }}
```
**TESTING**
_TestParseKnativeScaleAnnotation_ unit-tests the _parseKnativeScaleAnnotation_ helper across all input classes (absent, empty, "0", positive, negative, non-numeric), with the key assertion being that "0" returns a non-nil pointer to 0 — distinct from nil — since that nil-vs-zero distinction is exactly what makes scale-to-zero expressible. _TestGetInferenceServiceParamsKnativeScale_ then checks the Knative branch of GetInferenceServiceParams: given min-scale/max-scale annotations it sets params.MinReplicas/MaxReplicas correctly (scale-to-zero with a max bound), treats max-scale: "0" as unbounded (leaves max nil), leaves both untouched when no annotations are present, ignores malformed values, and never leaks the HPA autoscaler-class annotation into serverless mode.