### PR TITLE
Remove authSecret reqs for Air gapped use

### DIFF
--- a/api/apps/v1alpha1/nimservice_types.go
+++ b/api/apps/v1alpha1/nimservice_types.go
@@ -99,8 +99,9 @@ type NIMServiceSpec struct {
 	Command []string        `json:"command,omitempty"`
 	Args    []string        `json:"args,omitempty"`
 	Env     []corev1.EnvVar `json:"env,omitempty"`
-	// The name of an existing pull secret containing the NGC_API_KEY
-	AuthSecret string `json:"authSecret"`
+	// AuthSecret is the name of an existing secret containing the NGC_API_KEY (and optionally HF_TOKEN).
+	// It is optional for air-gapped deployments that serve a pre-cached model
+	AuthSecret string `json:"authSecret,omitempty"`
 	// Storage is the target storage for caching NIM model if NIMCache is not provided
 	Storage      NIMServiceStorage   `json:"storage,omitempty"`
 	Labels       map[string]string   `json:"labels,omitempty"`
@@ -308,17 +309,6 @@ func (n *NIMService) GetStandardEnv() []corev1.EnvVar {
 			Value: utils.DefaultModelStorePath,
 		},
 		{
-			Name: NGCAPIKey,
-			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: n.Spec.AuthSecret,
-					},
-					Key: NGCAPIKey,
-				},
-			},
-		},
-		{
 			Name:  "OUTLINES_CACHE_DIR",
 			Value: "/tmp/outlines",
 		},
@@ -338,6 +328,23 @@ func (n *NIMService) GetStandardEnv() []corev1.EnvVar {
 			Name:  "NIM_LOG_LEVEL",
 			Value: "INFO",
 		},
+	}
+
+	// Only inject NGC_API_KEY when AuthSecret is set. Air-gapped deployments that
+	// serve a pre-populated local cache must omit AuthSecret so NIM does not
+	// attempt NGC authentication.
+	if n.Spec.AuthSecret != "" {
+		envVars = append(envVars, corev1.EnvVar{
+			Name: NGCAPIKey,
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: n.Spec.AuthSecret,
+					},
+					Key: NGCAPIKey,
+				},
+			},
+		})
 	}
 	if n.Spec.Expose.Service.GRPCPort != nil {
 		envVars = append(envVars, corev1.EnvVar{

--- a/api/apps/v1alpha1/nimservice_types_test.go
+++ b/api/apps/v1alpha1/nimservice_types_test.go
@@ -1031,3 +1031,49 @@ func TestGetPriorityClassName(t *testing.T) {
 		t.Errorf("GetInferenceServiceParams().PriorityClassName = %q, want %q", inferenceParams.PriorityClassName, "gpu-critical")
 	}
 }
+
+func TestGetStandardEnvAuthSecret(t *testing.T) {
+	base := NIMServiceSpec{
+		Image: Image{
+			Repository: "test-repo",
+			Tag:        "test-tag",
+		},
+		Expose: Expose{
+			Service: Service{
+				Port: ptr.To[int32](8000),
+			},
+		},
+	}
+
+	t.Run("with authSecret injects NGC_API_KEY", func(t *testing.T) {
+		nimService := &NIMService{Spec: base}
+		nimService.Spec.AuthSecret = "ngc-api-secret"
+		env := nimService.GetStandardEnv()
+		var ngc *corev1.EnvVar
+		for i := range env {
+			if env[i].Name == NGCAPIKey {
+				ngc = &env[i]
+				break
+			}
+		}
+		if ngc == nil {
+			t.Fatal("expected NGC_API_KEY to be injected when AuthSecret is set")
+		}
+		if ngc.ValueFrom == nil || ngc.ValueFrom.SecretKeyRef == nil {
+			t.Fatal("expected NGC_API_KEY to reference a secret")
+		}
+		if ngc.ValueFrom.SecretKeyRef.Name != "ngc-api-secret" {
+			t.Errorf("SecretKeyRef.Name = %q, want %q", ngc.ValueFrom.SecretKeyRef.Name, "ngc-api-secret")
+		}
+	})
+
+	t.Run("without authSecret omits NGC_API_KEY", func(t *testing.T) {
+		nimService := &NIMService{Spec: base}
+		env := nimService.GetStandardEnv()
+		for _, e := range env {
+			if e.Name == NGCAPIKey {
+				t.Fatalf("expected NGC_API_KEY to be omitted when AuthSecret is empty, got %+v", e)
+			}
+		}
+	})
+}

--- a/bundle/manifests/apps.nvidia.com_nimpipelines.yaml
+++ b/bundle/manifests/apps.nvidia.com_nimpipelines.yaml
@@ -1019,8 +1019,9 @@ spec:
                             type: string
                           type: array
                         authSecret:
-                          description: The name of an existing pull secret containing
-                            the NGC_API_KEY
+                          description: |-
+                            AuthSecret is the name of an existing secret containing the NGC_API_KEY (and optionally HF_TOKEN).
+                            It is optional for air-gapped deployments that serve a pre-cached model
                           type: string
                         command:
                           items:
@@ -5162,7 +5163,6 @@ spec:
                           format: int64
                           type: integer
                       required:
-                      - authSecret
                       - image
                       type: object
                       x-kubernetes-validations:

--- a/bundle/manifests/apps.nvidia.com_nimservices.yaml
+++ b/bundle/manifests/apps.nvidia.com_nimservices.yaml
@@ -968,7 +968,9 @@ spec:
                   type: string
                 type: array
               authSecret:
-                description: The name of an existing pull secret containing the NGC_API_KEY
+                description: |-
+                  AuthSecret is the name of an existing secret containing the NGC_API_KEY (and optionally HF_TOKEN).
+                  It is optional for air-gapped deployments that serve a pre-cached model
                 type: string
               command:
                 items:
@@ -5007,7 +5009,6 @@ spec:
                 format: int64
                 type: integer
             required:
-            - authSecret
             - image
             type: object
             x-kubernetes-validations:

--- a/config/crd/bases/apps.nvidia.com_nimpipelines.yaml
+++ b/config/crd/bases/apps.nvidia.com_nimpipelines.yaml
@@ -1019,8 +1019,9 @@ spec:
                             type: string
                           type: array
                         authSecret:
-                          description: The name of an existing pull secret containing
-                            the NGC_API_KEY
+                          description: |-
+                            AuthSecret is the name of an existing secret containing the NGC_API_KEY (and optionally HF_TOKEN).
+                            It is optional for air-gapped deployments that serve a pre-cached model
                           type: string
                         command:
                           items:
@@ -5162,7 +5163,6 @@ spec:
                           format: int64
                           type: integer
                       required:
-                      - authSecret
                       - image
                       type: object
                       x-kubernetes-validations:

--- a/config/crd/bases/apps.nvidia.com_nimservices.yaml
+++ b/config/crd/bases/apps.nvidia.com_nimservices.yaml
@@ -968,7 +968,9 @@ spec:
                   type: string
                 type: array
               authSecret:
-                description: The name of an existing pull secret containing the NGC_API_KEY
+                description: |-
+                  AuthSecret is the name of an existing secret containing the NGC_API_KEY (and optionally HF_TOKEN).
+                  It is optional for air-gapped deployments that serve a pre-cached model
                 type: string
               command:
                 items:
@@ -5007,7 +5009,6 @@ spec:
                 format: int64
                 type: integer
             required:
-            - authSecret
             - image
             type: object
             x-kubernetes-validations:

--- a/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nimpipelines.yaml
+++ b/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nimpipelines.yaml
@@ -1019,8 +1019,9 @@ spec:
                             type: string
                           type: array
                         authSecret:
-                          description: The name of an existing pull secret containing
-                            the NGC_API_KEY
+                          description: |-
+                            AuthSecret is the name of an existing secret containing the NGC_API_KEY (and optionally HF_TOKEN).
+                            It is optional for air-gapped deployments that serve a pre-cached model
                           type: string
                         command:
                           items:
@@ -5162,7 +5163,6 @@ spec:
                           format: int64
                           type: integer
                       required:
-                      - authSecret
                       - image
                       type: object
                       x-kubernetes-validations:

--- a/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nimservices.yaml
+++ b/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nimservices.yaml
@@ -968,7 +968,9 @@ spec:
                   type: string
                 type: array
               authSecret:
-                description: The name of an existing pull secret containing the NGC_API_KEY
+                description: |-
+                  AuthSecret is the name of an existing secret containing the NGC_API_KEY (and optionally HF_TOKEN).
+                  It is optional for air-gapped deployments that serve a pre-cached model
                 type: string
               command:
                 items:
@@ -5007,7 +5009,6 @@ spec:
                 format: int64
                 type: integer
             required:
-            - authSecret
             - image
             type: object
             x-kubernetes-validations:

--- a/internal/controller/platform/kserve/nimservice.go
+++ b/internal/controller/platform/kserve/nimservice.go
@@ -550,63 +550,68 @@ func (r *NIMServiceReconciler) renderAndSyncInferenceService(ctx context.Context
 		// standard env requires NGC_API_KEY, which breaks auth secrets that only
 		// carry an HF token. Make NGC_API_KEY optional and surface HF_TOKEN (also
 		// optional) so either credential works.
+		// When AuthSecret is unset (air-gapped / pre-cached), omit both keys.
 		isvcParams.Env = utils.RemoveEnvVar(isvcParams.Env, appsv1alpha1.NGCAPIKey)
-		isvcParams.Env = utils.MergeEnvVars(isvcParams.Env, []corev1.EnvVar{
-			{
-				Name: appsv1alpha1.NGCAPIKey,
-				ValueFrom: &corev1.EnvVarSource{
-					SecretKeyRef: &corev1.SecretKeySelector{
-						LocalObjectReference: corev1.LocalObjectReference{
-							Name: nimService.Spec.AuthSecret,
+		if nimService.Spec.AuthSecret != "" {
+			isvcParams.Env = utils.MergeEnvVars(isvcParams.Env, []corev1.EnvVar{
+				{
+					Name: appsv1alpha1.NGCAPIKey,
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: nimService.Spec.AuthSecret,
+							},
+							Key:      appsv1alpha1.NGCAPIKey,
+							Optional: &[]bool{true}[0],
 						},
-						Key:      appsv1alpha1.NGCAPIKey,
-						Optional: &[]bool{true}[0],
 					},
 				},
-			},
-			{
-				Name: appsv1alpha1.HFToken,
-				ValueFrom: &corev1.EnvVarSource{
-					SecretKeyRef: &corev1.SecretKeySelector{
-						LocalObjectReference: corev1.LocalObjectReference{
-							Name: nimService.Spec.AuthSecret,
+				{
+					Name: appsv1alpha1.HFToken,
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: nimService.Spec.AuthSecret,
+							},
+							Key:      appsv1alpha1.HFToken,
+							Optional: &[]bool{true}[0],
 						},
-						Key:      appsv1alpha1.HFToken,
-						Optional: &[]bool{true}[0],
 					},
 				},
-			},
-		})
+			})
+		}
 	}
 	// If NIMCache or NIMService is a Hugging Face Multi-LLM NIM, add the HF_TOKEN to the environment variables and make NGC_API_KEY optional
 	// For custom models stored in Datastore, the NIM Container needs to access NGC to download base model. However, NGC_API_KEY is not required for Hugging Face models.
 	if nimCache.IsHFModel() || nimService.IsHFModel() {
 		isvcParams.Env = utils.RemoveEnvVar(isvcParams.Env, appsv1alpha1.NGCAPIKey)
-		isvcParams.Env = utils.MergeEnvVars(isvcParams.Env, []corev1.EnvVar{
-			{
-				Name: appsv1alpha1.NGCAPIKey,
-				ValueFrom: &corev1.EnvVarSource{
-					SecretKeyRef: &corev1.SecretKeySelector{
-						LocalObjectReference: corev1.LocalObjectReference{
-							Name: nimService.Spec.AuthSecret,
+		if nimService.Spec.AuthSecret != "" {
+			isvcParams.Env = utils.MergeEnvVars(isvcParams.Env, []corev1.EnvVar{
+				{
+					Name: appsv1alpha1.NGCAPIKey,
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: nimService.Spec.AuthSecret,
+							},
+							Key:      appsv1alpha1.NGCAPIKey,
+							Optional: &[]bool{true}[0],
 						},
-						Key:      appsv1alpha1.NGCAPIKey,
-						Optional: &[]bool{true}[0],
 					},
 				},
-			},
-			{
-				Name: appsv1alpha1.HFToken,
-				ValueFrom: &corev1.EnvVarSource{
-					SecretKeyRef: &corev1.SecretKeySelector{
-						LocalObjectReference: corev1.LocalObjectReference{
-							Name: nimService.Spec.AuthSecret,
+				{
+					Name: appsv1alpha1.HFToken,
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: nimService.Spec.AuthSecret,
+							},
+							Key: appsv1alpha1.HFToken,
 						},
-						Key: appsv1alpha1.HFToken,
 					},
 				},
-			},
-		})
+			})
+		}
 	}
 
 	// Setup volume mounts with model store. Native (NIMCraft) single-model NIMs

--- a/internal/controller/platform/standalone/nimservice.go
+++ b/internal/controller/platform/standalone/nimservice.go
@@ -591,64 +591,69 @@ func (r *NIMServiceReconciler) reconcileNIMService(ctx context.Context, nimServi
 			// standard env requires NGC_API_KEY, which breaks auth secrets that
 			// only carry an HF token. Make NGC_API_KEY optional and surface
 			// HF_TOKEN (also optional) so either credential works.
+			// When AuthSecret is unset (air-gapped / pre-cached), omit both keys.
 			deploymentParams.Env = utils.RemoveEnvVar(deploymentParams.Env, appsv1alpha1.NGCAPIKey)
-			deploymentParams.Env = utils.MergeEnvVars(deploymentParams.Env, []corev1.EnvVar{
-				{
-					Name: appsv1alpha1.NGCAPIKey,
-					ValueFrom: &corev1.EnvVarSource{
-						SecretKeyRef: &corev1.SecretKeySelector{
-							LocalObjectReference: corev1.LocalObjectReference{
-								Name: nimService.Spec.AuthSecret,
+			if nimService.Spec.AuthSecret != "" {
+				deploymentParams.Env = utils.MergeEnvVars(deploymentParams.Env, []corev1.EnvVar{
+					{
+						Name: appsv1alpha1.NGCAPIKey,
+						ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: nimService.Spec.AuthSecret,
+								},
+								Key:      appsv1alpha1.NGCAPIKey,
+								Optional: &[]bool{true}[0],
 							},
-							Key:      appsv1alpha1.NGCAPIKey,
-							Optional: &[]bool{true}[0],
 						},
 					},
-				},
-				{
-					Name: appsv1alpha1.HFToken,
-					ValueFrom: &corev1.EnvVarSource{
-						SecretKeyRef: &corev1.SecretKeySelector{
-							LocalObjectReference: corev1.LocalObjectReference{
-								Name: nimService.Spec.AuthSecret,
+					{
+						Name: appsv1alpha1.HFToken,
+						ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: nimService.Spec.AuthSecret,
+								},
+								Key:      appsv1alpha1.HFToken,
+								Optional: &[]bool{true}[0],
 							},
-							Key:      appsv1alpha1.HFToken,
-							Optional: &[]bool{true}[0],
 						},
 					},
-				},
-			})
+				})
+			}
 		}
 
 		// If NIMCache or NIMService is a Hugging Face Multi-LLM NIM, add the HF_TOKEN to the environment variables and make NGC_API_KEY optional
 		// For custom models stored in Datastore, the NIM Container needs to access NGC to download base model. However, NGC_API_KEY is not required for Hugging Face models.
 		if nimCache.IsHFModel() || nimService.IsHFModel() {
 			deploymentParams.Env = utils.RemoveEnvVar(deploymentParams.Env, appsv1alpha1.NGCAPIKey)
-			deploymentParams.Env = utils.MergeEnvVars(deploymentParams.Env, []corev1.EnvVar{
-				{
-					Name: appsv1alpha1.NGCAPIKey,
-					ValueFrom: &corev1.EnvVarSource{
-						SecretKeyRef: &corev1.SecretKeySelector{
-							LocalObjectReference: corev1.LocalObjectReference{
-								Name: nimService.Spec.AuthSecret,
+			if nimService.Spec.AuthSecret != "" {
+				deploymentParams.Env = utils.MergeEnvVars(deploymentParams.Env, []corev1.EnvVar{
+					{
+						Name: appsv1alpha1.NGCAPIKey,
+						ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: nimService.Spec.AuthSecret,
+								},
+								Key:      appsv1alpha1.NGCAPIKey,
+								Optional: &[]bool{true}[0],
 							},
-							Key:      appsv1alpha1.NGCAPIKey,
-							Optional: &[]bool{true}[0],
 						},
 					},
-				},
-				{
-					Name: appsv1alpha1.HFToken,
-					ValueFrom: &corev1.EnvVarSource{
-						SecretKeyRef: &corev1.SecretKeySelector{
-							LocalObjectReference: corev1.LocalObjectReference{
-								Name: nimService.Spec.AuthSecret,
+					{
+						Name: appsv1alpha1.HFToken,
+						ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: nimService.Spec.AuthSecret,
+								},
+								Key: appsv1alpha1.HFToken,
 							},
-							Key: appsv1alpha1.HFToken,
 						},
 					},
-				},
-			})
+				})
+			}
 		}
 
 		// Setup volume mounts with model store. Native (NIMCraft) single-model

--- a/internal/controller/platform/standalone/nimservice_test.go
+++ b/internal/controller/platform/standalone/nimservice_test.go
@@ -1194,21 +1194,11 @@ var _ = Describe("NIMServiceReconciler for a standalone platform", func() {
 			leaderEnv := utils.SortKeys(nimService.GetLWSLeaderEnv())
 			workerEnv := utils.SortKeys(nimService.GetLWSWorkerEnv())
 
+			// AuthSecret is unset, so NGC_API_KEY must be omitted from LWS env.
 			Expect(reflect.DeepEqual(leaderEnv, []corev1.EnvVar{
 				{
 					Name:  "NIM_CACHE_PATH",
 					Value: "/model-store",
-				},
-				{
-					Name: "NGC_API_KEY",
-					ValueFrom: &corev1.EnvVarSource{
-						SecretKeyRef: &corev1.SecretKeySelector{
-							LocalObjectReference: corev1.LocalObjectReference{
-								Name: "",
-							},
-							Key: "NGC_API_KEY",
-						},
-					},
 				},
 				{
 					Name:  "OUTLINES_CACHE_DIR",
@@ -1300,17 +1290,6 @@ var _ = Describe("NIMServiceReconciler for a standalone platform", func() {
 				{
 					Name:  "NIM_CACHE_PATH",
 					Value: "/model-store",
-				},
-				{
-					Name: "NGC_API_KEY",
-					ValueFrom: &corev1.EnvVarSource{
-						SecretKeyRef: &corev1.SecretKeySelector{
-							LocalObjectReference: corev1.LocalObjectReference{
-								Name: "",
-							},
-							Key: "NGC_API_KEY",
-						},
-					},
 				},
 				{
 					Name:  "OUTLINES_CACHE_DIR",

--- a/internal/webhook/apps/v1alpha1/nimservice_webhook_validation_helper.go
+++ b/internal/webhook/apps/v1alpha1/nimservice_webhook_validation_helper.go
@@ -446,8 +446,11 @@ func validateDRAResourceQuantitySelectorValue(value *apiresource.Quantity, fldPa
 func validateAuthSecret(authSecret *string, fldPath *field.Path) (admission.Warnings, field.ErrorList) {
 	warningList := admission.Warnings{}
 	errList := field.ErrorList{}
-	if *authSecret == "" {
-		errList = append(errList, field.Required(fldPath, "is required"))
+	// AuthSecret is optional for air-gapped deployments that serve a pre-cached
+	// model from local storage. Warn so users do not omit it unintentionally
+	// when they still need NGC/HF credentials for model download.
+	if authSecret == nil || *authSecret == "" {
+		warningList = append(warningList, fmt.Sprintf("%s is empty: NGC_API_KEY will not be injected. Omit this only for air-gapped deployments with a pre-populated local model cache", fldPath.String()))
 	}
 	return warningList, errList
 }

--- a/internal/webhook/apps/v1alpha1/nimservice_webhook_validation_helper_test.go
+++ b/internal/webhook/apps/v1alpha1/nimservice_webhook_validation_helper_test.go
@@ -777,7 +777,7 @@ func TestValidateDRAResourcesConfiguration(t *testing.T) {
 	}
 }
 
-// TestValidateAuthSecret verifies required secret enforcement using table-driven cases.
+// TestValidateAuthSecret verifies authSecret is optional, with a warning when empty.
 func TestValidateAuthSecret(t *testing.T) {
 	fld := field.NewPath("spec").Child("authSecret")
 	cases := []struct {
@@ -787,7 +787,7 @@ func TestValidateAuthSecret(t *testing.T) {
 		wantWarnings int
 	}{
 		{"non-empty", "secret", 0, 0},
-		{"empty", "", 1, 0},
+		{"empty", "", 0, 1},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
This PR is a response to this issue: https://github.com/NVIDIA/k8s-nim-operator/issues/887. Essentially the NIMService can't be created without authSecret. If you include that secret, the operator automatically puts NGC_API_KEY into the pod which causes an error in disconnected environments.

SOLUTION:
**api/apps/v1alpha1/nimservice_types.go** - Make the AuthSecret optional to enable air-gapped deployments that serve a pre-cached model
```
type NIMServiceSpec struct {
	.........................
	AuthSecret string `json:"authSecret,omitempty"`
```
...Remove the unconditional block for NGCAPIKey, and switch to:
```
// Only inject NGC_API_KEY when AuthSecret is set...
if n.Spec.AuthSecret != "" {
	envVars = append(envVars, corev1.EnvVar{
		Name: NGCAPIKey,

```
**internal/webhook/apps/v1alpha1/nimservice_webhook_validation_helper.go** - Similarly, for the webhook we can allow empty for an AuthSecret and provide a warning here instead:
```
if authSecret == nil || *authSecret == "" {
		warningList = append(warningList, fmt.Sprintf("%s is empty: NGC_API_KEY will not be injected. Omit this only for air-gapped deployments with a pre-populated local model cache", fldPath.String()))
```
In Standalone + KServe controllers — don’t automatically re-add secret refs when empty.

TESTING: The new/updated tests check the two main behaviors of the fix. TestGetStandardEnvAuthSecret verifies that when authSecret is set, GetStandardEnv() still injects NGC_API_KEY from that secret, and when it is omitted, NGC_API_KEY is not added at all. TestValidateAuthSecret was updated so an empty authSecret is accepted with a warning instead of being rejected as a validation error. Also verified with an airgapped cluster:
```
local-agadiyar@ipp2-2404:~/k8s-nim-operator$ kubectl -n nim-llm get nimservice nim-llm-service -o jsonpath='authSecret={.spec.authSecret} status={.status.state}{"\n"}'
authSecret= status=Ready
local-agadiyar@ipp2-2404:~/k8s-nim-operator$ POD=$(kubectl -n nim-llm getpod -l app=nim-llm-service -o jsonpath='{.items[0].metadata.name}')
local-agadiyar@ipp2-2404:~/k8s-nim-operator$ kubectl -n nim-llm get pod "$POD" -o jsonpath='{range .spec.containers[0].env[*]}{.name}{"="}{.value}{"\n"}{end}' | grep -E 'NGC_API_KEY|NIM_CACHE_PATH|NIM_MODEL_PROFILE' || echo 'PASS: NGC_API_KEY absent'
NIM_MODEL_PROFILE=72104c5b2318b83bb8dde1d255998243472158e48c236982c4974f5a1c693d8e
NIM_CACHE_PATH=/model-store
local-agadiyar@ipp2-2404:~/k8s-nim-operator$ kubectl -n nim-llm get netpol bug-repro-deny-egress
NAME                    POD-SELECTOR          AGE
bug-repro-deny-egress   app=nim-llm-service   23h
local-agadiyar@ipp2-2404:~/k8s-nim-operator$ kubectl -n nim-llm exec "$POD" -- python3 -c '
import json,urllib.request
body=json.dumps({"model":"meta/llama-3.2-1b-instruct","messages":[{"role":"user","content":"Say hello in one short sentence."}],"max_tokens":16,"temperature":0}).encode()
req=urllib.request.Request("http://127.0.0.1:8000/v1/chat/completions",data=body,headers={"Content-Type":"application/json"})
print(json.load(urllib.request.urlopen(req,timeout=60))["choices"][0]["message"]["content"])
'
Hello.
```