### PR TITLE
Fix openshift rbac gating

### DIFF
--- a/.agents/skills/nim-operator-install/SKILL.md
+++ b/.agents/skills/nim-operator-install/SKILL.md
@@ -353,6 +353,16 @@ Expose these Dynamo sub-options only when the customer asks for advanced Dynamo 
 
 Do not enable Dynamo or its sub-options by default.
 
+## OpenShift Options
+
+For OpenShift clusters, enable OpenShift-specific ClusterRole permissions (SCC, Routes, OpenShift config APIs):
+
+```sh
+--set openshift.enabled=true
+```
+
+Leave `openshift.enabled` false (the default) on vanilla Kubernetes.
+
 ## Admission Controller Choice
 
 If cert-manager is missing and the user wants to proceed without it, append:

--- a/api/apps/v1alpha1/nemo_customizer_types.go
+++ b/api/apps/v1alpha1/nemo_customizer_types.go
@@ -463,10 +463,14 @@ func (n *NemoCustomizer) GetVolumeMounts() []corev1.VolumeMount {
 // GetStandardAnnotations returns default annotations to apply to the NemoCustomizer instance.
 func (n *NemoCustomizer) GetStandardAnnotations() map[string]string {
 	standardAnnotations := map[string]string{
-		"openshift.io/required-scc":             "nonroot",
 		utils.NvidiaAnnotationParentSpecHashKey: utils.DeepHashObject(n.Spec),
 	}
 	return standardAnnotations
+}
+
+// GetRequiredSCC returns the OpenShift SCC name required by this resource.
+func (n *NemoCustomizer) GetRequiredSCC() string {
+	return "nonroot"
 }
 
 // GetNemoCustomizerAnnotations returns annotations to apply to the NemoCustomizer instance.
@@ -884,7 +888,8 @@ func (n *NemoCustomizer) GetHTTPRouteParams() *rendertypes.HTTPRouteParams {
 }
 
 // GetRoleParams returns params to render Role from templates.
-func (n *NemoCustomizer) GetRoleParams() *rendertypes.RoleParams {
+// When includeOpenShiftSCC is false, OpenShift SCC rules are omitted.
+func (n *NemoCustomizer) GetRoleParams(includeOpenShiftSCC bool) *rendertypes.RoleParams {
 	params := &rendertypes.RoleParams{}
 
 	// Set metadata
@@ -894,12 +899,6 @@ func (n *NemoCustomizer) GetRoleParams() *rendertypes.RoleParams {
 
 	// Set rules for customizer
 	params.Rules = []rbacv1.PolicyRule{
-		{
-			APIGroups:     []string{"security.openshift.io"},
-			Resources:     []string{"securitycontextconstraints"},
-			ResourceNames: []string{"nonroot"},
-			Verbs:         []string{"use"},
-		},
 		{
 			APIGroups: []string{"batch"},
 			Resources: []string{"jobs"},
@@ -964,6 +963,16 @@ func (n *NemoCustomizer) GetRoleParams() *rendertypes.RoleParams {
 		params.Rules = append(params.Rules, volcanoRules...)
 	case SchedulerTypeRunAI:
 		params.Rules = append(params.Rules, runAIRules...)
+	}
+	if includeOpenShiftSCC {
+		params.Rules = append([]rbacv1.PolicyRule{
+			{
+				APIGroups:     []string{"security.openshift.io"},
+				Resources:     []string{"securitycontextconstraints"},
+				ResourceNames: []string{"nonroot"},
+				Verbs:         []string{"use"},
+			},
+		}, params.Rules...)
 	}
 
 	return params

--- a/api/apps/v1alpha1/nemo_datastore_types.go
+++ b/api/apps/v1alpha1/nemo_datastore_types.go
@@ -499,10 +499,14 @@ func (n *NemoDatastore) ShouldCreatePersistentStorage() bool {
 // GetStandardAnnotations returns default annotations to apply to the NemoDatastore instance.
 func (n *NemoDatastore) GetStandardAnnotations() map[string]string {
 	standardAnnotations := map[string]string{
-		"openshift.io/required-scc":             "nonroot",
 		utils.NvidiaAnnotationParentSpecHashKey: utils.DeepHashObject(n.Spec),
 	}
 	return standardAnnotations
+}
+
+// GetRequiredSCC returns the OpenShift SCC name required by this resource.
+func (n *NemoDatastore) GetRequiredSCC() string {
+	return "nonroot"
 }
 
 // GetNemoDatastoreAnnotations returns annotations to apply to the NemoDatastore instance.
@@ -1009,13 +1013,18 @@ func (n *NemoDatastore) GetHTTPRouteParams() *rendertypes.HTTPRouteParams {
 }
 
 // GetRoleParams returns params to render Role from templates.
-func (n *NemoDatastore) GetRoleParams() *rendertypes.RoleParams {
+// When includeOpenShiftSCC is false, OpenShift SCC rules are omitted.
+func (n *NemoDatastore) GetRoleParams(includeOpenShiftSCC bool) *rendertypes.RoleParams {
 	params := &rendertypes.RoleParams{}
 
 	// Set metadata
 	params.Name = n.GetName()
 	params.Namespace = n.GetNamespace()
 	params.Labels = n.GetServiceLabels()
+
+	if !includeOpenShiftSCC {
+		return params
+	}
 
 	// Set rules to use SCC
 	params.Rules = []rbacv1.PolicyRule{

--- a/api/apps/v1alpha1/nemo_entitystore_types.go
+++ b/api/apps/v1alpha1/nemo_entitystore_types.go
@@ -206,10 +206,14 @@ func (n *NemoEntitystore) GetStandardEnv() []corev1.EnvVar {
 // GetStandardAnnotations returns default annotations to apply to the NemoEntitystore instance.
 func (n *NemoEntitystore) GetStandardAnnotations() map[string]string {
 	standardAnnotations := map[string]string{
-		"openshift.io/required-scc":             "nonroot",
 		utils.NvidiaAnnotationParentSpecHashKey: utils.DeepHashObject(n.Spec),
 	}
 	return standardAnnotations
+}
+
+// GetRequiredSCC returns the OpenShift SCC name required by this resource.
+func (n *NemoEntitystore) GetRequiredSCC() string {
+	return "nonroot"
 }
 
 // GetNemoEntitystoreAnnotations returns annotations to apply to the NemoEntitystore instance.
@@ -643,13 +647,18 @@ func (n *NemoEntitystore) GetHTTPRouteParams() *rendertypes.HTTPRouteParams {
 }
 
 // GetRoleParams returns params to render Role from templates.
-func (n *NemoEntitystore) GetRoleParams() *rendertypes.RoleParams {
+// When includeOpenShiftSCC is false, OpenShift SCC rules are omitted.
+func (n *NemoEntitystore) GetRoleParams(includeOpenShiftSCC bool) *rendertypes.RoleParams {
 	params := &rendertypes.RoleParams{}
 
 	// Set metadata
 	params.Name = n.GetName()
 	params.Namespace = n.GetNamespace()
 	params.Labels = n.GetServiceLabels()
+
+	if !includeOpenShiftSCC {
+		return params
+	}
 
 	// Set rules to use SCC
 	params.Rules = []rbacv1.PolicyRule{

--- a/api/apps/v1alpha1/nemo_evaluator_types.go
+++ b/api/apps/v1alpha1/nemo_evaluator_types.go
@@ -408,10 +408,14 @@ func (n *NemoEvaluator) GeneratePostgresConnString(secretValue string) string {
 // GetStandardAnnotations returns default annotations to apply to the NemoEvaluator instance.
 func (n *NemoEvaluator) GetStandardAnnotations() map[string]string {
 	standardAnnotations := map[string]string{
-		"openshift.io/required-scc":             "nonroot",
 		utils.NvidiaAnnotationParentSpecHashKey: utils.DeepHashObject(n.Spec),
 	}
 	return standardAnnotations
+}
+
+// GetRequiredSCC returns the OpenShift SCC name required by this resource.
+func (n *NemoEvaluator) GetRequiredSCC() string {
+	return "nonroot"
 }
 
 // GetNemoEvaluatorAnnotations returns annotations to apply to the NemoEvaluator instance.
@@ -826,7 +830,8 @@ func (n *NemoEvaluator) GetHTTPRouteParams() *rendertypes.HTTPRouteParams {
 }
 
 // GetRoleParams returns params to render Role from templates.
-func (n *NemoEvaluator) GetRoleParams() *rendertypes.RoleParams {
+// When includeOpenShiftSCC is false, OpenShift SCC rules are omitted.
+func (n *NemoEvaluator) GetRoleParams(includeOpenShiftSCC bool) *rendertypes.RoleParams {
 	params := &rendertypes.RoleParams{}
 
 	// Set metadata
@@ -834,19 +839,22 @@ func (n *NemoEvaluator) GetRoleParams() *rendertypes.RoleParams {
 	params.Namespace = n.GetNamespace()
 	params.Labels = n.GetServiceLabels()
 
-	// Set rules to use SCC
 	params.Rules = []rbacv1.PolicyRule{
-		{
-			APIGroups:     []string{"security.openshift.io"},
-			Resources:     []string{"securitycontextconstraints"},
-			ResourceNames: []string{"nonroot"},
-			Verbs:         []string{"use"},
-		},
 		{
 			APIGroups: []string{""},
 			Resources: []string{"secrets", "pods"},
 			Verbs:     []string{"get", "watch", "list", "create"},
 		},
+	}
+	if includeOpenShiftSCC {
+		params.Rules = append([]rbacv1.PolicyRule{
+			{
+				APIGroups:     []string{"security.openshift.io"},
+				Resources:     []string{"securitycontextconstraints"},
+				ResourceNames: []string{"nonroot"},
+				Verbs:         []string{"use"},
+			},
+		}, params.Rules...)
 	}
 
 	return params

--- a/api/apps/v1alpha1/nemo_guardrails_types.go
+++ b/api/apps/v1alpha1/nemo_guardrails_types.go
@@ -378,10 +378,14 @@ func (n *NemoGuardrail) GetSecretParams(secretMapData map[string]string) *render
 // GetStandardAnnotations returns default annotations to apply to the NemoGuardrail instance.
 func (n *NemoGuardrail) GetStandardAnnotations() map[string]string {
 	standardAnnotations := map[string]string{
-		"openshift.io/required-scc":             "nonroot",
 		utils.NvidiaAnnotationParentSpecHashKey: utils.DeepHashObject(n.Spec),
 	}
 	return standardAnnotations
+}
+
+// GetRequiredSCC returns the OpenShift SCC name required by this resource.
+func (n *NemoGuardrail) GetRequiredSCC() string {
+	return "nonroot"
 }
 
 // GetNemoGuardrailAnnotations returns annotations to apply to the NemoGuardrail instance.
@@ -843,13 +847,18 @@ func (n *NemoGuardrail) GetHTTPRouteParams() *rendertypes.HTTPRouteParams {
 }
 
 // GetRoleParams returns params to render Role from templates.
-func (n *NemoGuardrail) GetRoleParams() *rendertypes.RoleParams {
+// When includeOpenShiftSCC is false, OpenShift SCC rules are omitted.
+func (n *NemoGuardrail) GetRoleParams(includeOpenShiftSCC bool) *rendertypes.RoleParams {
 	params := &rendertypes.RoleParams{}
 
 	// Set metadata
 	params.Name = n.GetName()
 	params.Namespace = n.GetNamespace()
 	params.Labels = n.GetServiceLabels()
+
+	if !includeOpenShiftSCC {
+		return params
+	}
 
 	// Set rules to use SCC
 	params.Rules = []rbacv1.PolicyRule{

--- a/api/apps/v1alpha1/nimservice_types.go
+++ b/api/apps/v1alpha1/nimservice_types.go
@@ -519,15 +519,20 @@ func (n *NIMService) GetProxyEnv() []corev1.EnvVar {
 // GetStandardAnnotations returns default annotations to apply to the NIMService instance.
 func (n *NIMService) GetStandardAnnotations() map[string]string {
 	standardAnnotations := map[string]string{
-		"openshift.io/required-scc":             "nonroot",
 		utils.NvidiaAnnotationParentSpecHashKey: utils.DeepHashObject(n.Spec),
 	}
-	if n.GetProxyCertConfigMap() != "" {
-		standardAnnotations["openshift.io/required-scc"] = "anyuid"
-	} else if n.GetHostPath() != "" {
-		standardAnnotations["openshift.io/required-scc"] = "hostmount-anyuid"
-	}
 	return standardAnnotations
+}
+
+// GetRequiredSCC returns the OpenShift SCC name required by this NIMService, if any.
+func (n *NIMService) GetRequiredSCC() string {
+	if n.GetProxyCertConfigMap() != "" || n.GetProxySpec() != nil {
+		return "anyuid"
+	}
+	if n.GetHostPath() != "" {
+		return "hostmount-anyuid"
+	}
+	return "nonroot"
 }
 
 // GetNIMServiceAnnotations returns annotations to apply to the NIMService instance.
@@ -1638,13 +1643,18 @@ func (n *NIMService) GetGRPCRouteParams() *rendertypes.GRPCRouteParams {
 }
 
 // GetRoleParams returns params to render Role from templates.
-func (n *NIMService) GetRoleParams() *rendertypes.RoleParams {
+// When includeOpenShiftSCC is false, OpenShift SCC rules are omitted.
+func (n *NIMService) GetRoleParams(includeOpenShiftSCC bool) *rendertypes.RoleParams {
 	params := &rendertypes.RoleParams{}
 
 	// Set metadata
 	params.Name = n.GetName()
 	params.Namespace = n.GetNamespace()
 	params.Labels = n.GetServiceLabels()
+
+	if !includeOpenShiftSCC {
+		return params
+	}
 
 	// Set rules to use SCC
 	switch {

--- a/deployments/helm/k8s-nim-operator/templates/manager-rbac.yaml
+++ b/deployments/helm/k8s-nim-operator/templates/manager-rbac.yaml
@@ -333,6 +333,7 @@ rules:
   - get
   - list
   - watch
+{{- if .Values.openshift.enabled }}
 - apiGroups:
   - config.openshift.io
   resources:
@@ -342,6 +343,7 @@ rules:
   - get
   - list
   - watch
+{{- end }}
 - apiGroups:
   - ""
   resources:
@@ -388,6 +390,7 @@ rules:
   - watch
   - create
   - delete
+{{- if .Values.openshift.enabled }}
 - apiGroups:
   - route.openshift.io
   resources:
@@ -399,6 +402,7 @@ rules:
   - patch
   - update
   - watch
+{{- end }}
 - apiGroups:
   - networking.k8s.io
   resources:
@@ -432,6 +436,7 @@ rules:
   - get
   - list
   - watch
+{{- if .Values.openshift.enabled }}
 - apiGroups:
   - security.openshift.io
   resourceNames:
@@ -454,6 +459,7 @@ rules:
   - patch
   - update
   - watch
+{{- end }}
 - apiGroups:
   - storage.k8s.io
   resources:

--- a/deployments/helm/k8s-nim-operator/values.yaml
+++ b/deployments/helm/k8s-nim-operator/values.yaml
@@ -86,5 +86,11 @@ metricsService:
 nfd:
   nodeFeatureRules:
     deviceID: false
+
+# OpenShift-specific ClusterRole permissions (SCC, Routes, OpenShift config).
+# Enable on OpenShift installs. Leave false on vanilla Kubernetes.
+openshift:
+  enabled: false
+
 dynamo:
   enabled: false

--- a/internal/controller/nemo_datastore_controller.go
+++ b/internal/controller/nemo_datastore_controller.go
@@ -327,20 +327,28 @@ func (r *NemoDatastoreReconciler) reconcileNemoDatastore(ctx context.Context, ne
 		return ctrl.Result{}, err
 	}
 
-	// Sync role
-	err = r.renderAndSyncResource(ctx, nemoDatastore, &renderer, &rbacv1.Role{}, func() (client.Object, error) {
-		return renderer.Role(nemoDatastore.GetRoleParams())
-	}, "role", conditions.ReasonRoleFailed)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
+	// Sync role / rolebinding. SCC rules are OpenShift-only; clean up on other platforms.
+	if k8sutil.IsOpenShift(r.orchestratorType) {
+		err = r.renderAndSyncResource(ctx, nemoDatastore, &renderer, &rbacv1.Role{}, func() (client.Object, error) {
+			return renderer.Role(nemoDatastore.GetRoleParams(true))
+		}, "role", conditions.ReasonRoleFailed)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
 
-	// Sync rolebinding
-	err = r.renderAndSyncResource(ctx, nemoDatastore, &renderer, &rbacv1.RoleBinding{}, func() (client.Object, error) {
-		return renderer.RoleBinding(nemoDatastore.GetRoleBindingParams())
-	}, "rolebinding", conditions.ReasonRoleBindingFailed)
-	if err != nil {
-		return ctrl.Result{}, err
+		err = r.renderAndSyncResource(ctx, nemoDatastore, &renderer, &rbacv1.RoleBinding{}, func() (client.Object, error) {
+			return renderer.RoleBinding(nemoDatastore.GetRoleBindingParams())
+		}, "rolebinding", conditions.ReasonRoleBindingFailed)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+	} else {
+		if err = k8sutil.CleanupResource(ctx, r.GetClient(), &rbacv1.Role{}, namespacedName); err != nil && !apiErrors.IsNotFound(err) {
+			return ctrl.Result{}, err
+		}
+		if err = k8sutil.CleanupResource(ctx, r.GetClient(), &rbacv1.RoleBinding{}, namespacedName); err != nil && !apiErrors.IsNotFound(err) {
+			return ctrl.Result{}, err
+		}
 	}
 
 	// Sync service
@@ -408,6 +416,8 @@ func (r *NemoDatastoreReconciler) reconcileNemoDatastore(ctx context.Context, ne
 	}
 
 	deploymentParams := nemoDatastore.GetDeploymentParams()
+	deploymentParams.Annotations = k8sutil.WithRequiredSCCAnnotation(deploymentParams.Annotations, r.orchestratorType, nemoDatastore.GetRequiredSCC())
+	deploymentParams.PodAnnotations = k8sutil.WithRequiredSCCAnnotation(deploymentParams.PodAnnotations, r.orchestratorType, nemoDatastore.GetRequiredSCC())
 
 	// Setup volume mounts with model store
 	deploymentParams.Volumes = nemoDatastore.GetVolumes()

--- a/internal/controller/nemo_entitystore_controller.go
+++ b/internal/controller/nemo_entitystore_controller.go
@@ -320,20 +320,28 @@ func (r *NemoEntitystoreReconciler) reconcileNemoEntitystore(ctx context.Context
 		return ctrl.Result{}, err
 	}
 
-	// Sync role
-	err = r.renderAndSyncResource(ctx, nemoEntitystore, &renderer, &rbacv1.Role{}, func() (client.Object, error) {
-		return renderer.Role(nemoEntitystore.GetRoleParams())
-	}, "role", conditions.ReasonRoleFailed)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
+	// Sync role / rolebinding. SCC rules are OpenShift-only; clean up on other platforms.
+	if k8sutil.IsOpenShift(r.orchestratorType) {
+		err = r.renderAndSyncResource(ctx, nemoEntitystore, &renderer, &rbacv1.Role{}, func() (client.Object, error) {
+			return renderer.Role(nemoEntitystore.GetRoleParams(true))
+		}, "role", conditions.ReasonRoleFailed)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
 
-	// Sync rolebinding
-	err = r.renderAndSyncResource(ctx, nemoEntitystore, &renderer, &rbacv1.RoleBinding{}, func() (client.Object, error) {
-		return renderer.RoleBinding(nemoEntitystore.GetRoleBindingParams())
-	}, "rolebinding", conditions.ReasonRoleBindingFailed)
-	if err != nil {
-		return ctrl.Result{}, err
+		err = r.renderAndSyncResource(ctx, nemoEntitystore, &renderer, &rbacv1.RoleBinding{}, func() (client.Object, error) {
+			return renderer.RoleBinding(nemoEntitystore.GetRoleBindingParams())
+		}, "rolebinding", conditions.ReasonRoleBindingFailed)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+	} else {
+		if err = k8sutil.CleanupResource(ctx, r.GetClient(), &rbacv1.Role{}, namespacedName); err != nil && !apiErrors.IsNotFound(err) {
+			return ctrl.Result{}, err
+		}
+		if err = k8sutil.CleanupResource(ctx, r.GetClient(), &rbacv1.RoleBinding{}, namespacedName); err != nil && !apiErrors.IsNotFound(err) {
+			return ctrl.Result{}, err
+		}
 	}
 
 	// Sync service
@@ -401,6 +409,8 @@ func (r *NemoEntitystoreReconciler) reconcileNemoEntitystore(ctx context.Context
 	}
 
 	deploymentParams := nemoEntitystore.GetDeploymentParams()
+	deploymentParams.Annotations = k8sutil.WithRequiredSCCAnnotation(deploymentParams.Annotations, r.orchestratorType, nemoEntitystore.GetRequiredSCC())
+	deploymentParams.PodAnnotations = k8sutil.WithRequiredSCCAnnotation(deploymentParams.PodAnnotations, r.orchestratorType, nemoEntitystore.GetRequiredSCC())
 
 	// Setup volume mounts with model store
 	deploymentParams.Volumes = nemoEntitystore.GetVolumes()

--- a/internal/controller/nemo_entitystore_controller_test.go
+++ b/internal/controller/nemo_entitystore_controller_test.go
@@ -48,6 +48,7 @@ import (
 
 	appsv1alpha1 "github.com/NVIDIA/k8s-nim-operator/api/apps/v1alpha1"
 	"github.com/NVIDIA/k8s-nim-operator/internal/conditions"
+	"github.com/NVIDIA/k8s-nim-operator/internal/k8sutil"
 	"github.com/NVIDIA/k8s-nim-operator/internal/render"
 )
 
@@ -118,11 +119,12 @@ var _ = Describe("NemoEntitystore Controller", func() {
 		Expect(err).ToNot(HaveOccurred())
 		renderer = render.NewRenderer(manifestsDir)
 		reconciler = &NemoEntitystoreReconciler{
-			Client:   client,
-			scheme:   scheme,
-			updater:  updater,
-			renderer: renderer,
-			recorder: record.NewFakeRecorder(1000),
+			Client:           client,
+			scheme:           scheme,
+			updater:          updater,
+			renderer:         renderer,
+			recorder:         record.NewFakeRecorder(1000),
+			orchestratorType: k8sutil.OpenShift, // exercise OpenShift SCC Role path in unit tests
 		}
 
 		nemoEntitystore = &appsv1alpha1.NemoEntitystore{

--- a/internal/controller/nemo_evaluator_controller.go
+++ b/internal/controller/nemo_evaluator_controller.go
@@ -320,7 +320,7 @@ func (r *NemoEvaluatorReconciler) reconcileNemoEvaluator(ctx context.Context, ne
 
 	// Sync role
 	err = r.renderAndSyncResource(ctx, nemoEvaluator, &renderer, &rbacv1.Role{}, func() (client.Object, error) {
-		return renderer.Role(nemoEvaluator.GetRoleParams())
+		return renderer.Role(nemoEvaluator.GetRoleParams(k8sutil.IsOpenShift(r.orchestratorType)))
 	}, "role", conditions.ReasonRoleFailed)
 	if err != nil {
 		return ctrl.Result{}, err
@@ -419,6 +419,8 @@ func (r *NemoEvaluatorReconciler) reconcileNemoEvaluator(ctx context.Context, ne
 	}
 
 	deploymentParams := nemoEvaluator.GetDeploymentParams()
+	deploymentParams.Annotations = k8sutil.WithRequiredSCCAnnotation(deploymentParams.Annotations, r.orchestratorType, nemoEvaluator.GetRequiredSCC())
+	deploymentParams.PodAnnotations = k8sutil.WithRequiredSCCAnnotation(deploymentParams.PodAnnotations, r.orchestratorType, nemoEvaluator.GetRequiredSCC())
 
 	// Sync deployment
 	err = r.renderAndSyncResource(ctx, nemoEvaluator, &renderer, &appsv1.Deployment{}, func() (client.Object, error) {

--- a/internal/controller/nemo_guardrail_controller.go
+++ b/internal/controller/nemo_guardrail_controller.go
@@ -318,20 +318,28 @@ func (r *NemoGuardrailReconciler) reconcileNemoGuardrail(ctx context.Context, ne
 		return ctrl.Result{}, err
 	}
 
-	// Sync role
-	err = r.renderAndSyncResource(ctx, nemoGuardrail, &renderer, &rbacv1.Role{}, func() (client.Object, error) {
-		return renderer.Role(nemoGuardrail.GetRoleParams())
-	}, "role", conditions.ReasonRoleFailed)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
+	// Sync role / rolebinding. SCC rules are OpenShift-only; clean up on other platforms.
+	if k8sutil.IsOpenShift(r.orchestratorType) {
+		err = r.renderAndSyncResource(ctx, nemoGuardrail, &renderer, &rbacv1.Role{}, func() (client.Object, error) {
+			return renderer.Role(nemoGuardrail.GetRoleParams(true))
+		}, "role", conditions.ReasonRoleFailed)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
 
-	// Sync rolebinding
-	err = r.renderAndSyncResource(ctx, nemoGuardrail, &renderer, &rbacv1.RoleBinding{}, func() (client.Object, error) {
-		return renderer.RoleBinding(nemoGuardrail.GetRoleBindingParams())
-	}, "rolebinding", conditions.ReasonRoleBindingFailed)
-	if err != nil {
-		return ctrl.Result{}, err
+		err = r.renderAndSyncResource(ctx, nemoGuardrail, &renderer, &rbacv1.RoleBinding{}, func() (client.Object, error) {
+			return renderer.RoleBinding(nemoGuardrail.GetRoleBindingParams())
+		}, "rolebinding", conditions.ReasonRoleBindingFailed)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+	} else {
+		if err = k8sutil.CleanupResource(ctx, r.GetClient(), &rbacv1.Role{}, namespacedName); err != nil && !apiErrors.IsNotFound(err) {
+			return ctrl.Result{}, err
+		}
+		if err = k8sutil.CleanupResource(ctx, r.GetClient(), &rbacv1.RoleBinding{}, namespacedName); err != nil && !apiErrors.IsNotFound(err) {
+			return ctrl.Result{}, err
+		}
 	}
 
 	// Sync ConfigStore PVC
@@ -427,6 +435,8 @@ func (r *NemoGuardrailReconciler) reconcileNemoGuardrail(ctx context.Context, ne
 	}
 
 	deploymentParams := nemoGuardrail.GetDeploymentParams()
+	deploymentParams.Annotations = k8sutil.WithRequiredSCCAnnotation(deploymentParams.Annotations, r.orchestratorType, nemoGuardrail.GetRequiredSCC())
+	deploymentParams.PodAnnotations = k8sutil.WithRequiredSCCAnnotation(deploymentParams.PodAnnotations, r.orchestratorType, nemoGuardrail.GetRequiredSCC())
 
 	// Setup volume mounts with model store
 	deploymentParams.Volumes = nemoGuardrail.GetVolumes()

--- a/internal/controller/nemocustomizer_controller.go
+++ b/internal/controller/nemocustomizer_controller.go
@@ -336,7 +336,7 @@ func (r *NemoCustomizerReconciler) reconcileNemoCustomizer(ctx context.Context, 
 
 	// Sync role
 	err = r.renderAndSyncResource(ctx, nemoCustomizer, &renderer, &rbacv1.Role{}, func() (client.Object, error) {
-		return renderer.Role(nemoCustomizer.GetRoleParams())
+		return renderer.Role(nemoCustomizer.GetRoleParams(k8sutil.IsOpenShift(r.orchestratorType)))
 	}, "role", conditions.ReasonRoleFailed)
 	if err != nil {
 		return ctrl.Result{}, err
@@ -453,6 +453,8 @@ func (r *NemoCustomizerReconciler) reconcileNemoCustomizer(ctx context.Context, 
 
 	// Get params to render Deployment resource
 	deploymentParams := nemoCustomizer.GetDeploymentParams()
+	deploymentParams.Annotations = k8sutil.WithRequiredSCCAnnotation(deploymentParams.Annotations, r.orchestratorType, nemoCustomizer.GetRequiredSCC())
+	deploymentParams.PodAnnotations = k8sutil.WithRequiredSCCAnnotation(deploymentParams.PodAnnotations, r.orchestratorType, nemoCustomizer.GetRequiredSCC())
 
 	// Calculate the hash of the config data
 	configHash := utils.CalculateSHA256(string(customizerConfigYAML))

--- a/internal/controller/nimcache_controller.go
+++ b/internal/controller/nimcache_controller.go
@@ -333,6 +333,17 @@ func (r *NIMCacheReconciler) reconcileRole(ctx context.Context, nimCache *appsv1
 	roleName := NIMCacheRole
 	roleNamespacedName := types.NamespacedName{Name: roleName, Namespace: nimCache.GetNamespace()}
 
+	// SCC Role rules are only meaningful on OpenShift. On other platforms, clean up
+	// any previously created OpenShift-only Role so vanilla clusters do not retain it.
+	if !k8sutil.IsOpenShift(r.orchestratorType) {
+		logger.Info("Skipping OpenShift SCC Role on non-OpenShift cluster", "Name", roleName, "orchestrator", r.orchestratorType)
+		if err := k8sutil.CleanupResource(ctx, r.GetClient(), &rbacv1.Role{}, roleNamespacedName); err != nil {
+			logger.Error(err, "Failed to cleanup OpenShift SCC Role", "Name", roleName)
+			return err
+		}
+		return nil
+	}
+
 	// Desired Role configuration
 	desiredRole := &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
@@ -413,6 +424,16 @@ func (r *NIMCacheReconciler) reconcileRoleBinding(ctx context.Context, nimCache 
 	logger := r.GetLogger()
 	rbName := NIMCacheRoleBinding
 	rbNamespacedName := types.NamespacedName{Name: rbName, Namespace: nimCache.GetNamespace()}
+
+	// RoleBinding is only needed for the OpenShift SCC Role.
+	if !k8sutil.IsOpenShift(r.orchestratorType) {
+		logger.Info("Skipping OpenShift SCC RoleBinding on non-OpenShift cluster", "Name", rbName, "orchestrator", r.orchestratorType)
+		if err := k8sutil.CleanupResource(ctx, r.GetClient(), &rbacv1.RoleBinding{}, rbNamespacedName); err != nil {
+			logger.Error(err, "Failed to cleanup OpenShift SCC RoleBinding", "Name", rbName)
+			return err
+		}
+		return nil
+	}
 
 	// Desired RoleBinding configuration
 	desiredRB := &rbacv1.RoleBinding{

--- a/internal/controller/nimcache_controller_test.go
+++ b/internal/controller/nimcache_controller_test.go
@@ -279,8 +279,9 @@ var _ = Describe("NIMCache Controller", func() {
 	})
 
 	Context("when creating a NIMCache resource", func() {
-		It("should create a Role with SCC rules", func() {
+		It("should create a Role with SCC rules on OpenShift", func() {
 			ctx := context.TODO()
+			reconciler.orchestratorType = k8sutil.OpenShift
 			nimCache := &appsv1alpha1.NIMCache{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-nimcache",
@@ -312,8 +313,31 @@ var _ = Describe("NIMCache Controller", func() {
 			Expect(role.Rules[0]).To(Equal(expectedRule))
 		})
 
+		It("should not create an SCC Role on non-OpenShift", func() {
+			ctx := context.TODO()
+			reconciler.orchestratorType = k8sutil.K8s
+			nimCache := &appsv1alpha1.NIMCache{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-nimcache-k8s",
+					Namespace: "default",
+				},
+				Spec: appsv1alpha1.NIMCacheSpec{
+					Source: appsv1alpha1.NIMSource{NGC: &appsv1alpha1.NGCSource{ModelPuller: "nvcr.io/nim:test", PullSecret: "my-secret"}},
+				},
+			}
+
+			err := reconciler.reconcileRole(ctx, nimCache)
+			Expect(err).NotTo(HaveOccurred())
+
+			role := &rbacv1.Role{}
+			roleName := types.NamespacedName{Name: NIMCacheRole, Namespace: "default"}
+			err = cli.Get(ctx, roleName, role)
+			Expect(errors.IsNotFound(err)).To(BeTrue())
+		})
+
 		It("should create a RoleBinding for the Role", func() {
 			ctx := context.TODO()
+			reconciler.orchestratorType = k8sutil.OpenShift
 			nimCache := &appsv1alpha1.NIMCache{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-nimcache",

--- a/internal/controller/platform/kserve/nimservice.go
+++ b/internal/controller/platform/kserve/nimservice.go
@@ -146,20 +146,29 @@ func (r *NIMServiceReconciler) reconcileNIMService(ctx context.Context, nimServi
 		return ctrl.Result{}, err
 	}
 
-	// Sync role
-	err = r.renderAndSyncResource(ctx, nimService, &rbacv1.Role{}, func() (client.Object, error) {
-		return r.renderer.Role(nimService.GetRoleParams())
-	}, "role", conditions.ReasonRoleFailed)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
+	// Sync role / rolebinding. SCC rules are OpenShift-only; clean up on other platforms.
+	namespacedNameForRBAC := types.NamespacedName{Name: nimService.GetName(), Namespace: nimService.GetNamespace()}
+	if k8sutil.IsOpenShift(r.orchestratorType) {
+		err = r.renderAndSyncResource(ctx, nimService, &rbacv1.Role{}, func() (client.Object, error) {
+			return r.renderer.Role(nimService.GetRoleParams(true))
+		}, "role", conditions.ReasonRoleFailed)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
 
-	// Sync rolebinding
-	err = r.renderAndSyncResource(ctx, nimService, &rbacv1.RoleBinding{}, func() (client.Object, error) {
-		return r.renderer.RoleBinding(nimService.GetRoleBindingParams())
-	}, "rolebinding", conditions.ReasonRoleBindingFailed)
-	if err != nil {
-		return ctrl.Result{}, err
+		err = r.renderAndSyncResource(ctx, nimService, &rbacv1.RoleBinding{}, func() (client.Object, error) {
+			return r.renderer.RoleBinding(nimService.GetRoleBindingParams())
+		}, "rolebinding", conditions.ReasonRoleBindingFailed)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+	} else {
+		if err = k8sutil.CleanupResource(ctx, r.Client, &rbacv1.Role{}, namespacedNameForRBAC); err != nil && !apiErrors.IsNotFound(err) {
+			return ctrl.Result{}, err
+		}
+		if err = k8sutil.CleanupResource(ctx, r.Client, &rbacv1.RoleBinding{}, namespacedNameForRBAC); err != nil && !apiErrors.IsNotFound(err) {
+			return ctrl.Result{}, err
+		}
 	}
 
 	var modelPVC *appsv1alpha1.PersistentVolumeClaim
@@ -511,6 +520,8 @@ func (r *NIMServiceReconciler) renderAndSyncInferenceService(ctx context.Context
 	}
 
 	isvcParams.OrchestratorType = string(r.orchestratorType)
+	isvcParams.Annotations = k8sutil.WithRequiredSCCAnnotation(isvcParams.Annotations, r.orchestratorType, nimService.GetRequiredSCC())
+	isvcParams.PodAnnotations = k8sutil.WithRequiredSCCAnnotation(isvcParams.PodAnnotations, r.orchestratorType, nimService.GetRequiredSCC())
 
 	isvcParams.PodResourceClaims = namedDraResources.GetPodResourceClaims()
 

--- a/internal/controller/platform/kserve/nimservice_test.go
+++ b/internal/controller/platform/kserve/nimservice_test.go
@@ -176,13 +176,14 @@ var _ = Describe("NIMServiceReconciler for a KServe platform", func() {
 		}
 
 		reconciler = &NIMServiceReconciler{
-			Client:          client,
-			scheme:          scheme,
-			updater:         conditions.NewUpdater(client),
-			renderer:        render.NewRenderer(path.Join(strings.TrimSuffix(cwd, "internal/controller/platform/kserve"), "manifests")),
-			recorder:        record.NewFakeRecorder(1000),
-			discoveryClient: discoveryClient,
-			apiReader:       client,
+			Client:           client,
+			scheme:           scheme,
+			updater:          conditions.NewUpdater(client),
+			renderer:         render.NewRenderer(path.Join(strings.TrimSuffix(cwd, "internal/controller/platform/kserve"), "manifests")),
+			recorder:         record.NewFakeRecorder(1000),
+			discoveryClient:  discoveryClient,
+			apiReader:        client,
+			orchestratorType: k8sutil.OpenShift, // exercise OpenShift SCC Role path in unit tests
 		}
 		pvcName := "test-pvc"
 		nimService = &appsv1alpha1.NIMService{

--- a/internal/controller/platform/standalone/nimservice.go
+++ b/internal/controller/platform/standalone/nimservice.go
@@ -206,20 +206,28 @@ func (r *NIMServiceReconciler) reconcileNIMService(ctx context.Context, nimServi
 		return ctrl.Result{}, err
 	}
 
-	// Sync role
-	err = r.renderAndSyncResource(ctx, nimService, &renderer, &rbacv1.Role{}, func() (client.Object, error) {
-		return renderer.Role(nimService.GetRoleParams())
-	}, "role", conditions.ReasonRoleFailed)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
+	// Sync role / rolebinding. SCC rules are OpenShift-only; clean up on other platforms.
+	if k8sutil.IsOpenShift(r.GetOrchestratorType()) {
+		err = r.renderAndSyncResource(ctx, nimService, &renderer, &rbacv1.Role{}, func() (client.Object, error) {
+			return renderer.Role(nimService.GetRoleParams(true))
+		}, "role", conditions.ReasonRoleFailed)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
 
-	// Sync rolebinding
-	err = r.renderAndSyncResource(ctx, nimService, &renderer, &rbacv1.RoleBinding{}, func() (client.Object, error) {
-		return renderer.RoleBinding(nimService.GetRoleBindingParams())
-	}, "rolebinding", conditions.ReasonRoleBindingFailed)
-	if err != nil {
-		return ctrl.Result{}, err
+		err = r.renderAndSyncResource(ctx, nimService, &renderer, &rbacv1.RoleBinding{}, func() (client.Object, error) {
+			return renderer.RoleBinding(nimService.GetRoleBindingParams())
+		}, "rolebinding", conditions.ReasonRoleBindingFailed)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+	} else {
+		if err = k8sutil.CleanupResource(ctx, r.GetClient(), &rbacv1.Role{}, namespacedName); err != nil && !apiErrors.IsNotFound(err) {
+			return ctrl.Result{}, err
+		}
+		if err = k8sutil.CleanupResource(ctx, r.GetClient(), &rbacv1.RoleBinding{}, namespacedName); err != nil && !apiErrors.IsNotFound(err) {
+			return ctrl.Result{}, err
+		}
 	}
 
 	// Sync service
@@ -471,6 +479,8 @@ func (r *NIMServiceReconciler) reconcileNIMService(ctx context.Context, nimServi
 		lwsParams := nimService.GetLWSParams()
 		lwsParams.PodResourceClaims = namedDraResources.GetPodResourceClaims()
 		lwsParams.OrchestratorType = string(r.GetOrchestratorType())
+		lwsParams.Annotations = k8sutil.WithRequiredSCCAnnotation(lwsParams.Annotations, r.GetOrchestratorType(), nimService.GetRequiredSCC())
+		lwsParams.PodAnnotations = k8sutil.WithRequiredSCCAnnotation(lwsParams.PodAnnotations, r.GetOrchestratorType(), nimService.GetRequiredSCC())
 		if nimCache.IsUniversalNIM() {
 			lwsParams.WorkerEnvs = utils.MergeEnvVars([]corev1.EnvVar{{
 				Name:  "NIM_MODEL_NAME",
@@ -554,6 +564,8 @@ func (r *NIMServiceReconciler) reconcileNIMService(ctx context.Context, nimServi
 	} else {
 		deploymentParams := nimService.GetDeploymentParams()
 		deploymentParams.OrchestratorType = string(r.GetOrchestratorType())
+		deploymentParams.Annotations = k8sutil.WithRequiredSCCAnnotation(deploymentParams.Annotations, r.GetOrchestratorType(), nimService.GetRequiredSCC())
+		deploymentParams.PodAnnotations = k8sutil.WithRequiredSCCAnnotation(deploymentParams.PodAnnotations, r.GetOrchestratorType(), nimService.GetRequiredSCC())
 		deploymentParams.PodResourceClaims = namedDraResources.GetPodResourceClaims()
 
 		modelLayout, err := nimsource.ResolveModelLayout(ctx, r.imageProtocolResolver, nimService, &nimCache)

--- a/internal/controller/platform/standalone/nimservice_test.go
+++ b/internal/controller/platform/standalone/nimservice_test.go
@@ -181,12 +181,13 @@ var _ = Describe("NIMServiceReconciler for a standalone platform", func() {
 		}
 
 		reconciler = &NIMServiceReconciler{
-			Client:          client,
-			scheme:          scheme,
-			updater:         conditions.NewUpdater(client),
-			renderer:        render.NewRenderer(path.Join(strings.TrimSuffix(cwd, "internal/controller/platform/standalone"), "manifests")),
-			recorder:        record.NewFakeRecorder(1000),
-			discoveryClient: discoveryClient,
+			Client:           client,
+			scheme:           scheme,
+			updater:          conditions.NewUpdater(client),
+			renderer:         render.NewRenderer(path.Join(strings.TrimSuffix(cwd, "internal/controller/platform/standalone"), "manifests")),
+			recorder:         record.NewFakeRecorder(1000),
+			discoveryClient:  discoveryClient,
+			orchestratorType: k8sutil.OpenShift, // exercise OpenShift SCC Role path in unit tests
 		}
 		pvcName := "test-pvc"
 		minReplicas := int32(1)

--- a/internal/k8sutil/k8sutil.go
+++ b/internal/k8sutil/k8sutil.go
@@ -86,7 +86,34 @@ const (
 	K8s OrchestratorType = "Kubernetes"
 	// Unknown distribution type.
 	Unknown OrchestratorType = "Unknown"
+
+	// RequiredSCCAnnotation is the OpenShift annotation used to select an SCC.
+	RequiredSCCAnnotation = "openshift.io/required-scc"
 )
+
+// IsOpenShift reports whether the detected orchestrator is OpenShift.
+func IsOpenShift(t OrchestratorType) bool {
+	return t == OpenShift
+}
+
+// WithRequiredSCCAnnotation returns a copy of annotations with the OpenShift
+// required-SCC annotation set when running on OpenShift.
+func WithRequiredSCCAnnotation(annotations map[string]string, orchestrator OrchestratorType, scc string) map[string]string {
+	out := annotations
+	if out == nil {
+		out = map[string]string{}
+	} else {
+		copied := make(map[string]string, len(out)+1)
+		for k, v := range out {
+			copied[k] = v
+		}
+		out = copied
+	}
+	if IsOpenShift(orchestrator) && scc != "" {
+		out[RequiredSCCAnnotation] = scc
+	}
+	return out
+}
 
 // GetOrchestratorType checks the container orchestrator by looking for specific node labels that identify
 // TKGS, OpenShift, or CSP-specific Kubernetes distributions.


### PR DESCRIPTION
This PR is in response to this issue: https://github.com/NVIDIA/k8s-nim-operator/issues/406

**internal/k8sutil/k8sutil.go** - Adds RequiredSCCAnnotation, IsOpenShift(), and WithRequiredSCCAnnotation().
Controllers use these to decide whether to create SCC RBAC and whether to stamp the required-SCC annotation on workloads.

**CRD type helpers (Ex: api/apps/v1alpha1/nimservice_types.go)** - These stop hardcoding OpenShift into “standard” annotations / Roles, and expose an opt-in flag instead.

**Controllers** - internal/controller/nemocustomizer_controller.go and .../nemo_evaluator_controller.go will keep Role always, but gate SCC rules/annotations. These Roles have non-OpenShift permissions, so they still sync the Role; only the SCC piece is conditional. The other controllers will fully skip Role/RoleBinding off OpenShift. On OpenShift: sync Role + RoleBinding with SCC rules. Off OpenShift: cleanup any leftover Role/RoleBinding, and only add SCC annotations when OpenShift.

**deployments/helm/k8s-nim-operator/values.yaml** - Adds openshift.enabled: false

**deployments/helm/k8s-nim-operator/templates/manager-rbac.yaml** - Wraps OpenShift APIs (config.openshift.io, route.openshift.io, security.openshift.io SCC) in {{- if .Values.openshift.enabled }}

**TESTING** - The internal/controller/nimcache_controller_test.go existing SCC tests force orchestratorType=OpenShift and verifies no SCC Role on plain K8s. The internal/controller/... tests will set reconciler to OpenShift so Role path still covered.