### PR TITLE
Fix kserve with InferenceService and Standalone race conditions

### DIFF
--- a/internal/controller/nimservice_controller.go
+++ b/internal/controller/nimservice_controller.go
@@ -18,8 +18,11 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
+	"sync"
+	"time"
 
 	"github.com/go-logr/logr"
 	kservev1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
@@ -37,11 +40,13 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 	nvidiaresourcev1beta1 "sigs.k8s.io/dra-driver-nvidia-gpu/api/nvidia.com/resource/v1beta1"
 	lwsv1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
 
@@ -59,6 +64,12 @@ import (
 // NIMServiceFinalizer is the finalizer annotation.
 const NIMServiceFinalizer = "finalizer.nimservice.apps.nvidia.com"
 
+// inferenceServiceCRDRequeueInterval is how long to wait before retrying when a
+// KServe NIMService is reconciled but the InferenceService CRD is not yet installed.
+const inferenceServiceCRDRequeueInterval = 30 * time.Second
+
+var errInferenceServiceCRDMissing = errors.New("InferenceService CRD is not available")
+
 // NIMServiceReconciler reconciles a NIMService object.
 type NIMServiceReconciler struct {
 	client.Client
@@ -71,6 +82,15 @@ type NIMServiceReconciler struct {
 	orchestratorType k8sutil.OrchestratorType
 	recorder         record.EventRecorder
 	apiReader        client.Reader
+
+	// mgr and controller are retained so an InferenceService owner watch can be
+	// registered on first demand when a KServe NIMService is reconciled and the
+	// CRD was missing at operator start-up.
+	mgr        ctrl.Manager
+	controller controller.Controller
+
+	inferenceServiceWatchMu         sync.Mutex
+	inferenceServiceWatchRegistered bool
 }
 
 // Ensure NIMServiceReconciler implements the Reconciler interface.
@@ -137,6 +157,21 @@ func (r *NIMServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 
 	logger.Info("Reconciling", "NIMService", nimService.Name)
+
+	// For KServe NIMServices, ensure we are watching InferenceServices. If the
+	// CRD was missing at operator start-up, register the owner watch on first
+	// demand.
+	if nimService.Spec.InferencePlatform == appsv1alpha1.PlatformTypeKServe {
+		if err := r.ensureInferenceServiceWatch(); err != nil {
+			if errors.Is(err, errInferenceServiceCRDMissing) {
+				logger.Info("InferenceService CRD not available yet; requeueing",
+					"NIMService", nimService.Name)
+				return ctrl.Result{RequeueAfter: inferenceServiceCRDRequeueInterval}, nil
+			}
+			logger.Error(err, "failed to ensure InferenceService watch")
+			return ctrl.Result{}, err
+		}
+	}
 
 	// Get platform implementation based on NIMService's platform field
 	platformImpl, err := platform.GetInferencePlatform(nimService.Spec.InferencePlatform)
@@ -339,14 +374,14 @@ func (r *NIMServiceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return err
 	}
 
-	nimServiceBuilder, err = k8sutil.ControllerOwnsIfCRDExists(
-		r.discoveryClient,
-		nimServiceBuilder,
-		kservev1beta1.SchemeGroupVersion.WithResource("inferenceservices"),
-		&kservev1beta1.InferenceService{},
-	)
+	isvcGVR := kservev1beta1.SchemeGroupVersion.WithResource("inferenceservices")
+	isvcCRDExists, err := k8sutil.CRDExists(r.discoveryClient, isvcGVR)
 	if err != nil {
 		return err
+	}
+	if isvcCRDExists {
+		nimServiceBuilder = nimServiceBuilder.Owns(&kservev1beta1.InferenceService{})
+		r.inferenceServiceWatchRegistered = true
 	}
 
 	nimServiceBuilder, err = k8sutil.ControllerOwnsIfCRDExists(
@@ -393,7 +428,66 @@ func (r *NIMServiceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return err
 	}
 
-	return nimServiceBuilder.Complete(r)
+	c, err := nimServiceBuilder.Build(r)
+	if err != nil {
+		return err
+	}
+
+	// Retain manager/controller handles so a missing InferenceService watch can
+	// be registered later on the first KServe NIMService reconcile.
+	r.mgr = mgr
+	r.controller = c
+	return nil
+}
+
+// ensureInferenceServiceWatch registers an InferenceService owner watch on first
+// demand when a KServe NIMService is reconciled and the CRD is available.
+// If the CRD is still missing, it returns errInferenceServiceCRDMissing so the
+// caller can requeue.
+func (r *NIMServiceReconciler) ensureInferenceServiceWatch() error {
+	r.inferenceServiceWatchMu.Lock()
+	defer r.inferenceServiceWatchMu.Unlock()
+
+	if r.inferenceServiceWatchRegistered {
+		return nil
+	}
+	if r.controller == nil || r.mgr == nil {
+		return nil
+	}
+
+	isvcGVR := kservev1beta1.SchemeGroupVersion.WithResource("inferenceservices")
+	exists, err := k8sutil.CRDExists(r.discoveryClient, isvcGVR)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return errInferenceServiceCRDMissing
+	}
+
+	logger := r.log.WithName("inferenceServiceWatch")
+	logger.Info("registering InferenceService owner watch for KServe NIMService")
+
+	// Refresh the RESTMapper so the new CRD is resolvable without a restart.
+	if resettable, ok := r.mgr.GetRESTMapper().(interface{ Reset() }); ok {
+		resettable.Reset()
+	}
+
+	if err := r.controller.Watch(source.Kind(
+		r.mgr.GetCache(),
+		&kservev1beta1.InferenceService{},
+		handler.TypedEnqueueRequestForOwner[*kservev1beta1.InferenceService](
+			r.mgr.GetScheme(),
+			r.mgr.GetRESTMapper(),
+			&appsv1alpha1.NIMService{},
+			handler.OnlyControllerOwner(),
+		),
+	)); err != nil {
+		return err
+	}
+
+	r.inferenceServiceWatchRegistered = true
+	logger.Info("registered InferenceService owner watch")
+	return nil
 }
 
 func (r *NIMServiceReconciler) mapNIMCacheToNIMService(ctx context.Context, obj client.Object) []ctrl.Request {

--- a/internal/controller/platform/kserve/nimservice.go
+++ b/internal/controller/platform/kserve/nimservice.go
@@ -60,6 +60,12 @@ import (
 const (
 	// ManifestsDir is the directory to render k8s resource manifests.
 	ManifestsDir = "/manifests"
+
+	// inferenceServiceNotReadyRequeue is how long to wait before re-checking
+	// InferenceService readiness when the NIMService is not yet Ready.
+	// This bounds stuck NotReady status when the InferenceService informer was
+	// not registered at operator start-up (e.g. KServe installed later).
+	inferenceServiceNotReadyRequeue = 30 * time.Second
 )
 
 // NIMServiceReconciler represents the NIMService reconciler instance for KServe platform.
@@ -787,20 +793,27 @@ func (r *NIMServiceReconciler) checkInferenceServiceStatus(ctx context.Context, 
 		err = r.updater.SetConditionsNotReady(ctx, nimService, conditions.NotReady, msg)
 		r.recorder.Eventf(nimService, corev1.EventTypeNormal, conditions.NotReady,
 			"NIMService %s not ready yet, msg: %s", nimService.Name, msg)
-	} else {
-		// Update NIMServiceStatus with model config.
-		updateErr := r.updateModelStatus(ctx, nimService, deploymentMode)
-		if updateErr != nil {
-			logger.Info("WARN: Model status update failed, will retry in 5 seconds", "error", updateErr.Error())
-			return &ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+		if err != nil {
+			logger.Error(err, "failed to update status", "nimservice", nimService.Name, "state", conditions.NotReady)
+			return &ctrl.Result{}, err
 		}
-
-		// Update status as ready
-		err = r.updater.SetConditionsReady(ctx, nimService, conditions.Ready, msg)
-		r.recorder.Eventf(nimService, corev1.EventTypeNormal, conditions.Ready,
-			"NIMService %s ready, msg: %s", nimService.Name, msg)
+		// Requeue so readiness converges even when the InferenceService watch was
+		// not registered (KServe CRD installed after the operator started) and no
+		// other owned-resource events wake this reconcile.
+		return &ctrl.Result{RequeueAfter: inferenceServiceNotReadyRequeue}, nil
 	}
 
+	// Update NIMServiceStatus with model config.
+	updateErr := r.updateModelStatus(ctx, nimService, deploymentMode)
+	if updateErr != nil {
+		logger.Info("WARN: Model status update failed, will retry in 5 seconds", "error", updateErr.Error())
+		return &ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+	}
+
+	// Update status as ready
+	err = r.updater.SetConditionsReady(ctx, nimService, conditions.Ready, msg)
+	r.recorder.Eventf(nimService, corev1.EventTypeNormal, conditions.Ready,
+		"NIMService %s ready, msg: %s", nimService.Name, msg)
 	if err != nil {
 		logger.Error(err, "failed to update status", "nimservice", nimService.Name, "state", conditions.Ready)
 		return &ctrl.Result{}, err
@@ -813,8 +826,15 @@ func (r *NIMServiceReconciler) checkInferenceServiceStatus(ctx context.Context, 
 func (r *NIMServiceReconciler) isInferenceServiceReady(ctx context.Context, nimService *appsv1alpha1.NIMService) (string, bool, error) {
 	logger := r.log
 
+	// Prefer the API reader so readiness is observed even when the InferenceService
+	// informer was not started (CRD missing at operator boot / not in filtered cache).
+	reader := client.Reader(r.Client)
+	if r.apiReader != nil {
+		reader = r.apiReader
+	}
+
 	isvc := &kservev1beta1.InferenceService{}
-	err := r.Get(ctx, client.ObjectKey{Name: nimService.Name, Namespace: nimService.Namespace}, isvc)
+	err := reader.Get(ctx, client.ObjectKey{Name: nimService.Name, Namespace: nimService.Namespace}, isvc)
 	if err != nil {
 		logger.Error(err, "failed to fetch inferenceservice")
 		if apiErrors.IsNotFound(err) {

--- a/internal/controller/platform/kserve/nimservice_test.go
+++ b/internal/controller/platform/kserve/nimservice_test.go
@@ -182,6 +182,7 @@ var _ = Describe("NIMServiceReconciler for a KServe platform", func() {
 			renderer:        render.NewRenderer(path.Join(strings.TrimSuffix(cwd, "internal/controller/platform/kserve"), "manifests")),
 			recorder:        record.NewFakeRecorder(1000),
 			discoveryClient: discoveryClient,
+			apiReader:       client,
 		}
 		pvcName := "test-pvc"
 		nimService = &appsv1alpha1.NIMService{
@@ -533,7 +534,7 @@ var _ = Describe("NIMServiceReconciler for a KServe platform", func() {
 
 			result, err := reconciler.reconcileNIMService(context.TODO(), nimService)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(result).To(Equal(ctrl.Result{RequeueAfter: inferenceServiceNotReadyRequeue}))
 
 			// Role should be created
 			role := &rbacv1.Role{}
@@ -788,7 +789,7 @@ var _ = Describe("NIMServiceReconciler for a KServe platform", func() {
 
 			result, err := reconciler.reconcileNIMService(context.TODO(), nimService)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(result).To(Equal(ctrl.Result{RequeueAfter: inferenceServiceNotReadyRequeue}))
 
 			isvc := &kservev1beta1.InferenceService{}
 			err = client.Get(context.TODO(), namespacedName, isvc)
@@ -815,7 +816,7 @@ var _ = Describe("NIMServiceReconciler for a KServe platform", func() {
 
 			result, err = reconciler.reconcileNIMService(context.TODO(), nimService)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(result).To(Equal(ctrl.Result{RequeueAfter: inferenceServiceNotReadyRequeue}))
 
 			err = client.Get(context.TODO(), namespacedName, isvc)
 			Expect(err).NotTo(HaveOccurred())
@@ -842,7 +843,7 @@ var _ = Describe("NIMServiceReconciler for a KServe platform", func() {
 
 			result, err := reconciler.reconcileNIMService(context.TODO(), nimService)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(result).To(Equal(ctrl.Result{RequeueAfter: inferenceServiceNotReadyRequeue}))
 
 			// InferenceService should have cluster-local visibility
 			isvc := &kservev1beta1.InferenceService{}
@@ -864,7 +865,7 @@ var _ = Describe("NIMServiceReconciler for a KServe platform", func() {
 
 			result, err := reconciler.reconcileNIMService(context.TODO(), nimService)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(result).To(Equal(ctrl.Result{RequeueAfter: inferenceServiceNotReadyRequeue}))
 
 			// InferenceService should preserve user-provided visibility, not override with ClusterLocalVisibility
 			isvc := &kservev1beta1.InferenceService{}
@@ -886,7 +887,7 @@ var _ = Describe("NIMServiceReconciler for a KServe platform", func() {
 
 			result, err := reconciler.reconcileNIMService(context.TODO(), nimService)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(result).To(Equal(ctrl.Result{RequeueAfter: inferenceServiceNotReadyRequeue}))
 
 			// InferenceService should not have network visibility set (external access)
 			isvc := &kservev1beta1.InferenceService{}
@@ -909,7 +910,7 @@ var _ = Describe("NIMServiceReconciler for a KServe platform", func() {
 
 			result, err := reconciler.reconcileNIMService(context.TODO(), nimService)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(result).To(Equal(ctrl.Result{RequeueAfter: inferenceServiceNotReadyRequeue}))
 
 			// InferenceService should preserve user-provided visibility
 			isvc := &kservev1beta1.InferenceService{}
@@ -1047,6 +1048,64 @@ var _ = Describe("NIMServiceReconciler for a KServe platform", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(ready).To(Equal(true))
 			Expect(msg).To(Equal("Predictor Ready"))
+		})
+	})
+
+	Describe("checkInferenceServiceStatus requeue behavior", func() {
+		BeforeEach(func() {
+			Expect(client.Create(context.TODO(), nimService)).To(Succeed())
+		})
+		AfterEach(func() {
+			_ = client.Delete(context.TODO(), nimService)
+		})
+
+		It("should requeue when InferenceService is not ready", func() {
+			isvc := &kservev1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      nimService.Name,
+					Namespace: nimService.Namespace,
+				},
+				Spec:   kservev1beta1.InferenceServiceSpec{},
+				Status: kservev1beta1.InferenceServiceStatus{},
+			}
+			Expect(client.Create(context.TODO(), isvc)).To(Succeed())
+			defer func() { _ = client.Delete(context.TODO(), isvc) }()
+
+			result, err := reconciler.checkInferenceServiceStatus(context.TODO(), nimService, kserveconstants.Standard)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).ToNot(BeNil())
+			Expect(result.RequeueAfter).To(Equal(inferenceServiceNotReadyRequeue))
+
+			updated := &appsv1alpha1.NIMService{}
+			Expect(client.Get(context.TODO(), types.NamespacedName{Name: nimService.Name, Namespace: nimService.Namespace}, updated)).To(Succeed())
+			Expect(updated.Status.State).To(Equal(appsv1alpha1.NIMServiceStatusNotReady))
+		})
+
+		It("should requeue when PredictorReady is False", func() {
+			isvc := &kservev1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      nimService.Name,
+					Namespace: nimService.Namespace,
+				},
+				Spec:   kservev1beta1.InferenceServiceSpec{},
+				Status: kservev1beta1.InferenceServiceStatus{},
+			}
+			Expect(client.Create(context.TODO(), isvc)).To(Succeed())
+			defer func() { _ = client.Delete(context.TODO(), isvc) }()
+
+			isvc.Status.Conditions = knativeduckv1.Conditions{
+				{
+					Type:    kservev1beta1.PredictorReady,
+					Message: "Predictor not ready",
+					Status:  corev1.ConditionFalse,
+				},
+			}
+			Expect(client.Update(context.TODO(), isvc)).To(Succeed())
+
+			result, err := reconciler.checkInferenceServiceStatus(context.TODO(), nimService, kserveconstants.Standard)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).ToNot(BeNil())
+			Expect(result.RequeueAfter).To(Equal(inferenceServiceNotReadyRequeue))
 		})
 	})
 
@@ -1324,7 +1383,7 @@ var _ = Describe("NIMServiceReconciler for a KServe platform", func() {
 
 			result, err := reconciler.reconcileNIMService(context.TODO(), testNimService)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(result).To(Equal(ctrl.Result{RequeueAfter: inferenceServiceNotReadyRequeue}))
 
 			// InferenceService should be created
 			isvc := &kservev1beta1.InferenceService{}
@@ -1457,7 +1516,7 @@ var _ = Describe("NIMServiceReconciler for a KServe platform", func() {
 
 			result, err := reconciler.reconcileNIMService(context.TODO(), testNimService)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(result).To(Equal(ctrl.Result{RequeueAfter: inferenceServiceNotReadyRequeue}))
 
 			// InferenceService should be created
 			isvc := &kservev1beta1.InferenceService{}
@@ -1572,7 +1631,7 @@ var _ = Describe("NIMServiceReconciler for a KServe platform", func() {
 
 			result, err := reconciler.reconcileNIMService(context.TODO(), testNimService)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(result).To(Equal(ctrl.Result{RequeueAfter: inferenceServiceNotReadyRequeue}))
 
 			// InferenceService should be created
 			isvc := &kservev1beta1.InferenceService{}
@@ -1851,7 +1910,7 @@ var _ = Describe("NIMServiceReconciler for a KServe platform", func() {
 
 			result, err := reconciler.reconcileNIMService(context.TODO(), nimService)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(result).To(Equal(ctrl.Result{RequeueAfter: inferenceServiceNotReadyRequeue}))
 
 			// InferenceService should be created
 			isvc := &kservev1beta1.InferenceService{}
@@ -2034,7 +2093,7 @@ var _ = Describe("NIMServiceReconciler for a KServe platform", func() {
 
 				result, err := reconciler.reconcileNIMService(context.TODO(), testNimService)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(result).To(Equal(ctrl.Result{}))
+				Expect(result).To(Equal(ctrl.Result{RequeueAfter: inferenceServiceNotReadyRequeue}))
 
 				// InferenceService should be created
 				isvc := &kservev1beta1.InferenceService{}
@@ -2183,7 +2242,7 @@ var _ = Describe("NIMServiceReconciler for a KServe platform", func() {
 
 				result, err := reconciler.reconcileNIMService(context.TODO(), testNimService)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(result).To(Equal(ctrl.Result{}))
+				Expect(result).To(Equal(ctrl.Result{RequeueAfter: inferenceServiceNotReadyRequeue}))
 
 				// InferenceService should be created
 				isvc := &kservev1beta1.InferenceService{}
@@ -2330,7 +2389,7 @@ var _ = Describe("NIMServiceReconciler for a KServe platform", func() {
 
 				result, err := reconciler.reconcileNIMService(context.TODO(), testNimService)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(result).To(Equal(ctrl.Result{}))
+				Expect(result).To(Equal(ctrl.Result{RequeueAfter: inferenceServiceNotReadyRequeue}))
 
 				// InferenceService should be created
 				isvc := &kservev1beta1.InferenceService{}
@@ -2473,7 +2532,7 @@ var _ = Describe("NIMServiceReconciler for a KServe platform", func() {
 
 				result, err := reconciler.reconcileNIMService(context.TODO(), testNimService)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(result).To(Equal(ctrl.Result{}))
+				Expect(result).To(Equal(ctrl.Result{RequeueAfter: inferenceServiceNotReadyRequeue}))
 
 				// InferenceService should be created
 				isvc := &kservev1beta1.InferenceService{}
@@ -2626,7 +2685,7 @@ var _ = Describe("NIMServiceReconciler for a KServe platform", func() {
 
 			result, err := reconciler.reconcileNIMService(context.TODO(), testNimService)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(result).To(Equal(ctrl.Result{RequeueAfter: inferenceServiceNotReadyRequeue}))
 
 			// Get the rendered InferenceService
 			isvc := &kservev1beta1.InferenceService{}
@@ -2744,7 +2803,7 @@ var _ = Describe("NIMServiceReconciler for a KServe platform", func() {
 
 			result, err := reconciler.reconcileNIMService(context.TODO(), testNimService)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(result).To(Equal(ctrl.Result{RequeueAfter: inferenceServiceNotReadyRequeue}))
 
 			isvc := &kservev1beta1.InferenceService{}
 			err = client.Get(context.TODO(), namespacedName, isvc)
@@ -2821,7 +2880,7 @@ var _ = Describe("NIMServiceReconciler for a KServe platform", func() {
 
 			result, err := reconciler.reconcileNIMService(context.TODO(), testNimService)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(result).To(Equal(ctrl.Result{RequeueAfter: inferenceServiceNotReadyRequeue}))
 
 			isvc := &kservev1beta1.InferenceService{}
 			err = client.Get(context.TODO(), namespacedName, isvc)

--- a/internal/controller/platform/standalone/nimservice.go
+++ b/internal/controller/platform/standalone/nimservice.go
@@ -61,6 +61,15 @@ import (
 	"github.com/NVIDIA/k8s-nim-operator/internal/utils"
 )
 
+const (
+	// deploymentNotReadyRequeue is how long to wait before re-checking Deployment
+	// readiness when the NIMService is not yet Ready.
+	deploymentNotReadyRequeue = 30 * time.Second
+	// autoscalingDisableRequeue is a short requeue used after disabling
+	// autoscaling so a late HPA write cannot permanently pin Deployment replicas.
+	autoscalingDisableRequeue = 5 * time.Second
+)
+
 // GetScheme returns the scheme of the reconciler.
 func (r *NIMServiceReconciler) GetScheme() *runtime.Scheme {
 	return r.scheme
@@ -267,6 +276,7 @@ func (r *NIMServiceReconciler) reconcileNIMService(ctx context.Context, nimServi
 	}
 
 	// Sync HPA
+	autoscalingJustDisabled := false
 	if nimService.IsAutoScalingEnabled() {
 		err = r.renderAndSyncResource(ctx, nimService, &renderer, &autoscalingv2.HorizontalPodAutoscaler{}, func() (client.Object, error) {
 			return renderer.HPA(nimService.GetHPAParams())
@@ -275,10 +285,16 @@ func (r *NIMServiceReconciler) reconcileNIMService(ctx context.Context, nimServi
 			return ctrl.Result{}, err
 		}
 	} else {
-		// If autoscaling is disabled, ensure the HPA is deleted
+		// If autoscaling is disabled, ensure the HPA is deleted. Track whether an
+		// HPA existed so we can requeue once and win races with late HPA writes.
+		existingHPA := &autoscalingv2.HorizontalPodAutoscaler{}
+		hpaGetErr := r.Get(ctx, namespacedName, existingHPA)
 		err = k8sutil.CleanupResource(ctx, r.GetClient(), &autoscalingv2.HorizontalPodAutoscaler{}, namespacedName)
 		if err != nil {
 			return ctrl.Result{}, err
+		}
+		if hpaGetErr == nil {
+			autoscalingJustDisabled = true
 		}
 	}
 
@@ -717,25 +733,42 @@ func (r *NIMServiceReconciler) reconcileNIMService(ctx context.Context, nimServi
 		err = r.updater.SetConditionsNotReady(ctx, nimService, conditions.NotReady, msg)
 		r.GetEventRecorder().Eventf(nimService, corev1.EventTypeNormal, conditions.NotReady,
 			"NIMService %s not ready, msg: %s", nimService.Name, msg)
-	} else {
-		// Update NIMServiceStatus with model config.
-		updateErr := r.updateModelStatus(ctx, nimService)
-		if updateErr != nil {
-			logger.V(4).Info("WARN: Model status update failed, will retry in 5 seconds", "error", updateErr.Error())
-			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+		if err != nil {
+			logger.Error(err, "failed to update status", "nimservice", nimService.Name, "state", conditions.NotReady)
+			return ctrl.Result{}, err
 		}
-
-		// Update status as ready
-		err = r.updater.SetConditionsReady(ctx, nimService, conditions.Ready, msg)
-		r.GetEventRecorder().Eventf(nimService, corev1.EventTypeNormal, conditions.Ready,
-			"NIMService %s ready, msg: %s", nimService.Name, msg)
+		return ctrl.Result{RequeueAfter: deploymentNotReadyRequeue}, nil
 	}
 
+	// Update NIMServiceStatus with model config.
+	updateErr := r.updateModelStatus(ctx, nimService)
+	if updateErr != nil {
+		logger.V(4).Info("WARN: Model status update failed, will retry in 5 seconds", "error", updateErr.Error())
+		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+	}
+
+	// Update status as ready
+	err = r.updater.SetConditionsReady(ctx, nimService, conditions.Ready, msg)
+	r.GetEventRecorder().Eventf(nimService, corev1.EventTypeNormal, conditions.Ready,
+		"NIMService %s ready, msg: %s", nimService.Name, msg)
 	if err != nil {
 		logger.Error(err, "failed to update status", "nimservice", nimService.Name, "state", conditions.Ready)
 		return ctrl.Result{}, err
 	}
-	return ctrl.Result{}, nil
+
+	result := ctrl.Result{}
+	if autoscalingJustDisabled {
+		// Requeue so any late HPA mutation of Deployment replicas is overwritten
+		// with spec.replicas after the HPA is gone.
+		result.RequeueAfter = autoscalingDisableRequeue
+	} else if !nimService.IsAutoScalingEnabled() && nimService.Spec.MultiNode == nil {
+		if outOfSync, syncErr := r.deploymentReplicasOutOfSync(ctx, namespacedName, nimService.GetReplicas()); syncErr != nil {
+			return ctrl.Result{}, syncErr
+		} else if outOfSync {
+			result.RequeueAfter = autoscalingDisableRequeue
+		}
+	}
+	return result, nil
 }
 
 func (r *NIMServiceReconciler) createMultiNodeVolumeObjects(ctx context.Context, nimService *appsv1alpha1.NIMService) error {
@@ -1005,8 +1038,18 @@ func (r *NIMServiceReconciler) renderAndSyncResource(ctx context.Context, nimSer
 	// Track an existing resource
 	found := getErr == nil
 
-	// Don't do anything if CR is unchanged.
-	if found && !utils.IsParentSpecChanged(obj, utils.DeepHashObject(nimService.Spec)) {
+	parentSpecChanged := !found || utils.IsParentSpecChanged(obj, utils.DeepHashObject(nimService.Spec))
+	// When autoscaling is disabled, HPA may have left Deployment replicas drifted
+	// after the parent-spec hash was already written. Still sync in that case.
+	replicasOutOfSync := false
+	if found && !nimService.IsAutoScalingEnabled() {
+		if curr, ok := obj.(*appsv1.Deployment); ok {
+			replicasOutOfSync = deploymentSpecReplicasOutOfSync(curr, nimService.GetReplicas())
+		}
+	}
+
+	// Don't do anything if CR is unchanged and replicas are already correct.
+	if found && !parentSpecChanged && !replicasOutOfSync {
 		return nil
 	}
 
@@ -1018,6 +1061,22 @@ func (r *NIMServiceReconciler) renderAndSyncResource(ctx context.Context, nimSer
 			if desired, ok := resource.(*appsv1.Deployment); ok && curr.Spec.Replicas != nil {
 				replicas := *curr.Spec.Replicas
 				desired.Spec.Replicas = &replicas
+			}
+		}
+	}
+
+	// When autoscaling is off, live Deployment replicas can drift (e.g. late HPA
+	// writes) while the stored resource hash still matches the desired spec.
+	// Clear the hash annotation so SyncResource does not skip the update.
+	if found && !nimService.IsAutoScalingEnabled() {
+		if curr, ok := obj.(*appsv1.Deployment); ok {
+			if desired, ok := resource.(*appsv1.Deployment); ok &&
+				deploymentSpecReplicasOutOfSync(curr, desired.Spec.Replicas) {
+				annotations := curr.GetAnnotations()
+				if annotations != nil {
+					delete(annotations, utils.NvidiaAnnotationHashKey)
+					curr.SetAnnotations(annotations)
+				}
 			}
 		}
 	}
@@ -1089,6 +1148,30 @@ func (r *NIMServiceReconciler) isDeploymentReady(ctx context.Context, namespaced
 		return fmt.Sprintf("Waiting for deployment %q rollout to finish: %d of %d updated replicas are available...\n", deployment.Name, deployment.Status.AvailableReplicas, deployment.Status.UpdatedReplicas), false, nil
 	}
 	return fmt.Sprintf("deployment %q successfully rolled out\n", deployment.Name), true, nil
+}
+
+// deploymentSpecReplicasOutOfSync reports whether the Deployment's spec.replicas
+// differs from the desired replica count.
+func deploymentSpecReplicasOutOfSync(deployment *appsv1.Deployment, desired *int32) bool {
+	if desired == nil {
+		return false
+	}
+	if deployment.Spec.Replicas == nil {
+		return true
+	}
+	return *deployment.Spec.Replicas != *desired
+}
+
+func (r *NIMServiceReconciler) deploymentReplicasOutOfSync(ctx context.Context, namespacedName types.NamespacedName, desired *int32) (bool, error) {
+	deployment := &appsv1.Deployment{}
+	err := r.Get(ctx, namespacedName, deployment)
+	if err != nil {
+		if apiErrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return deploymentSpecReplicasOutOfSync(deployment, desired), nil
 }
 
 func getDeploymentCondition(status appsv1.DeploymentStatus, condType appsv1.DeploymentConditionType) *appsv1.DeploymentCondition {

--- a/internal/controller/platform/standalone/nimservice_test.go
+++ b/internal/controller/platform/standalone/nimservice_test.go
@@ -486,7 +486,7 @@ var _ = Describe("NIMServiceReconciler for a standalone platform", func() {
 
 			result, err := reconciler.reconcileNIMService(context.TODO(), nimService)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(result).To(Equal(ctrl.Result{RequeueAfter: deploymentNotReadyRequeue}))
 
 			// Role should be created
 			role := &rbacv1.Role{}
@@ -852,7 +852,7 @@ var _ = Describe("NIMServiceReconciler for a standalone platform", func() {
 
 			result, err := reconciler.reconcileNIMService(context.TODO(), nimService)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(result).To(Equal(ctrl.Result{RequeueAfter: deploymentNotReadyRequeue}))
 
 			// HPA should be deployed
 			hpa := &autoscalingv2.HorizontalPodAutoscaler{}
@@ -873,7 +873,7 @@ var _ = Describe("NIMServiceReconciler for a standalone platform", func() {
 
 			result, err = reconciler.reconcileNIMService(context.TODO(), nimService)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(result).To(Equal(ctrl.Result{RequeueAfter: deploymentNotReadyRequeue}))
 			hpa = &autoscalingv2.HorizontalPodAutoscaler{}
 			err = client.Get(context.TODO(), namespacedName, hpa)
 			Expect(err).To(HaveOccurred())
@@ -882,6 +882,88 @@ var _ = Describe("NIMServiceReconciler for a standalone platform", func() {
 			err = client.Get(context.TODO(), namespacedName, ingress)
 			Expect(err).To(HaveOccurred())
 			Expect(errors.IsNotFound(err)).To(Equal(true))
+		})
+
+		It("should reset Deployment replicas after autoscaling is disabled even if parent hash is unchanged", func() {
+			namespacedName := types.NamespacedName{Name: nimService.Name, Namespace: nimService.Namespace}
+			Expect(client.Create(context.TODO(), nimService)).To(Succeed())
+
+			_, err := reconciler.reconcileNIMService(context.TODO(), nimService)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Simulate HPA scaling the Deployment up while autoscaling is enabled.
+			deployment := &appsv1.Deployment{}
+			Expect(client.Get(context.TODO(), namespacedName, deployment)).To(Succeed())
+			deployment.Spec.Replicas = ptr.To(int32(3))
+			Expect(client.Update(context.TODO(), deployment)).To(Succeed())
+
+			// Disable autoscaling and pin replicas to 1.
+			updated := &appsv1alpha1.NIMService{}
+			Expect(client.Get(context.TODO(), namespacedName, updated)).To(Succeed())
+			updated.Spec.Scale.Enabled = ptr.To(false)
+			updated.Spec.Replicas = ptr.To(int32(1))
+			updated.Spec.Expose.Router.Ingress = nil
+			Expect(client.Update(context.TODO(), updated)).To(Succeed())
+
+			result, err := reconciler.reconcileNIMService(context.TODO(), updated)
+			Expect(err).NotTo(HaveOccurred())
+			// Disable transition should either be waiting on rollout or scheduling a
+			// short follow-up after HPA deletion — never a silent no-op.
+			Expect(result.RequeueAfter).To(BeNumerically(">", 0))
+
+			Expect(client.Get(context.TODO(), namespacedName, deployment)).To(Succeed())
+			Expect(deployment.Spec.Replicas).NotTo(BeNil())
+			Expect(*deployment.Spec.Replicas).To(Equal(int32(1)))
+
+			hpa := &autoscalingv2.HorizontalPodAutoscaler{}
+			err = client.Get(context.TODO(), namespacedName, hpa)
+			Expect(errors.IsNotFound(err)).To(BeTrue())
+
+			// Simulate a late HPA write that bumps replicas back up without changing
+			// the parent-spec hash annotation (the Symptom 2 race).
+			parentHash := deployment.Annotations[utils.NvidiaAnnotationParentSpecHashKey]
+			Expect(parentHash).NotTo(BeEmpty())
+			deployment.Spec.Replicas = ptr.To(int32(3))
+			Expect(client.Update(context.TODO(), deployment)).To(Succeed())
+
+			Expect(client.Get(context.TODO(), namespacedName, updated)).To(Succeed())
+			_, err = reconciler.reconcileNIMService(context.TODO(), updated)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(client.Get(context.TODO(), namespacedName, deployment)).To(Succeed())
+			Expect(deployment.Annotations[utils.NvidiaAnnotationParentSpecHashKey]).To(Equal(parentHash))
+			Expect(deployment.Spec.Replicas).NotTo(BeNil())
+			Expect(*deployment.Spec.Replicas).To(Equal(int32(1)))
+
+			// Once replicas match and the Deployment is Ready, we must not keep
+			// requeueing on the 5s autoscaling-disable / drift path.
+			deployment.Status.Replicas = 1
+			deployment.Status.UpdatedReplicas = 1
+			deployment.Status.AvailableReplicas = 1
+			deployment.Status.Conditions = []appsv1.DeploymentCondition{{
+				Type:   appsv1.DeploymentProgressing,
+				Status: corev1.ConditionTrue,
+				Reason: "NewReplicaSetAvailable",
+			}}
+			Expect(client.Status().Update(context.TODO(), deployment)).To(Succeed())
+
+			Expect(client.Get(context.TODO(), namespacedName, updated)).To(Succeed())
+			result, err = reconciler.reconcileNIMService(context.TODO(), updated)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(client.Get(context.TODO(), namespacedName, deployment)).To(Succeed())
+			Expect(*deployment.Spec.Replicas).To(Equal(int32(1)))
+		})
+
+		It("deploymentSpecReplicasOutOfSync detects drift correctly", func() {
+			Expect(deploymentSpecReplicasOutOfSync(&appsv1.Deployment{}, nil)).To(BeFalse())
+			Expect(deploymentSpecReplicasOutOfSync(&appsv1.Deployment{}, ptr.To(int32(1)))).To(BeTrue())
+			Expect(deploymentSpecReplicasOutOfSync(&appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{Replicas: ptr.To(int32(3))},
+			}, ptr.To(int32(1)))).To(BeTrue())
+			Expect(deploymentSpecReplicasOutOfSync(&appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{Replicas: ptr.To(int32(1))},
+			}, ptr.To(int32(1)))).To(BeFalse())
 		})
 
 	})
@@ -1816,7 +1898,7 @@ var _ = Describe("NIMServiceReconciler for a standalone platform", func() {
 
 			result, err := reconciler.reconcileNIMService(context.TODO(), testNimService)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(result).To(Equal(ctrl.Result{RequeueAfter: deploymentNotReadyRequeue}))
 
 			// Deployment should be created
 			deployment := &appsv1.Deployment{}
@@ -1949,7 +2031,7 @@ var _ = Describe("NIMServiceReconciler for a standalone platform", func() {
 
 			result, err := reconciler.reconcileNIMService(context.TODO(), testNimService)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(result).To(Equal(ctrl.Result{RequeueAfter: deploymentNotReadyRequeue}))
 
 			// Deployment should be created
 			deployment := &appsv1.Deployment{}
@@ -2057,7 +2139,7 @@ var _ = Describe("NIMServiceReconciler for a standalone platform", func() {
 
 			result, err := reconciler.reconcileNIMService(context.TODO(), testNimService)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(result).To(Equal(ctrl.Result{RequeueAfter: deploymentNotReadyRequeue}))
 
 			// LeaderWorkerSet should be created instead of Deployment
 			lws := &lwsv1.LeaderWorkerSet{}
@@ -2163,7 +2245,7 @@ var _ = Describe("NIMServiceReconciler for a standalone platform", func() {
 
 			result, err := reconciler.reconcileNIMService(context.TODO(), testNimService)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(result).To(Equal(ctrl.Result{RequeueAfter: deploymentNotReadyRequeue}))
 
 			// Deployment should be created
 			deployment := &appsv1.Deployment{}
@@ -2280,7 +2362,7 @@ var _ = Describe("NIMServiceReconciler for a standalone platform", func() {
 
 			result, err := reconciler.reconcileNIMService(context.TODO(), testNimService)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(result).To(Equal(ctrl.Result{RequeueAfter: deploymentNotReadyRequeue}))
 
 			// LeaderWorkerSet should be created instead of Deployment
 			lws := &lwsv1.LeaderWorkerSet{}
@@ -2401,7 +2483,7 @@ var _ = Describe("NIMServiceReconciler for a standalone platform", func() {
 
 			result, err := reconciler.reconcileNIMService(context.TODO(), testNimService)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(result).To(Equal(ctrl.Result{RequeueAfter: deploymentNotReadyRequeue}))
 
 			lws := &lwsv1.LeaderWorkerSet{}
 			lwsKey := types.NamespacedName{Name: testNimService.GetLWSName(), Namespace: testNimService.Namespace}
@@ -2755,7 +2837,7 @@ var _ = Describe("NIMServiceReconciler for a standalone platform", func() {
 
 			result, err := reconciler.reconcileNIMService(context.TODO(), nimService)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(result).To(Equal(ctrl.Result{RequeueAfter: deploymentNotReadyRequeue}))
 
 			// Deployment should be created
 			deployment := &appsv1.Deployment{}
@@ -2940,7 +3022,7 @@ var _ = Describe("NIMServiceReconciler for a standalone platform", func() {
 
 			result, err := reconciler.reconcileNIMService(context.TODO(), testNimService)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(result).To(Equal(ctrl.Result{RequeueAfter: deploymentNotReadyRequeue}))
 
 			// Deployment should be created
 			deployment := &appsv1.Deployment{}
@@ -3089,7 +3171,7 @@ var _ = Describe("NIMServiceReconciler for a standalone platform", func() {
 
 			result, err := reconciler.reconcileNIMService(context.TODO(), testNimService)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(result).To(Equal(ctrl.Result{RequeueAfter: deploymentNotReadyRequeue}))
 
 			// Deployment should be created
 			deployment := &appsv1.Deployment{}
@@ -3236,7 +3318,7 @@ var _ = Describe("NIMServiceReconciler for a standalone platform", func() {
 
 			result, err := reconciler.reconcileNIMService(context.TODO(), testNimService)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(result).To(Equal(ctrl.Result{RequeueAfter: deploymentNotReadyRequeue}))
 
 			// Deployment should be created
 			deployment := &appsv1.Deployment{}
@@ -3379,7 +3461,7 @@ var _ = Describe("NIMServiceReconciler for a standalone platform", func() {
 
 			result, err := reconciler.reconcileNIMService(context.TODO(), testNimService)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(result).To(Equal(ctrl.Result{RequeueAfter: deploymentNotReadyRequeue}))
 
 			// Deployment should be created
 			deployment := &appsv1.Deployment{}
@@ -3513,7 +3595,7 @@ var _ = Describe("NIMServiceReconciler for a standalone platform", func() {
 
 			result, err := reconciler.reconcileNIMService(context.TODO(), testNimService)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(result).To(Equal(ctrl.Result{RequeueAfter: deploymentNotReadyRequeue}))
 
 			// Get the rendered Deployment
 			deployment := &appsv1.Deployment{}
@@ -3665,7 +3747,7 @@ var _ = Describe("NIMServiceReconciler for a standalone platform", func() {
 
 			result, err := reconciler.reconcileNIMService(context.TODO(), testNimService)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(result).To(Equal(ctrl.Result{RequeueAfter: deploymentNotReadyRequeue}))
 
 			// Get the rendered LeaderWorkerSet
 			lws := &lwsv1.LeaderWorkerSet{}
@@ -3759,7 +3841,7 @@ var _ = Describe("NIMServiceReconciler for a standalone platform", func() {
 
 			result, err := reconciler.reconcileNIMService(context.TODO(), testNimService)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(result).To(Equal(ctrl.Result{RequeueAfter: deploymentNotReadyRequeue}))
 
 			deployment := &appsv1.Deployment{}
 			err = client.Get(context.TODO(), namespacedName, deployment)


### PR DESCRIPTION
**Issue 1**: NIM Operator starts before the InferenceService CRD exists and there is no isvc watch, when the isvc later becomes Ready, nothing runs NIMService reconcile so its status remains NotReady.

Solution:
Created two new constants - If a KServe NIMService is reconciled and the CRD still isn’t there, wait 30s and try again
const _inferenceServiceCRDRequeueInterval_ = 30 * time.Second
var _errInferenceServiceCRDMissing_ = errors.New("InferenceService CRD is not available")

For KServe NIMServices, ensure we are watching InferenceServices. If the CRD was missing at operator start-up, register the owner watch on first demand instead of polling discovery in the background.
```
	if nimService.Spec.InferencePlatform == appsv1alpha1.PlatformTypeKServe {
		if err := r.ensureInferenceServiceWatch(); err != nil {
			if errors.Is(err, errInferenceServiceCRDMissing) {
				logger.Info("InferenceService CRD not available yet; requeueing",
					"NIMService", nimService.Name)
				return ctrl.Result{RequeueAfter: inferenceServiceCRDRequeueInterval}, nil
			}
```
SetupWithManager: stop treating “no CRD at boot” as permanent
```
isvcCRDExists, err := k8sutil.CRDExists(...)
if isvcCRDExists {
    nimServiceBuilder = nimServiceBuilder.Owns(&kservev1beta1.InferenceService{})
    r.inferenceServiceWatchRegistered = true
}
```
**internal/controller/platform/kserve/nimservice.go** - for checkInferenceServiceStatus we will requeue on NotReady. Prefer the API reader so readiness is observed even when the InferenceService informer was not started (CRD missing at operator boot / not in filtered cache).
```
	reader := client.Reader(r.Client)
	if r.apiReader != nil {
		reader = r.apiReader
	}
```

**Issue 2**: when spec.scale.enabled is flipped to false while the HPA is actively rescaling, the HPA is deleted but the Deployment keeps the HPA's replica count forever, this breaks kubectl wait, GitOps health checks and any status-driven automation; symptom 2 also silently holds GPUs.

Solution:
Created two new constants:
_deploymentNotReadyRequeue_ -> wait 30s to re-check Deployment when the NIMService is not yet Ready.
_autoscalingDisableRequeue_ -> a short requeue used after disabling autoscaling so a late HPA write cannot permanently pin Deployment replicas

We will define a variable autoscalingJustDisabled which corresponds to the scenario where HPA was present and we just deleted it. Then we will proceed to delete the HPA as we did before.
```
if hpaGetErr == nil {
	autoscalingJustDisabled = true
}
```
Inside _renderAndSyncResource_, before if parent-spec hash matches we would return immediately (do nothing) leading to the replicas being stuck at 3. Now we skip only if parent-spec hash matches and live replicas already match spec.replicas.
```
parentSpecChanged := !found || utils.IsParentSpecChanged(obj, utils.DeepHashObject(nimService.Spec))
	replicasOutOfSync := false
	if found && !nimService.IsAutoScalingEnabled() {
		if curr, ok := obj.(*appsv1.Deployment); ok {
			replicasOutOfSync = deploymentSpecReplicasOutOfSync(curr, nimService.GetReplicas())
		}
	}
	if found && !parentSpecChanged && !replicasOutOfSync {
		return nil
	}
```
After disable you often are NotReady for a while (pods terminating). If a late HPA write left incorrect replicas you would be stuck. Now we will requeue in 30s.
```
if !ready {
	..................
	return ctrl.Result{RequeueAfter: deploymentNotReadyRequeue}, nil
}
```
Once the deployment is Ready, we add a check for where autoscalingJustDisabled=True and RequeueAfter 5s to catch late HPA writes. If a late HPA write set deployment back to 3, without a requeue, we might never look again (spec hash unchanged → skip). With the 5s requeue, we come back, see replicas 3 ≠ 1, force sync back to 1.

TESTING: For issue 1 - We verified issue 1 by reproducing the install-order bug on a live cluster: the fixed NIM Operator image was started first (with no InferenceService CRD present), then KServe v0.19 was installed afterward without restarting the operator. Creating a inferencePlatform: kserve, and once the owned InferenceService reported PredictorReady=True / Ready=True, the NIMService converged to Ready on the same operator pod that had booted before KServe—confirming status no longer stays stuck NotReady until a restart. 
For issue 2 we simulates the bug: HPA has scaled the Deployment to 3, then autoscaling is turned off with replicas: 1. It checks that reconcile deletes the HPA, forces Deployment replicas back to 1, and returns a non-zero RequeueAfter (not a silent no-op). It then fakes a late HPA write that bumps replicas to 3 again without changing the parent-spec hash, and asserts the next reconcile still restores replicas to 1.