### PR TITLE
Remove NGC API Key reqs

### DIFF
--- a/api/apps/v1alpha1/nimcache_types.go
+++ b/api/apps/v1alpha1/nimcache_types.go
@@ -116,8 +116,9 @@ type HuggingFaceHubSource struct {
 // NGCSource references a model stored on NVIDIA NGC.
 // +kubebuilder:validation:XValidation:rule="!(has(self.model) && has(self.modelEndpoint))",message="Only one of 'model' or 'modelEndpoint' can be specified"
 type NGCSource struct {
-	// The name of an existing pull secret containing the NGC_API_KEY
-	AuthSecret string `json:"authSecret"`
+	// AuthSecret is the name of an existing secret containing the NGC_API_KEY.
+	// Optional for certain NIMs.
+	AuthSecret string `json:"authSecret,omitempty"`
 	// ModelPuller is the container image that can pull the model
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="modelPuller is an immutable field. Please create a new NIMCache resource instead when you want to change this container."
 	ModelPuller string `json:"modelPuller"`
@@ -232,6 +233,7 @@ const (
 
 // EnvFromSecrets return the list of secrets that should be mounted as env vars.
 func (s *NIMSource) EnvFromSecrets() []corev1.EnvFromSource {
+	optional := true
 	if s.NGC != nil && s.NGC.AuthSecret != "" { // nolint:gocritic
 		return []corev1.EnvFromSource{
 			{
@@ -239,6 +241,7 @@ func (s *NIMSource) EnvFromSecrets() []corev1.EnvFromSource {
 					LocalObjectReference: corev1.LocalObjectReference{
 						Name: s.NGC.AuthSecret,
 					},
+					Optional: &optional,
 				},
 			},
 		}

--- a/api/apps/v1alpha1/nimservice_types.go
+++ b/api/apps/v1alpha1/nimservice_types.go
@@ -102,7 +102,7 @@ type NIMServiceSpec struct {
 	Args    []string        `json:"args,omitempty"`
 	Env     []corev1.EnvVar `json:"env,omitempty"`
 	// AuthSecret is the name of an existing secret containing the NGC_API_KEY (and optionally HF_TOKEN).
-	// It is optional for air-gapped deployments that serve a pre-cached model
+	// Optional for certain NIMs.
 	AuthSecret string `json:"authSecret,omitempty"`
 	// Storage is the target storage for caching NIM model if NIMCache is not provided
 	Storage      NIMServiceStorage   `json:"storage,omitempty"`
@@ -332,9 +332,8 @@ func (n *NIMService) GetStandardEnv() []corev1.EnvVar {
 		},
 	}
 
-	// Only inject NGC_API_KEY when AuthSecret is set. Air-gapped deployments that
-	// serve a pre-populated local cache must omit AuthSecret so NIM does not
-	// attempt NGC authentication.
+	// Only inject NGC_API_KEY when AuthSecret is set. The secret key is optional
+	// so certain NIMs can start without it.
 	if n.Spec.AuthSecret != "" {
 		envVars = append(envVars, corev1.EnvVar{
 			Name: NGCAPIKey,
@@ -343,7 +342,8 @@ func (n *NIMService) GetStandardEnv() []corev1.EnvVar {
 					LocalObjectReference: corev1.LocalObjectReference{
 						Name: n.Spec.AuthSecret,
 					},
-					Key: NGCAPIKey,
+					Key:      NGCAPIKey,
+					Optional: ptr.To(true),
 				},
 			},
 		})

--- a/api/apps/v1alpha1/nimservice_types_test.go
+++ b/api/apps/v1alpha1/nimservice_types_test.go
@@ -1183,6 +1183,9 @@ func TestGetStandardEnvAuthSecret(t *testing.T) {
 		if ngc.ValueFrom.SecretKeyRef.Name != "ngc-api-secret" {
 			t.Errorf("SecretKeyRef.Name = %q, want %q", ngc.ValueFrom.SecretKeyRef.Name, "ngc-api-secret")
 		}
+		if ngc.ValueFrom.SecretKeyRef.Optional == nil || !*ngc.ValueFrom.SecretKeyRef.Optional {
+			t.Fatal("expected NGC_API_KEY SecretKeyRef to be optional")
+		}
 	})
 
 	t.Run("without authSecret omits NGC_API_KEY", func(t *testing.T) {

--- a/bundle/manifests/apps.nvidia.com_nimcaches.yaml
+++ b/bundle/manifests/apps.nvidia.com_nimcaches.yaml
@@ -588,8 +588,9 @@ spec:
                     description: NGCSource represents models stored in NGC
                     properties:
                       authSecret:
-                        description: The name of an existing pull secret containing
-                          the NGC_API_KEY
+                        description: |-
+                          AuthSecret is the name of an existing secret containing the NGC_API_KEY.
+                          Optional for certain NIMs.
                         type: string
                       model:
                         description: Model spec for caching
@@ -662,7 +663,6 @@ spec:
                         description: PullSecret to pull the model puller image
                         type: string
                     required:
-                    - authSecret
                     - modelPuller
                     type: object
                     x-kubernetes-validations:

--- a/bundle/manifests/apps.nvidia.com_nimpipelines.yaml
+++ b/bundle/manifests/apps.nvidia.com_nimpipelines.yaml
@@ -1021,7 +1021,7 @@ spec:
                         authSecret:
                           description: |-
                             AuthSecret is the name of an existing secret containing the NGC_API_KEY (and optionally HF_TOKEN).
-                            It is optional for air-gapped deployments that serve a pre-cached model
+                            Optional for certain NIMs.
                           type: string
                         command:
                           items:

--- a/bundle/manifests/apps.nvidia.com_nimservices.yaml
+++ b/bundle/manifests/apps.nvidia.com_nimservices.yaml
@@ -970,7 +970,7 @@ spec:
               authSecret:
                 description: |-
                   AuthSecret is the name of an existing secret containing the NGC_API_KEY (and optionally HF_TOKEN).
-                  It is optional for air-gapped deployments that serve a pre-cached model
+                  Optional for certain NIMs.
                 type: string
               command:
                 items:

--- a/config/crd/bases/apps.nvidia.com_nimcaches.yaml
+++ b/config/crd/bases/apps.nvidia.com_nimcaches.yaml
@@ -588,8 +588,9 @@ spec:
                     description: NGCSource represents models stored in NGC
                     properties:
                       authSecret:
-                        description: The name of an existing pull secret containing
-                          the NGC_API_KEY
+                        description: |-
+                          AuthSecret is the name of an existing secret containing the NGC_API_KEY.
+                          Optional for certain NIMs.
                         type: string
                       model:
                         description: Model spec for caching
@@ -662,7 +663,6 @@ spec:
                         description: PullSecret to pull the model puller image
                         type: string
                     required:
-                    - authSecret
                     - modelPuller
                     type: object
                     x-kubernetes-validations:

--- a/config/crd/bases/apps.nvidia.com_nimpipelines.yaml
+++ b/config/crd/bases/apps.nvidia.com_nimpipelines.yaml
@@ -1021,7 +1021,7 @@ spec:
                         authSecret:
                           description: |-
                             AuthSecret is the name of an existing secret containing the NGC_API_KEY (and optionally HF_TOKEN).
-                            It is optional for air-gapped deployments that serve a pre-cached model
+                            Optional for certain NIMs.
                           type: string
                         command:
                           items:

--- a/config/crd/bases/apps.nvidia.com_nimservices.yaml
+++ b/config/crd/bases/apps.nvidia.com_nimservices.yaml
@@ -970,7 +970,7 @@ spec:
               authSecret:
                 description: |-
                   AuthSecret is the name of an existing secret containing the NGC_API_KEY (and optionally HF_TOKEN).
-                  It is optional for air-gapped deployments that serve a pre-cached model
+                  Optional for certain NIMs.
                 type: string
               command:
                 items:

--- a/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nimcaches.yaml
+++ b/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nimcaches.yaml
@@ -588,8 +588,9 @@ spec:
                     description: NGCSource represents models stored in NGC
                     properties:
                       authSecret:
-                        description: The name of an existing pull secret containing
-                          the NGC_API_KEY
+                        description: |-
+                          AuthSecret is the name of an existing secret containing the NGC_API_KEY.
+                          Optional for certain NIMs.
                         type: string
                       model:
                         description: Model spec for caching
@@ -662,7 +663,6 @@ spec:
                         description: PullSecret to pull the model puller image
                         type: string
                     required:
-                    - authSecret
                     - modelPuller
                     type: object
                     x-kubernetes-validations:

--- a/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nimpipelines.yaml
+++ b/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nimpipelines.yaml
@@ -1021,7 +1021,7 @@ spec:
                         authSecret:
                           description: |-
                             AuthSecret is the name of an existing secret containing the NGC_API_KEY (and optionally HF_TOKEN).
-                            It is optional for air-gapped deployments that serve a pre-cached model
+                            Optional for certain NIMs.
                           type: string
                         command:
                           items:

--- a/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nimservices.yaml
+++ b/deployments/helm/k8s-nim-operator/crds/apps.nvidia.com_nimservices.yaml
@@ -970,7 +970,7 @@ spec:
               authSecret:
                 description: |-
                   AuthSecret is the name of an existing secret containing the NGC_API_KEY (and optionally HF_TOKEN).
-                  It is optional for air-gapped deployments that serve a pre-cached model
+                  Optional for certain NIMs.
                 type: string
               command:
                 items:

--- a/internal/controller/nimbuild_controller.go
+++ b/internal/controller/nimbuild_controller.go
@@ -647,17 +647,6 @@ func (r *NIMBuildReconciler) constructEngineBuildPod(nimBuild *appsv1alpha1.NIMB
 					Name:  "NIM_MODEL_PROFILE",
 					Value: inputNimProfile.Name,
 				},
-				{
-					Name: appsv1alpha1.NGCAPIKey,
-					ValueFrom: &corev1.EnvVarSource{
-						SecretKeyRef: &corev1.SecretKeySelector{
-							LocalObjectReference: corev1.LocalObjectReference{
-								Name: nimCache.Spec.Source.NGC.AuthSecret,
-							},
-							Key: appsv1alpha1.NGCAPIKey,
-						},
-					},
-				},
 			},
 			VolumeMounts: []corev1.VolumeMount{
 				{
@@ -723,6 +712,23 @@ func (r *NIMBuildReconciler) constructEngineBuildPod(nimBuild *appsv1alpha1.NIMB
 				RunAsUser:    nimCache.GetUserID(),
 			},
 		},
+	}
+
+	// Inject NGC_API_KEY when the backing NIMCache has an auth secret. Optional
+	// so certain NIMs can omit the key.
+	if nimCache.Spec.Source.NGC != nil && nimCache.Spec.Source.NGC.AuthSecret != "" {
+		pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, corev1.EnvVar{
+			Name: appsv1alpha1.NGCAPIKey,
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: nimCache.Spec.Source.NGC.AuthSecret,
+					},
+					Key:      appsv1alpha1.NGCAPIKey,
+					Optional: ptr.To(true),
+				},
+			},
+		})
 	}
 
 	// Merge env with the user provided values

--- a/internal/controller/nimbuild_controller_test.go
+++ b/internal/controller/nimbuild_controller_test.go
@@ -751,6 +751,7 @@ var _ = Describe("NIMBuild Controller", func() {
 					Expect(env.ValueFrom.SecretKeyRef).NotTo(BeNil())
 					Expect(env.ValueFrom.SecretKeyRef.Name).To(Equal(nimCache.Spec.Source.NGC.AuthSecret))
 					Expect(env.ValueFrom.SecretKeyRef.Key).To(Equal("NGC_API_KEY"))
+					Expect(env.ValueFrom.SecretKeyRef.Optional).To(Equal(ptr.To(true)))
 					ngcApiKeyFound = true
 				}
 			}

--- a/internal/controller/platform/kserve/nimservice_test.go
+++ b/internal/controller/platform/kserve/nimservice_test.go
@@ -2557,6 +2557,7 @@ var _ = Describe("NIMServiceReconciler for a KServe platform", func() {
 				Expect(ngcKeyEnv.ValueFrom.SecretKeyRef).NotTo(BeNil())
 				Expect(ngcKeyEnv.ValueFrom.SecretKeyRef.Name).To(Equal("ngc-secret"))
 				Expect(ngcKeyEnv.ValueFrom.SecretKeyRef.Key).To(Equal(appsv1alpha1.NGCAPIKey))
+				Expect(ngcKeyEnv.ValueFrom.SecretKeyRef.Optional).To(Equal(ptr.To(true)))
 
 				// HF_TOKEN should NOT be present
 				var hfTokenPresent bool

--- a/internal/controller/platform/standalone/nimservice_test.go
+++ b/internal/controller/platform/standalone/nimservice_test.go
@@ -3465,6 +3465,7 @@ var _ = Describe("NIMServiceReconciler for a standalone platform", func() {
 			Expect(ngcKeyEnv.ValueFrom.SecretKeyRef).NotTo(BeNil())
 			Expect(ngcKeyEnv.ValueFrom.SecretKeyRef.Name).To(Equal("ngc-secret"))
 			Expect(ngcKeyEnv.ValueFrom.SecretKeyRef.Key).To(Equal(appsv1alpha1.NGCAPIKey))
+			Expect(ngcKeyEnv.ValueFrom.SecretKeyRef.Optional).To(Equal(ptr.To(true)))
 
 			// HF_TOKEN should NOT be present
 			var hfTokenPresent bool

--- a/internal/webhook/apps/v1alpha1/nimcache_webhook_validation_helper.go
+++ b/internal/webhook/apps/v1alpha1/nimcache_webhook_validation_helper.go
@@ -56,11 +56,6 @@ func validateNGCSource(ngcSource *appsv1alpha1.NGCSource, fldPath *field.Path) (
 	// Evaluate NGCSource.Model fields
 	warnList, errList := validateModel(ngcSource.Model, fldPath.Child("model"))
 
-	// Ensure AuthSecret is a non-empty string
-	if ngcSource.AuthSecret == "" {
-		errList = append(errList, field.Required(fldPath.Child("authSecret"), "must be non-empty"))
-	}
-
 	// Ensure ModelPuller is a non-empty string
 	if ngcSource.ModelPuller == "" {
 		errList = append(errList, field.Required(fldPath.Child("modelPuller"), "must be non-empty"))

--- a/internal/webhook/apps/v1alpha1/nimcache_webhook_validation_helper_test.go
+++ b/internal/webhook/apps/v1alpha1/nimcache_webhook_validation_helper_test.go
@@ -46,7 +46,7 @@ func TestValidateNGCSource(t *testing.T) {
 			src: &appsv1alpha1.NGCSource{
 				Model: &appsv1alpha1.ModelSpec{},
 			},
-			wantErrs:     2,
+			wantErrs:     1, // modelPuller required; authSecret is optional
 			wantWarnings: 0,
 		},
 		{
@@ -305,7 +305,7 @@ func TestValidateNIMSourceConfiguration(t *testing.T) {
 					},
 				},
 			},
-			wantErrs:     5, // missing authSecret & modelPuller, profiles should only have one entry. If profiles is defined, all other model fields must be empty
+			wantErrs:     4, // modelPuller required; authSecret optional; profiles should only have one entry. If profiles is defined, all other model fields must be empty
 			wantWarnings: 0,
 		},
 	}

--- a/internal/webhook/apps/v1alpha1/nimservice_webhook_validation_helper.go
+++ b/internal/webhook/apps/v1alpha1/nimservice_webhook_validation_helper.go
@@ -78,10 +78,6 @@ func validateNIMServiceSpec(ctx context.Context, nimservice *appsv1alpha1.NIMSer
 	warningList = append(warningList, w...)
 	errList = append(errList, err...)
 
-	w, err = validateAuthSecret(&spec.AuthSecret, fldPath.Child("authSecret"))
-	warningList = append(warningList, w...)
-	errList = append(errList, err...)
-
 	w, err = validateServiceStorageConfiguration(&spec.Storage, fldPath.Child("storage"))
 	warningList = append(warningList, w...)
 	errList = append(errList, err...)
@@ -439,18 +435,6 @@ func validateDRAResourceQuantitySelectorValue(value *apiresource.Quantity, fldPa
 	errList := field.ErrorList{}
 	if value == nil {
 		errList = append(errList, field.Required(fldPath, "is required"))
-	}
-	return warningList, errList
-}
-
-func validateAuthSecret(authSecret *string, fldPath *field.Path) (admission.Warnings, field.ErrorList) {
-	warningList := admission.Warnings{}
-	errList := field.ErrorList{}
-	// AuthSecret is optional for air-gapped deployments that serve a pre-cached
-	// model from local storage. Warn so users do not omit it unintentionally
-	// when they still need NGC/HF credentials for model download.
-	if authSecret == nil || *authSecret == "" {
-		warningList = append(warningList, fmt.Sprintf("%s is empty: NGC_API_KEY will not be injected. Omit this only for air-gapped deployments with a pre-populated local model cache", fldPath.String()))
 	}
 	return warningList, errList
 }

--- a/internal/webhook/apps/v1alpha1/nimservice_webhook_validation_helper_test.go
+++ b/internal/webhook/apps/v1alpha1/nimservice_webhook_validation_helper_test.go
@@ -777,31 +777,6 @@ func TestValidateDRAResourcesConfiguration(t *testing.T) {
 	}
 }
 
-// TestValidateAuthSecret verifies authSecret is optional, with a warning when empty.
-func TestValidateAuthSecret(t *testing.T) {
-	fld := field.NewPath("spec").Child("authSecret")
-	cases := []struct {
-		name         string
-		value        string
-		wantErrs     int
-		wantWarnings int
-	}{
-		{"non-empty", "secret", 0, 0},
-		{"empty", "", 0, 1},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			w, errs := validateAuthSecret(&tc.value, fld)
-			gotErrs := len(errs)
-			gotWarnings := len(w)
-			if gotErrs != tc.wantErrs || gotWarnings != tc.wantWarnings {
-				t.Logf("Validation errors:")
-				t.Fatalf("got %d errs, %d warnings, want %d errs, %d warnings", gotErrs, gotWarnings, tc.wantErrs, tc.wantWarnings)
-			}
-		})
-	}
-}
-
 // TestValidateMetricsConfiguration table-driven.
 func TestValidateMetricsConfiguration(t *testing.T) {
 	fld := field.NewPath("spec").Child("metrics")


### PR DESCRIPTION
This change is aimed at removing general NGC API Key gating requirements for the NIM Operator. Its a follow up on this earlier [issue](https://github.com/NVIDIA/k8s-nim-operator/pull/910) which removed NIMService AuthSecret Reqs for air gapped use.

**/api/apps/v1alpha1/nimcache_types.go** - set authSecret to be optional and for EnvFromSecrets() for SecretEnvSource, set Optional: &optional. If authSecret is set but the Secret or NGC_API_KEY key is missing, kubelet does not fail.

**api/apps/v1alpha1/nimservice_types.go** - Only inject NGC_API_KEY when AuthSecret is set. The secret key is optional so certain NIMs can start without it.

**internal/controller/nimbuild_controller.go** - For constructEngineBuildPod, remove the NGC_API_KEY env that used nimCache.Spec.Source.NGC.AuthSecret (would panic or point at empty name if cache had no secret). After the pod spec is built: if NGC source exists and AuthSecret != "", append NGC_API_KEY with Optional: true. Then merge user nimBuild.Spec.Env as before.

**TESTING**
nimbuild_controller_test.go, kserve/nimservice_test.go, standalone/nimservice_test.go  — switched to expect SecretKeyRef.Optional == true when the key is injected. Also verified with by deploying the NIM Operator with OSS NIM