### PR TITLE
Fix legacy v1 parser and nimcache controller path for MolMIM

### DIFF
--- a/api/apps/v1alpha1/nimcache_types.go
+++ b/api/apps/v1alpha1/nimcache_types.go
@@ -169,11 +169,17 @@ type NIMCacheStorage struct {
 
 // NIMCacheStatus defines the observed state of NIMCache.
 type NIMCacheStatus struct {
-	State      string             `json:"state,omitempty"`
-	Type       string             `json:"type,omitempty"`
-	PVC        string             `json:"pvc,omitempty"`
-	Profiles   []NIMProfile       `json:"profiles,omitempty"`
-	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
+	State string `json:"state,omitempty"`
+	Type  string `json:"type,omitempty"`
+	// DownloadMethod records how model weights should be cached for this NIM
+	// image, as discovered by the manifest probe pod. Empty defaults to the
+	// standard download-to-cache CLI. "nimlib" is used for BioNeMo-style NIMs
+	// (e.g. MolMIM) that expose nimutils.download_models() but not download-to-cache.
+	// +optional
+	DownloadMethod string             `json:"downloadMethod,omitempty"`
+	PVC            string             `json:"pvc,omitempty"`
+	Profiles       []NIMProfile       `json:"profiles,omitempty"`
+	Conditions     []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
 }
 
 // NIMProfile defines the profiles that were cached.
@@ -228,6 +234,13 @@ const (
 	// model_manifest.yaml, no download-to-cache/list-model-profiles commands,
 	// and download their single model on start when NGC_API_KEY/HF_TOKEN is set.
 	NIMCacheModelTypeNative = "native"
+
+	// NIMCacheDownloadMethodCLI indicates the image provides the standard
+	// download-to-cache CLI used by LLM/VLM NIMs.
+	NIMCacheDownloadMethodCLI = "download-to-cache"
+	// NIMCacheDownloadMethodNIMLib indicates the image has no download-to-cache
+	// CLI but exposes nimlib.nimutils.download_models() (BioNeMo-style NIMs).
+	NIMCacheDownloadMethodNIMLib = "nimlib"
 )
 
 // EnvFromSecrets return the list of secrets that should be mounted as env vars.
@@ -363,6 +376,12 @@ func (n *NIMCache) IsOptimizedNIM() bool {
 // the status so subsequent reconciles do not need to re-inspect the registry.
 func (n *NIMCache) IsNativeModelDownload() bool {
 	return n.Status.Type == NIMCacheModelTypeNative
+}
+
+// UsesNimlibDownload returns true if the manifest probe determined the image
+// caches models via nimlib.nimutils.download_models() rather than download-to-cache.
+func (n *NIMCache) UsesNimlibDownload() bool {
+	return n.Status.DownloadMethod == NIMCacheDownloadMethodNIMLib
 }
 
 // GetModelSpec returns the model spec for the NIMCache.

--- a/bundle/manifests/apps.nvidia.com_nimcaches.yaml
+++ b/bundle/manifests/apps.nvidia.com_nimcaches.yaml
@@ -825,6 +825,13 @@ spec:
                   - type
                   type: object
                 type: array
+              downloadMethod:
+                description: |-
+                  DownloadMethod records how model weights should be cached for this NIM
+                  image, as discovered by the manifest probe pod. Empty defaults to the
+                  standard download-to-cache CLI. "nimlib" is used for BioNeMo-style NIMs
+                  (e.g. MolMIM) that expose nimutils.download_models() but not download-to-cache.
+                type: string
               profiles:
                 items:
                   description: NIMProfile defines the profiles that were cached.

--- a/config/crd/bases/apps.nvidia.com_nimcaches.yaml
+++ b/config/crd/bases/apps.nvidia.com_nimcaches.yaml
@@ -825,6 +825,13 @@ spec:
                   - type
                   type: object
                 type: array
+              downloadMethod:
+                description: |-
+                  DownloadMethod records how model weights should be cached for this NIM
+                  image, as discovered by the manifest probe pod. Empty defaults to the
+                  standard download-to-cache CLI. "nimlib" is used for BioNeMo-style NIMs
+                  (e.g. MolMIM) that expose nimutils.download_models() but not download-to-cache.
+                type: string
               profiles:
                 items:
                   description: NIMProfile defines the profiles that were cached.

--- a/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nimcaches.yaml
+++ b/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nimcaches.yaml
@@ -825,6 +825,13 @@ spec:
                   - type
                   type: object
                 type: array
+              downloadMethod:
+                description: |-
+                  DownloadMethod records how model weights should be cached for this NIM
+                  image, as discovered by the manifest probe pod. Empty defaults to the
+                  standard download-to-cache CLI. "nimlib" is used for BioNeMo-style NIMs
+                  (e.g. MolMIM) that expose nimutils.download_models() but not download-to-cache.
+                type: string
               profiles:
                 items:
                   description: NIMProfile defines the profiles that were cached.

--- a/internal/controller/nimbuild_controller.go
+++ b/internal/controller/nimbuild_controller.go
@@ -812,9 +812,7 @@ func (r *NIMBuildReconciler) reconcileLocalModelManifest(ctx context.Context, ni
 		return nil
 	}
 
-	parser := nimparserutils.GetNIMParser([]byte(output))
-	// Parse the file
-	manifest, err := parser.ParseModelManifestFromRawOutput([]byte(output))
+	manifest, err := nimparserutils.ParseModelManifest([]byte(output))
 	if err != nil {
 		logger.Error(err, "Failed to parse model manifest from the pod")
 		return err

--- a/internal/controller/nimcache_controller.go
+++ b/internal/controller/nimcache_controller.go
@@ -659,11 +659,35 @@ func (r *NIMCacheReconciler) reconcileModelManifest(ctx context.Context, nimCach
 		return true, nil
 	}
 
-	if strings.Contains(output, "model_manifest.yaml not found") {
-		logger.Info("model manifest file not found", "output", output)
+	caps, manifestOutput := parseProbeOutput(output)
+	if !caps.Complete() {
+		logger.Info("Requeuing to wait for probe capability markers", "output", output)
+		return true, nil
+	}
+	if strings.TrimSpace(manifestOutput) == "" {
+		logger.Info("Requeuing to wait for the manifest to be copied from the container")
+		return true, nil
+	}
+
+	if strings.Contains(manifestOutput, "model_manifest.yaml not found") {
+		logger.Info("model manifest file not found", "output", manifestOutput)
 		nimCache.Status.Type = appsv1alpha1.NIMCacheModelTypeModelFree
+		// Record download method when discoverable; model-free HF flows do not
+		// require nimlib and may use download-to-cache --model-uri or huggingface-cli.
+		if method, methodErr := resolveDownloadMethod(caps); methodErr == nil {
+			nimCache.Status.DownloadMethod = method
+		}
 	} else {
-		manifest, err := nimparserutils.ParseModelManifest([]byte(output))
+		// Manifest-backed NGC optimized NIMs must expose a cache entrypoint.
+		downloadMethod, err := resolveDownloadMethod(caps)
+		if err != nil {
+			logger.Error(err, "unsupported NIM image for caching", "output", output)
+			return false, err
+		}
+		nimCache.Status.DownloadMethod = downloadMethod
+		logger.Info("discovered NIM download method", "method", downloadMethod)
+
+		manifest, err := nimparserutils.ParseModelManifest([]byte(manifestOutput))
 		if err != nil {
 			logger.Error(err, "Failed to parse model manifest from the pod")
 			return false, err
@@ -979,6 +1003,18 @@ func getCommand() []string {
 		"sh",
 		"-c",
 		strings.Join([]string{
+			// Emit operator capability markers before the manifest body so the
+			// reconciler can choose download-to-cache vs nimlib.download_models.
+			"if command -v download-to-cache >/dev/null 2>&1; then",
+			"echo \"NIM_OPERATOR_CAP download_to_cache=yes\";",
+			"else",
+			"echo \"NIM_OPERATOR_CAP download_to_cache=no\";",
+			"fi;",
+			"if python3 -c 'from nimlib import nimutils' >/dev/null 2>&1; then",
+			"echo \"NIM_OPERATOR_CAP nimlib_download=yes\";",
+			"else",
+			"echo \"NIM_OPERATOR_CAP nimlib_download=no\";",
+			"fi;",
 			"if [ -f /opt/nim/etc/default/model_manifest.yaml ]; then",
 			"cat /opt/nim/etc/default/model_manifest.yaml;",
 			"elif [ -f /etc/nim/config/model_manifest.yaml ]; then",
@@ -989,6 +1025,73 @@ func getCommand() []string {
 			"sleep infinity",
 		}, " "),
 	}
+}
+
+// probeCapabilities captures download-related tools discovered in the NIM image.
+type probeCapabilities struct {
+	HasDownloadToCache bool
+	HasNimlibDownload  bool
+	// SawDownloadToCache / SawNimlibDownload track whether both capability
+	// markers have been observed. Partial pod logs can include only the first
+	// marker; callers should requeue until both are present.
+	SawDownloadToCache bool
+	SawNimlibDownload  bool
+}
+
+// Complete reports whether both expected capability markers were present in the
+// probe output. Incomplete output should be treated as "not ready yet".
+func (c probeCapabilities) Complete() bool {
+	return c.SawDownloadToCache && c.SawNimlibDownload
+}
+
+// parseProbeOutput splits capability markers from the model manifest body.
+func parseProbeOutput(output string) (probeCapabilities, string) {
+	caps := probeCapabilities{}
+	var manifestLines []string
+	for _, line := range strings.Split(output, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "NIM_OPERATOR_CAP ") {
+			kv := strings.TrimPrefix(trimmed, "NIM_OPERATOR_CAP ")
+			switch {
+			case strings.HasPrefix(kv, "download_to_cache="):
+				caps.SawDownloadToCache = true
+				caps.HasDownloadToCache = kv == "download_to_cache=yes"
+			case strings.HasPrefix(kv, "nimlib_download="):
+				caps.SawNimlibDownload = true
+				caps.HasNimlibDownload = kv == "nimlib_download=yes"
+			}
+			continue
+		}
+		manifestLines = append(manifestLines, line)
+	}
+	return caps, strings.Join(manifestLines, "\n")
+}
+
+// resolveDownloadMethod maps probe capabilities to a persisted download method.
+func resolveDownloadMethod(caps probeCapabilities) (string, error) {
+	if caps.HasDownloadToCache {
+		return appsv1alpha1.NIMCacheDownloadMethodCLI, nil
+	}
+	if caps.HasNimlibDownload {
+		return appsv1alpha1.NIMCacheDownloadMethodNIMLib, nil
+	}
+	return "", fmt.Errorf("image has neither download-to-cache nor nimlib.download_models support")
+}
+
+// nimlibDownloadCommand builds a Job command that caches models via nimlib and exits.
+func nimlibDownloadCommand(profiles []string) []string {
+	const downloadPy = "from nimlib import nimutils; nimutils.download_models()"
+	if slices.Contains(profiles, AllProfiles) {
+		return []string{"python3", "-c", downloadPy}
+	}
+
+	var b strings.Builder
+	b.WriteString("set -e\n")
+	for _, profile := range profiles {
+		// Profiles are operator-selected IDs (hashes or short names like MolMIM).
+		fmt.Fprintf(&b, "NIM_MANIFEST_PROFILE=%s python3 -c %q\n", profile, downloadPy)
+	}
+	return []string{"sh", "-c", b.String()}
 }
 
 // constructPodSpec constructs a Pod specification.
@@ -1288,11 +1391,37 @@ func (r *NIMCacheReconciler) constructJob(ctx context.Context, nimCache *appsv1a
 		}
 
 	case nimCache.Spec.Source.NGC != nil && nimCache.Spec.Source.NGC.ModelEndpoint == nil:
+		// Pass specific profiles to download based on user selection or auto-selection
+		selectedProfiles, err := getSelectedProfiles(nimCache)
+		if err != nil {
+			logger.Error(err, "failed to get selected profiles for caching")
+			return nil, err
+		}
+
+		if len(selectedProfiles) == 0 {
+			return nil, fmt.Errorf("no profiles are selected for caching")
+		}
+
+		command := []string{"download-to-cache"}
+		var args []string
+		switch {
+		case nimCache.UsesNimlibDownload():
+			// BioNeMo-style NIMs (e.g. MolMIM) have no download-to-cache CLI.
+			// Cache via nimutils.download_models() which exits after download.
+			command = nimlibDownloadCommand(selectedProfiles)
+		case slices.Contains(selectedProfiles, AllProfiles):
+			args = append(args, "--all")
+		default:
+			args = append(args, "--profiles")
+			args = append(args, selectedProfiles...)
+		}
+
 		job.Spec.Template.Spec.Containers = []corev1.Container{
 			{
 				Name:    NIMCacheContainerName,
 				Image:   nimCache.Spec.Source.NGC.ModelPuller,
-				Command: []string{"download-to-cache"},
+				Command: command,
+				Args:    args,
 				EnvFrom: nimCache.Spec.Source.EnvFromSecrets(),
 				Env: []corev1.EnvVar{
 					{
@@ -1338,26 +1467,6 @@ func (r *NIMCacheReconciler) constructJob(ctx context.Context, nimCache *appsv1a
 			{
 				Name: nimCache.Spec.Source.NGC.PullSecret,
 			},
-		}
-
-		// Pass specific profiles to download based on user selection or auto-selection
-		selectedProfiles, err := getSelectedProfiles(nimCache)
-		if err != nil {
-			logger.Error(err, "failed to get selected profiles for caching")
-			return nil, err
-		}
-
-		if len(selectedProfiles) == 0 {
-			return nil, fmt.Errorf("no profiles are selected for caching")
-		}
-
-		if len(selectedProfiles) > 0 {
-			if slices.Contains(selectedProfiles, AllProfiles) {
-				job.Spec.Template.Spec.Containers[0].Args = append(job.Spec.Template.Spec.Containers[0].Args, "--all")
-			} else {
-				job.Spec.Template.Spec.Containers[0].Args = append(job.Spec.Template.Spec.Containers[0].Args, "--profiles")
-				job.Spec.Template.Spec.Containers[0].Args = append(job.Spec.Template.Spec.Containers[0].Args, selectedProfiles...)
-			}
 		}
 
 	case nimCache.Spec.Source.NGC != nil && nimCache.Spec.Source.NGC.ModelEndpoint != nil:

--- a/internal/controller/nimcache_controller.go
+++ b/internal/controller/nimcache_controller.go
@@ -663,8 +663,7 @@ func (r *NIMCacheReconciler) reconcileModelManifest(ctx context.Context, nimCach
 		logger.Info("model manifest file not found", "output", output)
 		nimCache.Status.Type = appsv1alpha1.NIMCacheModelTypeModelFree
 	} else {
-		parser := nimparserutils.GetNIMParser([]byte(output))
-		manifest, err := parser.ParseModelManifestFromRawOutput([]byte(output))
+		manifest, err := nimparserutils.ParseModelManifest([]byte(output))
 		if err != nil {
 			logger.Error(err, "Failed to parse model manifest from the pod")
 			return false, err
@@ -1481,8 +1480,7 @@ func (r *NIMCacheReconciler) extractNIMManifest(ctx context.Context, configName,
 		return nil, fmt.Errorf("model_manifest.yaml not found in ConfigMap")
 	}
 
-	parser := nimparserutils.GetNIMParser([]byte(data))
-	manifest, err := parser.ParseModelManifestFromRawOutput([]byte(data))
+	manifest, err := nimparserutils.ParseModelManifest([]byte(data))
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal manifest data: %w", err)
 	}

--- a/internal/controller/nimcache_controller_test.go
+++ b/internal/controller/nimcache_controller_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"path/filepath"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -367,6 +368,8 @@ var _ = Describe("NIMCache Controller", func() {
 			Expect(*pod.Spec.SecurityContext.FSGroup).To(Equal(int64(2000)))
 			Expect(*pod.Spec.SecurityContext.RunAsNonRoot).To(Equal(true))
 			Expect(pod.Spec.NodeSelector["feature.node.kubernetes.io/pci-10de.present"]).To(Equal("true"))
+			Expect(strings.Join(pod.Spec.Containers[0].Command, " ")).To(ContainSubstring("NIM_OPERATOR_CAP download_to_cache"))
+			Expect(strings.Join(pod.Spec.Containers[0].Command, " ")).To(ContainSubstring("nimlib_download"))
 			// Add resource checks
 			resources := pod.Spec.Containers[0].Resources
 			Expect(resources.Requests.Cpu().String()).To(Equal("250m"))
@@ -507,6 +510,59 @@ var _ = Describe("NIMCache Controller", func() {
 			Expect(job.Spec.Template.Spec.ImagePullSecrets[0].Name).To(Equal("my-secret"))
 			Expect(job.Spec.Template.Spec.Containers[0].Command).To(ContainElements("download-to-cache"))
 			Expect(job.Spec.Template.Spec.Containers[0].Args).To(ContainElements("--all"))
+		})
+
+		It("should construct a nimlib download job when download-to-cache is unavailable", func() {
+			profiles := []string{"MolMIM"}
+			profilesJSON, err := json.Marshal(profiles)
+			Expect(err).ToNot(HaveOccurred())
+
+			nimCache := &appsv1alpha1.NIMCache{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-molmim-cache",
+					Namespace:   "default",
+					Annotations: map[string]string{SelectedNIMProfilesAnnotationKey: string(profilesJSON)},
+				},
+				Spec: appsv1alpha1.NIMCacheSpec{
+					Source: appsv1alpha1.NIMSource{NGC: &appsv1alpha1.NGCSource{ModelPuller: "nvcr.io/nim/nvidia/molmim:1.0.0", PullSecret: "my-secret"}},
+				},
+				Status: appsv1alpha1.NIMCacheStatus{
+					DownloadMethod: appsv1alpha1.NIMCacheDownloadMethodNIMLib,
+				},
+			}
+
+			job, err := reconciler.constructJob(context.TODO(), nimCache, k8sutil.K8s)
+			Expect(err).ToNot(HaveOccurred())
+
+			container := job.Spec.Template.Spec.Containers[0]
+			Expect(container.Image).To(Equal("nvcr.io/nim/nvidia/molmim:1.0.0"))
+			Expect(container.Command).To(Equal([]string{"sh", "-c", "set -e\nNIM_MANIFEST_PROFILE=MolMIM python3 -c \"from nimlib import nimutils; nimutils.download_models()\"\n"}))
+			Expect(container.Args).To(BeEmpty())
+			Expect(container.Env).To(ContainElement(corev1.EnvVar{Name: "NIM_CACHE_PATH", Value: "/model-store"}))
+			Expect(container.Command).ToNot(ContainElement("download-to-cache"))
+		})
+
+		It("should construct a nimlib download job for all profiles without NIM_MANIFEST_PROFILE", func() {
+			profiles := []string{AllProfiles}
+			nimCache := &appsv1alpha1.NIMCache{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-molmim-cache",
+					Namespace: "default",
+				},
+				Spec: appsv1alpha1.NIMCacheSpec{
+					Source: appsv1alpha1.NIMSource{NGC: &appsv1alpha1.NGCSource{ModelPuller: "nvcr.io/nim/nvidia/molmim:1.0.0", PullSecret: "my-secret", Model: &appsv1alpha1.ModelSpec{Profiles: profiles}}},
+				},
+				Status: appsv1alpha1.NIMCacheStatus{
+					DownloadMethod: appsv1alpha1.NIMCacheDownloadMethodNIMLib,
+				},
+			}
+
+			job, err := reconciler.constructJob(context.TODO(), nimCache, k8sutil.K8s)
+			Expect(err).ToNot(HaveOccurred())
+
+			container := job.Spec.Template.Spec.Containers[0]
+			Expect(container.Command).To(Equal([]string{"python3", "-c", "from nimlib import nimutils; nimutils.download_models()"}))
+			Expect(container.Args).To(BeEmpty())
 		})
 
 		It("should create a job with the correct specifications", func() {

--- a/internal/controller/nimcache_probe_unit_test.go
+++ b/internal/controller/nimcache_probe_unit_test.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"strings"
+	"testing"
+
+	appsv1alpha1 "github.com/NVIDIA/k8s-nim-operator/api/apps/v1alpha1"
+)
+
+func TestParseProbeOutput(t *testing.T) {
+	output := strings.Join([]string{
+		"NIM_OPERATOR_CAP download_to_cache=no",
+		"NIM_OPERATOR_CAP nimlib_download=yes",
+		"model_profile: MolMIM",
+		"manifest:",
+		"  - id: MolMIM",
+	}, "\n")
+
+	caps, manifest := parseProbeOutput(output)
+	if !caps.Complete() {
+		t.Fatalf("Complete() = false, want true")
+	}
+	if caps.HasDownloadToCache {
+		t.Fatalf("HasDownloadToCache = true, want false")
+	}
+	if !caps.HasNimlibDownload {
+		t.Fatalf("HasNimlibDownload = false, want true")
+	}
+	if !strings.Contains(manifest, "model_profile: MolMIM") {
+		t.Fatalf("manifest missing model_profile: %q", manifest)
+	}
+	if strings.Contains(manifest, "NIM_OPERATOR_CAP") {
+		t.Fatalf("manifest still contains capability markers: %q", manifest)
+	}
+}
+
+func TestParseProbeOutputIncomplete(t *testing.T) {
+	// Partial log read can capture only the first capability marker.
+	caps, manifest := parseProbeOutput("NIM_OPERATOR_CAP download_to_cache=no\n")
+	if caps.Complete() {
+		t.Fatal("Complete() = true for partial probe output, want false")
+	}
+	if !caps.SawDownloadToCache {
+		t.Fatal("SawDownloadToCache = false, want true")
+	}
+	if caps.SawNimlibDownload {
+		t.Fatal("SawNimlibDownload = true, want false")
+	}
+	if strings.TrimSpace(manifest) != "" {
+		t.Fatalf("manifest = %q, want empty", manifest)
+	}
+}
+
+func TestResolveDownloadMethod(t *testing.T) {
+	t.Run("prefers download-to-cache", func(t *testing.T) {
+		method, err := resolveDownloadMethod(probeCapabilities{HasDownloadToCache: true, HasNimlibDownload: true, SawDownloadToCache: true, SawNimlibDownload: true})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if method != appsv1alpha1.NIMCacheDownloadMethodCLI {
+			t.Fatalf("method = %q, want %q", method, appsv1alpha1.NIMCacheDownloadMethodCLI)
+		}
+	})
+
+	t.Run("falls back to nimlib", func(t *testing.T) {
+		method, err := resolveDownloadMethod(probeCapabilities{HasNimlibDownload: true, SawDownloadToCache: true, SawNimlibDownload: true})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if method != appsv1alpha1.NIMCacheDownloadMethodNIMLib {
+			t.Fatalf("method = %q, want %q", method, appsv1alpha1.NIMCacheDownloadMethodNIMLib)
+		}
+	})
+
+	t.Run("errors when neither capability is present", func(t *testing.T) {
+		_, err := resolveDownloadMethod(probeCapabilities{SawDownloadToCache: true, SawNimlibDownload: true})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "neither download-to-cache nor nimlib") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestNimlibDownloadCommand(t *testing.T) {
+	t.Run("all profiles", func(t *testing.T) {
+		cmd := nimlibDownloadCommand([]string{AllProfiles})
+		want := []string{"python3", "-c", "from nimlib import nimutils; nimutils.download_models()"}
+		if len(cmd) != len(want) {
+			t.Fatalf("cmd = %#v, want %#v", cmd, want)
+		}
+		for i := range want {
+			if cmd[i] != want[i] {
+				t.Fatalf("cmd = %#v, want %#v", cmd, want)
+			}
+		}
+	})
+
+	t.Run("selected profiles", func(t *testing.T) {
+		cmd := nimlibDownloadCommand([]string{"MolMIM"})
+		if len(cmd) != 3 || cmd[0] != "sh" || cmd[1] != "-c" {
+			t.Fatalf("unexpected command: %#v", cmd)
+		}
+		if !strings.Contains(cmd[2], "NIM_MANIFEST_PROFILE=MolMIM") {
+			t.Fatalf("script missing profile env: %q", cmd[2])
+		}
+		if !strings.Contains(cmd[2], "from nimlib import nimutils; nimutils.download_models()") {
+			t.Fatalf("script missing download call: %q", cmd[2])
+		}
+	})
+}
+
+func TestUsesNimlibDownload(t *testing.T) {
+	n := &appsv1alpha1.NIMCache{}
+	if n.UsesNimlibDownload() {
+		t.Fatal("empty status should not report nimlib download")
+	}
+	n.Status.DownloadMethod = appsv1alpha1.NIMCacheDownloadMethodNIMLib
+	if !n.UsesNimlibDownload() {
+		t.Fatal("expected UsesNimlibDownload true")
+	}
+}

--- a/internal/nimparser/legacy.go
+++ b/internal/nimparser/legacy.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    10|Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nimparser
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// NormalizeLegacyManifest converts a legacy wrapped manifest (model_profile + manifest list) into a v1 hash-keyed profile map YAML.
+// Returns (normalizedYAML, true, nil) when the input is legacy and conversion succeeds.
+// Returns (nil, false, nil) when the input is not a legacy wrapped manifest.
+// Returns a non-nil error when the input looks legacy but cannot be normalized.
+func NormalizeLegacyManifest(data []byte) ([]byte, bool, error) {
+	var root map[string]interface{}
+	if err := yaml.Unmarshal(data, &root); err != nil {
+		// Not a mapping document; leave for the standard parsers.
+		return nil, false, nil
+	}
+
+	modelProfile, hasModelProfile := root["model_profile"].(string)
+	if !hasModelProfile || modelProfile == "" {
+		return nil, false, nil
+	}
+
+	manifestRaw, hasManifest := root["manifest"]
+	if !hasManifest {
+		return nil, false, nil
+	}
+
+	// schema_version documents are handled by the v2 parser.
+	if _, hasSchemaVersion := root["schema_version"]; hasSchemaVersion {
+		return nil, false, nil
+	}
+
+	manifestList, ok := manifestRaw.([]interface{})
+	if !ok {
+		return nil, true, fmt.Errorf("legacy model manifest: top-level 'manifest' must be a list")
+	}
+	if len(manifestList) == 0 {
+		return nil, true, fmt.Errorf("legacy model manifest: top-level 'manifest' list is empty")
+	}
+
+	normalized := make(map[string]interface{}, len(manifestList))
+	for i, item := range manifestList {
+		entry, ok := asStringKeyMap(item)
+		if !ok {
+			return nil, true, fmt.Errorf("legacy model manifest: entry %d is not a mapping", i)
+		}
+
+		id, profile, err := extractLegacyProfile(entry, modelProfile)
+		if err != nil {
+			return nil, true, fmt.Errorf("legacy model manifest: entry %d: %w", i, err)
+		}
+		if _, exists := normalized[id]; exists {
+			return nil, true, fmt.Errorf("legacy model manifest: duplicate profile id %q", id)
+		}
+		normalized[id] = profile
+	}
+
+	out, err := yaml.Marshal(normalized)
+	if err != nil {
+		return nil, true, fmt.Errorf("legacy model manifest: failed to marshal normalized v1 manifest: %w", err)
+	}
+	return out, true, nil
+}
+
+// extractLegacyProfile pulls a profile ID and profile fields from one legacy manifest list entry (id-based or single-key hash form).
+func extractLegacyProfile(entry map[string]interface{}, modelProfile string) (string, map[string]interface{}, error) {
+	if id, ok := entry["id"].(string); ok && id != "" {
+		profile := copyStringKeyMap(entry)
+		delete(profile, "id")
+		return id, coerceLegacyProfile(profile, modelProfile), nil
+	}
+
+	// Single-key form: "<profile-hash>": { ...profile fields... }
+	if len(entry) == 1 {
+		for id, rawProfile := range entry {
+			profile, ok := asStringKeyMap(rawProfile)
+			if !ok {
+				return "", nil, fmt.Errorf("single-key profile %q is not a mapping", id)
+			}
+			if id == "" {
+				return "", nil, fmt.Errorf("profile hash key is empty")
+			}
+			return id, coerceLegacyProfile(copyStringKeyMap(profile), modelProfile), nil
+		}
+	}
+
+	return "", nil, fmt.Errorf("profile entry must include an 'id' field or be a single-key hash map")
+}
+
+// coerceLegacyProfile fills missing model from model_profile and stringifies tag values for v1 compatibility.
+func coerceLegacyProfile(profile map[string]interface{}, modelProfile string) map[string]interface{} {
+	if model, ok := profile["model"].(string); !ok || model == "" {
+		profile["model"] = modelProfile
+	}
+
+	if tagsRaw, ok := profile["tags"]; ok {
+		if tags, ok := asStringKeyMap(tagsRaw); ok {
+			stringTags := make(map[string]string, len(tags))
+			for k, v := range tags {
+				stringTags[k] = fmt.Sprint(v)
+			}
+			profile["tags"] = stringTags
+		}
+	}
+
+	return profile
+}
+
+// asStringKeyMap converts a value to map[string]interface{} when it is a string-keyed or interface-keyed map.
+func asStringKeyMap(v interface{}) (map[string]interface{}, bool) {
+	switch m := v.(type) {
+	case map[string]interface{}:
+		return m, true
+	case map[interface{}]interface{}:
+		out := make(map[string]interface{}, len(m))
+		for k, val := range m {
+			ks, ok := k.(string)
+			if !ok {
+				return nil, false
+			}
+			out[ks] = val
+		}
+		return out, true
+	default:
+		return nil, false
+	}
+}
+
+// copyStringKeyMap returns a shallow copy of a string-keyed map so callers can mutate safely.
+func copyStringKeyMap(in map[string]interface{}) map[string]interface{} {
+	out := make(map[string]interface{}, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}

--- a/internal/nimparser/legacy_test.go
+++ b/internal/nimparser/legacy_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nimparser
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNormalizeLegacyManifestMolMIM(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("testdata", "manifest_legacy_molmim.yaml"))
+	if err != nil {
+		t.Fatalf("failed to read fixture: %v", err)
+	}
+
+	normalized, isLegacy, err := NormalizeLegacyManifest(data)
+	if err != nil {
+		t.Fatalf("NormalizeLegacyManifest returned error: %v", err)
+	}
+	if !isLegacy {
+		t.Fatal("expected legacy manifest to be detected")
+	}
+	if len(normalized) == 0 {
+		t.Fatal("expected normalized YAML bytes")
+	}
+}
+
+func TestNormalizeLegacyManifestPassthroughV1(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("v1", "testdata", "manifest_non_llm.yaml"))
+	if err != nil {
+		t.Fatalf("failed to read fixture: %v", err)
+	}
+
+	normalized, isLegacy, err := NormalizeLegacyManifest(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if isLegacy {
+		t.Fatalf("v1 manifest incorrectly detected as legacy: %s", normalized)
+	}
+}
+
+func TestNormalizeLegacyManifestPassthroughV2(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("v2", "testdata", "manifest_v2.yaml"))
+	if err != nil {
+		t.Fatalf("failed to read fixture: %v", err)
+	}
+
+	_, isLegacy, err := NormalizeLegacyManifest(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if isLegacy {
+		t.Fatal("v2 manifest incorrectly detected as legacy")
+	}
+}
+
+func TestNormalizeLegacyManifestInvalidList(t *testing.T) {
+	data := []byte("model_profile: MolMIM\nmanifest: not-a-list\n")
+	_, isLegacy, err := NormalizeLegacyManifest(data)
+	if !isLegacy {
+		t.Fatal("expected legacy detection")
+	}
+	if err == nil {
+		t.Fatal("expected error for non-list manifest")
+	}
+}

--- a/internal/nimparser/testdata/manifest_legacy_molmim.yaml
+++ b/internal/nimparser/testdata/manifest_legacy_molmim.yaml
@@ -1,0 +1,12 @@
+model_profile: MolMIM
+manifest:
+  - id: a1b2c3d4e5f60718293a4b5c6d7e8f90123456789abcdef0123456789abcdef0
+    tags:
+      backend: tensorrt
+      precision: fp16
+      gpu: A100
+      product_name_regex: ^NVIDIA-A100.*
+  - id: 0fedcba9876543210fedcba9876543210fedcba9876543210fedcba987654321
+    tags:
+      backend: pytorch
+      precision: fp16

--- a/internal/nimparser/testdata/manifest_legacy_single_key.yaml
+++ b/internal/nimparser/testdata/manifest_legacy_single_key.yaml
@@ -1,0 +1,7 @@
+model_profile: MolMIM
+manifest:
+  - f1e2d3c4b5a697887766554433221100ffeeddccbbaa99887766554433221100:
+      tags:
+        backend: tensorrt
+        precision: fp16
+        product_name_regex: ^NVIDIA-L40S.*

--- a/internal/nimparser/testdata/manifest_molmim_1.0.0_real.yaml
+++ b/internal/nimparser/testdata/manifest_molmim_1.0.0_real.yaml
@@ -1,0 +1,14 @@
+model_profile: MolMIM
+manifest:
+  # This is the ID of the profile that can be specified with the NIM_MANIFEST_PROFILE environment variable.
+  - id: MolMIM
+    model: MolMIM
+    nim_name: nvidia/molmim
+    release: '1.0.0'
+    tags:
+      backend: pytorch
+    workspace: 
+      components:
+      - dst: 'models/'
+        src:
+          repo_id: nim/nvidia/molmim:1.3

--- a/internal/nimparser/utils/utils.go
+++ b/internal/nimparser/utils/utils.go
@@ -17,6 +17,7 @@ limitations under the License.
 package utils
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 
@@ -37,17 +38,32 @@ import (
 // Returns:
 // - A NIMParserInterface implementation based on the schema version.
 func GetNIMParser(data []byte) nimparser.NIMParserInterface {
+	if normalized, isLegacy, err := nimparser.NormalizeLegacyManifest(data); err == nil && isLegacy {
+		data = normalized
+	}
+
 	var config nimparser.NIMSchemaManifest
 	err := yaml.Unmarshal(data, &config)
 	if err != nil {
 		return nimparserv1.NIMParser{}
-	} else {
-		schemaVersion := strings.TrimSpace(config.SchemaVersion)
+	}
 
-		match, _ := regexp.MatchString("2\\.*\\.*", schemaVersion)
-		if match {
-			return nimparserv2.NIMParser{}
-		}
+	schemaVersion := strings.TrimSpace(config.SchemaVersion)
+
+	match, _ := regexp.MatchString("2\\.*\\.*", schemaVersion)
+	if match {
+		return nimparserv2.NIMParser{}
 	}
 	return nimparserv1.NIMParser{}
+}
+
+// ParseModelManifest selects the schema-appropriate NIM parser and parses the manifest.
+// Legacy wrapped manifests (e.g. MolMIM) are normalized by the v1 parser.
+func ParseModelManifest(data []byte) (nimparser.NIMManifestInterface, error) {
+	parser := GetNIMParser(data)
+	manifest, err := parser.ParseModelManifestFromRawOutput(data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse model manifest: %w", err)
+	}
+	return manifest, nil
 }

--- a/internal/nimparser/v1/legacy_manifest_test.go
+++ b/internal/nimparser/v1/legacy_manifest_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	appsv1alpha1 "github.com/NVIDIA/k8s-nim-operator/api/apps/v1alpha1"
+)
+
+func TestParseLegacyMolMIMManifest(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("..", "testdata", "manifest_legacy_molmim.yaml"))
+	if err != nil {
+		t.Fatalf("failed to read fixture: %v", err)
+	}
+
+	manifest, err := NIMParser{}.ParseModelManifestFromRawOutput(data)
+	if err != nil {
+		t.Fatalf("ParseModelManifestFromRawOutput returned error: %v", err)
+	}
+
+	profiles := manifest.GetProfilesList()
+	if len(profiles) != 2 {
+		t.Fatalf("expected 2 profiles, got %d (%v)", len(profiles), profiles)
+	}
+
+	const profileID = "a1b2c3d4e5f60718293a4b5c6d7e8f90123456789abcdef0123456789abcdef0"
+	if got := manifest.GetProfileModel(profileID); got != "MolMIM" {
+		t.Fatalf("GetProfileModel(%q) = %q, want MolMIM", profileID, got)
+	}
+	tags := manifest.GetProfileTags(profileID)
+	if tags["backend"] != "tensorrt" {
+		t.Fatalf("expected backend=tensorrt, got %q", tags["backend"])
+	}
+
+	selected, err := manifest.MatchProfiles(appsv1alpha1.ModelSpec{
+		Engine: "tensorrt",
+		GPUs: []appsv1alpha1.GPUSpec{{
+			Product: "A100",
+		}},
+	}, nil)
+	if err != nil {
+		t.Fatalf("MatchProfiles returned error: %v", err)
+	}
+	if len(selected) != 1 || selected[0] != profileID {
+		t.Fatalf("unexpected selected profiles: %v", selected)
+	}
+}
+
+func TestParseLegacySingleKeyManifest(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("..", "testdata", "manifest_legacy_single_key.yaml"))
+	if err != nil {
+		t.Fatalf("failed to read fixture: %v", err)
+	}
+
+	manifest, err := NIMParser{}.ParseModelManifestFromRawOutput(data)
+	if err != nil {
+		t.Fatalf("ParseModelManifestFromRawOutput returned error: %v", err)
+	}
+
+	const profileID = "f1e2d3c4b5a697887766554433221100ffeeddccbbaa99887766554433221100"
+	profiles := manifest.GetProfilesList()
+	if len(profiles) != 1 || profiles[0] != profileID {
+		t.Fatalf("unexpected profiles list: %v", profiles)
+	}
+	if got := manifest.GetProfileModel(profileID); got != "MolMIM" {
+		t.Fatalf("GetProfileModel(%q) = %q, want MolMIM", profileID, got)
+	}
+}

--- a/internal/nimparser/v1/molmim_real_image_test.go
+++ b/internal/nimparser/v1/molmim_real_image_test.go
@@ -1,0 +1,48 @@
+package v1
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/NVIDIA/k8s-nim-operator/internal/nimparser"
+)
+
+func TestParseRealMolMIM100Manifest(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("..", "testdata", "manifest_molmim_1.0.0_real.yaml"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	normalized, isLegacy, err := nimparser.NormalizeLegacyManifest(data)
+	if err != nil {
+		t.Fatalf("NormalizeLegacyManifest error: %v", err)
+	}
+	if !isLegacy {
+		t.Fatal("expected real MolMIM manifest to be detected as legacy")
+	}
+	t.Logf("normalized:\n%s", string(normalized))
+
+	manifest, err := NIMParser{}.ParseModelManifestFromRawOutput(data)
+	if err != nil {
+		t.Fatalf("ParseModelManifestFromRawOutput error: %v", err)
+	}
+
+	profiles := manifest.GetProfilesList()
+	if len(profiles) != 1 {
+		t.Fatalf("expected 1 profile, got %v", profiles)
+	}
+	if profiles[0] != "MolMIM" {
+		t.Fatalf("expected profile id MolMIM, got %q", profiles[0])
+	}
+	if got := manifest.GetProfileModel("MolMIM"); got != "MolMIM" {
+		t.Fatalf("model = %q, want MolMIM", got)
+	}
+	if got := manifest.GetProfileRelease("MolMIM"); got != "1.0.0" {
+		t.Fatalf("release = %q, want 1.0.0", got)
+	}
+	tags := manifest.GetProfileTags("MolMIM")
+	if tags["backend"] != "pytorch" {
+		t.Fatalf("tags = %v, want backend=pytorch", tags)
+	}
+}

--- a/internal/nimparser/v1/nimparser.go
+++ b/internal/nimparser/v1/nimparser.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1
 
 import (
+	"fmt"
 	"maps"
 	"os"
 	"regexp"
@@ -281,19 +282,20 @@ func (NIMParser) ParseModelManifest(filePath string) (nimparser.NIMManifestInter
 	if err != nil {
 		return nil, err
 	}
-
-	var config NIMManifest
-	err = yaml.Unmarshal(data, &config)
-	if err != nil {
-		return nil, err
-	}
-	return config, nil
-
+	return NIMParser{}.ParseModelManifestFromRawOutput(data)
 }
 
 func (NIMParser) ParseModelManifestFromRawOutput(data []byte) (nimparser.NIMManifestInterface, error) {
+	normalized, isLegacy, err := nimparser.NormalizeLegacyManifest(data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to normalize legacy model manifest: %w", err)
+	}
+	if isLegacy {
+		data = normalized
+	}
+
 	var config NIMManifest
-	err := yaml.Unmarshal(data, &config)
+	err = yaml.Unmarshal(data, &config)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**Issue 1**: MolMIM 1.0.0 ships a legacy model_manifest.yaml (shown below). Right now, the operator only maps v1: hash → profile map and v2: schema_version + profiles: []. So NIMCache failed while parsing the manifest.
```
model_profile: MolMIM
manifest:
  - id: <hash>
    tags: {...}
```
**internal/nimparser/legacy.go** - Created a function _NormalizeLegacyManifest_, which detects if the data is of the form of the wrapped legacy shape and rewrites it to a v1 map. Returns (normalizedYAML, true, nil) when the input is legacy and conversion succeeds, returns (nil, false, nil) when the input is not a legacy wrapped manifest, returns a non-nil error when the input looks legacy but cannot be normalized.

**internal/nimparser/v1/nimparser.go** - Update _ParseModelManifest_ to call ParseModelManifestFromRawOutput which will call NormalizeLegacyManifest. If it is legacy it will follow the new pathway to create a normalized YAML. Otherwise it will use the existing v1 hash map directly. So any caller of the v1 parser gets MolMIM support automatically.

**internal/nimparser/utils/utils.go** - updated GetNimParser to use NormalizeLegacyManifest first. Created a helper ParseModelManifest to select the schema-appropriate NIM parser and parse the manifest. Legacy wrapped manifests (e.g. MolMIM) are normalized by the v1 parser. This will be invoked by the controllers.

**TESTING**: The normalizer tests in _legacy_test.go_ check detection and conversion boundaries. One case confirms a MolMIM-style fixture is recognized as legacy and produces non-empty normalized YAML. Two passthrough cases confirm normal v1 and v2 fixtures are left alone (isLegacy == false). An invalid case confirms that a legacy-looking document with a non-list manifest is flagged as legacy and returns an error. The v1 parser tests in _legacy_manifest_test.go_ check end-to-end parse behavior. _TestParseLegacyMolMIMManifest_ runs the id-list fixture through ParseModelManifestFromRawOutput, verifies two profiles, model name MolMIM, tags, and that MatchProfiles can select the TensorRT/A100 profile. _TestParseLegacySingleKeyManifest_ does the same for the single-key hash form and checks the profile ID and model name.


**Issue 2**: MoIMIM 1.0.0 will require some changes to the NimCache pathway. Similar to our standard (unset) path, MolMIM expects model_manifest.yaml and has profile selection. However, it does not have download-to-cache. Additionally, when we trigger start_server() to download the weights by providing an NGC token, the NIM image will not exit after download, but will proceed to serve and block. To download and exit, we would need to explicitly run: `python3 -c "from nimlib import nimutils; nimutils.download_models()"`

**api/apps/v1alpha1/nimcache_types.go**: _DownloadMethod_ stores what download mechanism we use
```
type NIMCacheStatus struct {....DownloadMethod string    `json:"downloadMethod,omitempty"`}
NIMCacheDownloadMethodCLI = "download-to-cache"
NIMCacheDownloadMethodNIMLib = "nimlib"
```

**internal/controller/nimcache_controller.go**: Update _getCommand()_ to check whether download-to-cache or nimlib-download is present when probing for model manifest. Create function _resolveDownloadMethod()_ to use download-to-cache when available and otherwise use nimlib. Create function _nimlibDownloadCommand()_ which will run the nimutils.downloadModels cmd: `const downloadPy = "from nimlib import nimutils; nimutils.download_models()"`. Then update to choose the correct job command in _constructJob()_:
```
if nimCache.UsesNimlibDownload() {
			command = nimlibDownloadCommand(selectedProfiles)
		} else if slices.Contains(selectedProfiles, AllProfiles) {
			args = append(args, "--all")
		} else {
			args = append(args, "--profiles")
			args = append(args, selectedProfiles...)
		}
```

**TESTING**:
_nimcache_controller_test.go_ now verifies that the probe contains both capability checks, MolMIM produces a nimlib Job and that the standard CLI is absent from that Job. _NIM_CACHE_PATH_=/model-store remains set and the all branch calls nimlib directly. Additionally, _nimcache_probe_unit_test.go_ verifies that the markers are parsed and removed from YAML, standard CLI wins if both are available, nimlib is the fallback, and that selected profiles produce _NIM_MANIFEST_PROFILE_. Additionally, both issues were verified using a MolMIM 1.0.0 image and it was confirmed that it could deploy without any issues.

